### PR TITLE
#44 feat: EventBus to Action Cable bridge

### DIFF
--- a/config/initializers/event_subscribers.rb
+++ b/config/initializers/event_subscribers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Registers global EventBus subscribers at boot time.
+# Subscribers registered here receive all events regardless of which
+# process emitted them (TUI, background job, etc.).
+Rails.application.config.after_initialize do
+  Events::Bus.subscribe(Events::Subscribers::ActionCableBridge.instance)
+end

--- a/lib/events/subscribers/action_cable_bridge.rb
+++ b/lib/events/subscribers/action_cable_bridge.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Events
+  module Subscribers
+    # Forwards EventBus events to Action Cable, bridging internal pub/sub
+    # to external WebSocket clients. Each event is broadcast to the
+    # session-specific stream (e.g. "session_42"), matching the stream
+    # name used by {SessionChannel}.
+    #
+    # Only events with a valid session_id are broadcast — events without
+    # one have no destination channel and are silently skipped.
+    #
+    # @example
+    #   Events::Bus.subscribe(Events::Subscribers::ActionCableBridge.instance)
+    #   # Now all events with session_id flow to "session_<id>" streams
+    class ActionCableBridge
+      include Events::Subscriber
+      include Singleton
+
+      # Receives a Rails.event notification hash and broadcasts the payload
+      # to the session's Action Cable stream.
+      #
+      # @param event [Hash] with :payload containing event data including :session_id
+      def emit(event)
+        payload = event[:payload]
+        return unless payload.is_a?(Hash)
+
+        session_id = payload[:session_id]
+        return if session_id.nil?
+
+        ActionCable.server.broadcast("session_#{session_id}", payload)
+      end
+    end
+  end
+end

--- a/spec/lib/events/subscribers/action_cable_bridge_spec.rb
+++ b/spec/lib/events/subscribers/action_cable_bridge_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Subscribers::ActionCableBridge do
+  subject(:bridge) { described_class.instance }
+
+  describe "#emit" do
+    it "broadcasts user_message events to the session stream" do
+      expect {
+        bridge.emit(event_hash(Events::UserMessage.new(content: "hello", session_id: 42)))
+      }.to have_broadcasted_to("session_42")
+        .with(a_hash_including(type: "user_message", content: "hello", session_id: 42))
+    end
+
+    it "broadcasts agent_message events to the session stream" do
+      expect {
+        bridge.emit(event_hash(Events::AgentMessage.new(content: "hi there", session_id: 7)))
+      }.to have_broadcasted_to("session_7")
+        .with(a_hash_including(type: "agent_message", content: "hi there"))
+    end
+
+    it "broadcasts system_message events" do
+      expect {
+        bridge.emit(event_hash(Events::SystemMessage.new(content: "retrying...", session_id: 1)))
+      }.to have_broadcasted_to("session_1")
+        .with(a_hash_including(type: "system_message", content: "retrying..."))
+    end
+
+    it "broadcasts tool_call events with tool metadata" do
+      expect {
+        bridge.emit(event_hash(Events::ToolCall.new(
+          content: "running bash", tool_name: "bash",
+          tool_input: {cmd: "ls"}, tool_use_id: "toolu_abc",
+          session_id: 5
+        )))
+      }.to have_broadcasted_to("session_5")
+        .with(a_hash_including(
+          type: "tool_call",
+          tool_name: "bash",
+          tool_input: {cmd: "ls"},
+          tool_use_id: "toolu_abc"
+        ))
+    end
+
+    it "broadcasts tool_response events with success status" do
+      expect {
+        bridge.emit(event_hash(Events::ToolResponse.new(
+          content: "file.txt", tool_name: "bash", success: true,
+          tool_use_id: "toolu_abc", session_id: 5
+        )))
+      }.to have_broadcasted_to("session_5")
+        .with(a_hash_including(
+          type: "tool_response",
+          tool_name: "bash",
+          success: true,
+          tool_use_id: "toolu_abc"
+        ))
+    end
+
+    it "skips events without session_id" do
+      expect {
+        bridge.emit(event_hash(Events::UserMessage.new(content: "orphan")))
+      }.not_to have_broadcasted_to("session_")
+    end
+
+    it "skips events with nil payload" do
+      expect { bridge.emit({payload: nil}) }.not_to raise_error
+    end
+
+    it "skips events with non-hash payload" do
+      expect { bridge.emit({payload: "not a hash"}) }.not_to raise_error
+    end
+
+    it "isolates broadcasts to the correct session stream" do
+      expect {
+        bridge.emit(event_hash(Events::UserMessage.new(content: "hello", session_id: 42)))
+      }.not_to have_broadcasted_to("session_99")
+    end
+
+    it "broadcasts events from different sessions to their respective streams" do
+      expect {
+        bridge.emit(event_hash(Events::UserMessage.new(content: "first", session_id: 1)))
+        bridge.emit(event_hash(Events::UserMessage.new(content: "second", session_id: 2)))
+      }.to have_broadcasted_to("session_1").with(a_hash_including(content: "first"))
+        .and have_broadcasted_to("session_2").with(a_hash_including(content: "second"))
+    end
+  end
+
+  describe "integration with EventBus" do
+    it "is registered globally at boot and receives events emitted through the Bus" do
+      expect {
+        Events::Bus.emit(Events::UserMessage.new(content: "via bus", session_id: 10))
+      }.to have_broadcasted_to("session_10")
+        .with(a_hash_including(type: "user_message", content: "via bus"))
+    end
+  end
+
+  describe "subscriber interface" do
+    it "includes Events::Subscriber" do
+      expect(bridge).to be_a(Events::Subscriber)
+    end
+  end
+
+  # Builds the event hash that Rails.event delivers to subscribers
+  def event_hash(event)
+    {name: event.event_name, payload: event.to_h, timestamp: event.timestamp}
+  end
+end


### PR DESCRIPTION
## Summary

- Add `Events::Subscribers::ActionCableBridge` singleton that forwards EventBus events to Action Cable streams, filtered by `session_id`
- All event types forwarded: `user_message`, `agent_message`, `system_message`, `tool_call`, `tool_response`
- Registered automatically at boot via `after_initialize` initializer — no changes to event publishers needed
- Wire format: event payload hash passed through as-is (same structure persisted to DB)

## Wire format (JSON over WebSocket)

```json
{
  "type": "agent_message",
  "content": "Hello!",
  "session_id": 42,
  "timestamp": 1772964211001841522
}
```

Tool events include additional fields: `tool_name`, `tool_input`/`success`, `tool_use_id`.

## Test plan

- [x] 12 RSpec examples covering all event types, session isolation, edge cases, and Bus integration
- [x] All 93 related specs pass (events, channels, jobs)
- [x] StandardRB clean
- [ ] CI passes

Closes #44
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)