### PR TITLE
#38 fix: TUI process ignores SIGHUP/SIGTERM, orphans on tmux exit

### DIFF
--- a/lib/tui/app.rb
+++ b/lib/tui/app.rb
@@ -307,7 +307,7 @@ module TUI
     end
 
     # Polls {CONTROLLING_TERMINAL} every {TERMINAL_CHECK_INTERVAL} seconds.
-    # When the terminal disappears, attempts WebSocket disconnect and force-exits.
+    # When the terminal disappears, calls {#handle_terminal_loss}.
     # Exits silently in non-TTY environments (CI, test suites).
     # @return [void]
     def terminal_watchdog_loop
@@ -318,17 +318,24 @@ module TUI
         begin
           File.stat(CONTROLLING_TERMINAL)
         rescue Errno::ENXIO, Errno::EIO, Errno::ENOENT
-          begin
-            @cable_client.disconnect
-          rescue
-            nil
-          end
-          Kernel.exit!(0)
+          handle_terminal_loss
         end
         sleep TERMINAL_CHECK_INTERVAL
       end
     rescue Errno::ENXIO, Errno::EIO, Errno::ENOENT
       # No controlling terminal — nothing to watch
+    end
+
+    # Best-effort WebSocket cleanup followed by immediate process termination.
+    # Uses Kernel.exit!(0) because the main thread is stuck in native Rust FFI
+    # (crossterm poll_event/draw) and cannot be interrupted by Ruby signals.
+    # @return [void]
+    def handle_terminal_loss
+      @cable_client.disconnect
+    rescue
+      nil
+    ensure
+      Kernel.exit!(0)
     end
   end
 end

--- a/spec/lib/tui/app_spec.rb
+++ b/spec/lib/tui/app_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe TUI::App do
         expect { app.send(:terminal_watchdog_loop) }.not_to raise_error
       end
 
-      it "force-exits when terminal disappears mid-loop" do
+      it "calls handle_terminal_loss when terminal disappears mid-loop" do
         call_count = 0
         allow(File).to receive(:stat).with(TUI::App::CONTROLLING_TERMINAL) do
           call_count += 1
@@ -356,43 +356,28 @@ RSpec.describe TUI::App do
           stat_double
         end
         allow(app).to receive(:sleep)
-        allow(Kernel).to receive(:exit!) { throw :force_exit }
+        allow(app).to receive(:handle_terminal_loss) { throw :force_exit }
 
         catch(:force_exit) { app.send(:terminal_watchdog_loop) }
 
-        expect(Kernel).to have_received(:exit!).with(0)
+        expect(app).to have_received(:handle_terminal_loss)
       end
+    end
 
-      it "attempts cable disconnect before force-exit" do
-        call_count = 0
-        allow(File).to receive(:stat).with(TUI::App::CONTROLLING_TERMINAL) do
-          call_count += 1
-          raise Errno::EIO if call_count > 1
-          stat_double
-        end
-        allow(app).to receive(:sleep)
-        allow(Kernel).to receive(:exit!) { throw :force_exit }
+    describe "handle_terminal_loss" do
+      it "attempts cable disconnect" do
+        allow(Kernel).to receive(:exit!)
 
-        catch(:force_exit) { app.send(:terminal_watchdog_loop) }
+        app.send(:handle_terminal_loss)
 
         expect(cable_client).to have_received(:disconnect)
-        expect(Kernel).to have_received(:exit!).with(0)
       end
 
-      it "force-exits even when disconnect raises" do
-        call_count = 0
-        allow(File).to receive(:stat).with(TUI::App::CONTROLLING_TERMINAL) do
-          call_count += 1
-          raise Errno::ENXIO if call_count > 1
-          stat_double
-        end
-        allow(app).to receive(:sleep)
+      it "tolerates disconnect failure" do
         allow(cable_client).to receive(:disconnect).and_raise(IOError)
-        allow(Kernel).to receive(:exit!) { throw :force_exit }
+        allow(Kernel).to receive(:exit!)
 
-        catch(:force_exit) { app.send(:terminal_watchdog_loop) }
-
-        expect(Kernel).to have_received(:exit!).with(0)
+        expect { app.send(:handle_terminal_loss) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add signal handlers (SIGHUP, SIGTERM, SIGINT) that set a shutdown flag checked by the TUI event loop — handles direct `kill` signals
- Add terminal watchdog thread that probes `/dev/tty` every 500ms and force-exits when the controlling terminal disappears — handles `tmux kill-session`, SSH disconnect, terminal crash where RatatuiRuby's Rust layer (crossterm) intercepts SIGHUP at the native level
- Signal handlers are saved and restored after TUI exits to avoid polluting the parent process

## Root cause

RatatuiRuby's crossterm (Rust) intercepts SIGHUP via `sigaction` at the native level before Ruby's signal handlers can fire. When tmux kills a session, the PTY master closes and SIGHUP is sent, but the Rust layer consumes it. The main Ruby thread gets stuck in native `poll_event`/`draw` calls that cannot be interrupted by `Thread.main.raise`.

## Test plan

- [x] `bundle exec rspec spec/lib/tui/app_spec.rb` — 34 examples, 0 failures
- [x] TUI terminates on `tmux kill-session` (previously orphaned at 80%+ CPU)
- [x] TUI terminates on direct `kill -TERM`
- [x] TUI terminates on direct `kill -HUP`
- [x] No orphaned processes after repeated tmux session kills
- [x] `bundle exec standardrb` passes
- [x] Watchdog thread exits gracefully in non-TTY environments (CI)

Closes #38