### PR TITLE
#33 chore: E2E testing, bugfixes, and v0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-13
+
 ### Added
-- Verbose view mode rendering — `render_verbose` on all decorator subclasses (#76)
-- Timestamped messages in verbose mode (`[HH:MM:SS] You:` / `[HH:MM:SS] Anima:`)
+- TUI view mode switching via `Ctrl+a → v` — cycle between Basic, Verbose, and Debug (#75)
+- Draper EventDecorator hierarchy — structured data decorators for all event types (#74)
+- Decorators return structured hashes (not strings) for transport-layer filtering (#86)
+- Basic mode tool call counter — inline `🔧 Tools: X/Y ✓` aggregation (#73)
+- Verbose view mode rendering — timestamps, tool call previews, system messages (#76)
 - Tool call previews: bash `$ command`, web_get `GET url`, generic JSON fallback
 - Tool response display: truncated to 3 lines, `↩` success / `❌` failure indicators
-- System messages visible in verbose mode (`[HH:MM:SS] [system] ...`)
-- TUI view mode switching via `Ctrl+a → v` (#75)
+- Debug view mode — token counts per message, full tool args/responses, tool use IDs (#77)
+- Estimated token indicator (`~` prefix) for events not yet counted by background job
+- View mode persisted on Session model — survives TUI disconnect/reconnect
+- Mode changes broadcast to all connected clients with re-decorated viewport
+
+### Fixed
+- Newlines in LLM responses collapsed into single line in rendered view modes
+- Loading state stuck after view mode switch — input blocked with "Thinking..."
 
 ## [0.2.0] - 2026-03-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,30 @@ Do not add "defense-in-depth" rescue clauses or fallback logic. Silently swallow
 
 The development environment is fully configured (LLM API keys, credentials, dependencies). Don't ask — just run things.
 
+## Starting the dev environment
+
+Start the brain in a detached tmux session so it persists across commands:
+
+```bash
+# Start brain (web server + background worker) on port 42135
+tmux new-session -d -s anima-brain 'bin/dev; sleep 30'
+
+# Verify it's running (look for "Listening on" in output)
+sleep 3 && tmux capture-pane -t anima-brain -p
+
+# Clean up when done
+tmux kill-session -t anima-brain
+```
+
+Development uses port **42135** (not 42134) to avoid conflicting with the production brain running via systemd.
+
 ## Testing TUI in tmux
 
 RatatuiRuby requires a real PTY. Background processes (`&`) and `script` don't work reliably. Use tmux to smoke-test the TUI:
 
 ```bash
-# Launch TUI in a detached tmux session
-tmux new-session -d -s anima-test -x 120 -y 30 './exe/anima tui'
+# Launch TUI in a detached tmux session (connects to dev brain on 42135)
+tmux new-session -d -s anima-test -x 120 -y 30 './exe/anima tui --host localhost:42135'
 
 # Wait for render, then capture the screen
 sleep 1 && tmux capture-pane -t anima-test -p

--- a/README.md
+++ b/README.md
@@ -194,7 +194,19 @@ Events fire, subscribers react, state updates, the cortex (LLM) reads the result
 
 There is no linear chat history. There are only events attached to a session. The context window is a **viewport** — a sliding window over the event stream, assembled on demand for each LLM call within a configured token budget.
 
-Currently uses a simple sliding window (newest events first, walk backwards until budget exhausted). Future versions will add multi-resolution compression with Draper decorators and associative recall from Mneme.
+Currently uses a simple sliding window (newest events first, walk backwards until budget exhausted). Future versions will add associative recall from Mneme.
+
+### TUI View Modes
+
+Three switchable view modes let you control how much detail the TUI shows. Cycle with `Ctrl+a → v`:
+
+| Mode | What you see |
+|------|-------------|
+| **Basic** (default) | User + assistant messages. Tool calls are hidden but summarized as an inline counter: `🔧 Tools: 2/2 ✓` |
+| **Verbose** | Everything in Basic, plus timestamps `[HH:MM:SS]`, tool call previews (`🔧 bash` / `$ command` / `↩ response`), and system messages |
+| **Debug** | Full X-ray view — timestamps, token counts per message (`[14 tok]`), full tool call args, full tool responses, tool use IDs |
+
+View modes are implemented via Draper decorators that operate at the transport layer. Each event type has a dedicated decorator (`UserMessageDecorator`, `ToolCallDecorator`, etc.) that returns structured data — the TUI renders it. Mode is stored on the `Session` model server-side, so it persists across reconnections.
 
 ### Brain as Microservices on a Shared Event Bus
 
@@ -331,7 +343,7 @@ This single example demonstrates every core principle:
 
 ## Status
 
-**Core agent complete.** The conversational agent works end-to-end: event-driven architecture, LLM integration with tool calling (bash, web), sliding viewport context assembly, persistent sessions, and client-server architecture with WebSocket transport and graceful reconnection.
+**Core agent complete.** The conversational agent works end-to-end: event-driven architecture, LLM integration with tool calling (bash, web), sliding viewport context assembly, persistent sessions, client-server architecture with WebSocket transport, graceful reconnection, and three TUI view modes (Basic/Verbose/Debug) via Draper decorators.
 
 The hormonal system (Thymos, feelings, desires), semantic memory (Mneme), and soul matrix (Psyche) are designed but not yet implemented — they're the next layer on top of the working agent.
 

--- a/lib/anima/version.rb
+++ b/lib/anima/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anima
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/tui/screens/chat.rb
+++ b/lib/tui/screens/chat.rb
@@ -207,6 +207,7 @@ module TUI
 
         @view_mode = new_mode
         @message_store.clear
+        @loading = false
         @scroll_offset = 0
         @auto_scroll = true
       end
@@ -332,15 +333,17 @@ module TUI
       def render_conversation_entry(tui, data, role)
         color = ROLE_COLORS.fetch(role, "white")
         prefix = ROLE_LABELS.fetch(role, role)
-        body = data["content"]
+        style = tui.style(fg: color)
 
-        parts = []
-        parts << "[#{format_ns_timestamp(data["timestamp"])}]" if data["timestamp"]
-        parts << format_token_label(data["tokens"], data["estimated"]) if data["tokens"]
-        parts << "#{prefix}: #{body}"
+        meta = []
+        meta << "[#{format_ns_timestamp(data["timestamp"])}]" if data["timestamp"]
+        meta << format_token_label(data["tokens"], data["estimated"]) if data["tokens"]
+        header = meta.empty? ? "#{prefix}:" : "#{meta.join(" ")} #{prefix}:"
 
-        text = parts.join(" ")
-        [tui.line(spans: [tui.span(content: text, style: tui.style(fg: color))])]
+        content_lines = data["content"].to_s.split("\n", -1)
+        lines = [tui.line(spans: [tui.span(content: "#{header} #{content_lines.first}", style: style)])]
+        content_lines.drop(1).each { |line| lines << tui.line(spans: [tui.span(content: line, style: style)]) }
+        lines
       end
 
       # Renders a tool invocation with tool name, optional tool_use_id, and indented input.
@@ -384,10 +387,14 @@ module TUI
       # @param data [Hash] structured data with "content" and optional "timestamp"
       # @return [Array<RatatuiRuby::Widgets::Line>]
       def render_system_entry(tui, data)
-        body = data["content"]
         ts = data["timestamp"]
-        text = ts ? "[#{format_ns_timestamp(ts)}] [system] #{body}" : "[system] #{body}"
-        [tui.line(spans: [tui.span(content: text, style: tui.style(fg: "white"))])]
+        header = ts ? "[#{format_ns_timestamp(ts)}] [system]" : "[system]"
+        style = tui.style(fg: "white")
+
+        content_lines = data["content"].to_s.split("\n", -1)
+        lines = [tui.line(spans: [tui.span(content: "#{header} #{content_lines.first}", style: style)])]
+        content_lines.drop(1).each { |line| lines << tui.line(spans: [tui.span(content: "  #{line}", style: style)]) }
+        lines
       end
 
       # Renders the assembled system prompt block in debug mode.

--- a/spec/lib/tui/screens/chat_spec.rb
+++ b/spec/lib/tui/screens/chat_spec.rb
@@ -852,6 +852,15 @@ RSpec.describe TUI::Screens::Chat do
         expect(screen.scroll_offset).to eq(0)
         expect(screen.instance_variable_get(:@auto_scroll)).to be true
       end
+
+      it "resets loading state" do
+        screen.instance_variable_set(:@loading, true)
+        allow(cable_client).to receive(:drain_messages).and_return([
+          {"action" => "view_mode_changed", "view_mode" => "verbose"}
+        ])
+        screen.send(:process_incoming_messages)
+        expect(screen.loading?).to be false
+      end
     end
 
     describe "view_mode_changed with invalid data" do


### PR DESCRIPTION
## Summary

Closes #33 — TUI View Modes epic. All 5 sub-issues (#73, #74, #75, #76, #77) are complete.

This PR adds:
- **Bugfixes found during E2E testing:**
  - Newlines in LLM responses were collapsed into single lines in all rendered view modes
  - Loading state got stuck after view mode switching, blocking input with "Thinking..."
- **Documentation:**
  - CLAUDE.md: dev environment startup (`bin/dev` in tmux) and TUI testing instructions with correct port (42135)
  - README: TUI View Modes section (Basic/Verbose/Debug), updated Status section
- **Release prep:**
  - Version bump to 0.2.1
  - CHANGELOG updated with all epic features and bugfixes

## E2E Test Results

All three view modes verified via tmux:

| Mode | Timestamps | Token counts | Tool previews | Tool counter | Newlines |
|------|-----------|-------------|--------------|-------------|---------|
| Basic | — | — | — | ✓ | ✓ |
| Verbose | ✓ | — | ✓ | ✓ | ✓ |
| Debug | ✓ | ✓ | ✓ (full) | ✓ | ✓ |

- View mode cycling (`Ctrl+a → v`) works across all modes
- Mode persists across TUI reconnections
- Loading state resets correctly on mode switch
- JSON and multiline content renders with proper line breaks

## Test plan

- [x] 442 specs pass (decorators, TUI, channels, models, bridge)
- [x] standardrb clean
- [x] E2E smoke test: all 3 view modes in tmux
- [x] Newline rendering verified with multiline LLM responses
- [x] JSON rendering verified in debug mode
- [x] Loading state verified after rapid mode cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)