### PR TITLE
#110 feat: Tools::Edit — text replacement with uniqueness constraint

### DIFF
--- a/lib/agent_loop.rb
+++ b/lib/agent_loop.rb
@@ -93,6 +93,7 @@ class AgentLoop
     registry.register(Tools::Bash)
     registry.register(Tools::Read)
     registry.register(Tools::Write)
+    registry.register(Tools::Edit)
     registry.register(Tools::WebGet)
     registry
   end

--- a/lib/tools/edit.rb
+++ b/lib/tools/edit.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module Tools
+  # Performs surgical text replacement with uniqueness constraint.
+  # Finds old_text in the file (must match exactly one location), replaces
+  # with new_text, and returns a unified diff. Falls back to
+  # whitespace-normalized fuzzy matching when exact match fails.
+  #
+  # Normalizes BOM and CRLF line endings for matching, restoring them after
+  # the edit. Rejects ambiguous edits where old_text matches zero or
+  # multiple locations.
+  #
+  # @example Replacing a method body
+  #   tool.execute("path" => "app.rb",
+  #                "old_text" => "def greet\n  'hi'\nend",
+  #                "new_text" => "def greet\n  'hello'\nend")
+  #   # => "--- app.rb\n+++ app.rb\n@@ -1,3 +1,3 @@\n ..."
+  class Edit < Base
+    MAX_FILE_SIZE = 10 * 1024 * 1024 # 10 MB
+
+    def self.tool_name = "edit"
+
+    def self.description = "Replace exact text in a file. old_text must match exactly one location; " \
+                           "include surrounding lines for uniqueness. Use for surgical edits; " \
+                           "use write for new files or full replacement."
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          path: {type: "string", description: "Absolute or relative file path (relative resolved against working directory)"},
+          old_text: {type: "string", description: "Exact text to find (must match exactly one location — include surrounding context if needed)"},
+          new_text: {type: "string", description: "Replacement text (empty string to delete)"}
+        },
+        required: %w[path old_text new_text]
+      }
+    end
+
+    # @param shell_session [ShellSession, nil] provides working directory for resolving relative paths
+    def initialize(shell_session: nil, **)
+      @working_directory = shell_session&.pwd
+    end
+
+    # @param input [Hash<String, Object>] string-keyed hash from the Anthropic API
+    # @return [String] unified diff showing the change
+    # @return [Hash] with :error key on failure
+    def execute(input)
+      path, old_text, new_text = extract_params(input)
+      return {error: "Path cannot be blank"} if path.empty?
+      return {error: "old_text cannot be blank"} if old_text.empty?
+
+      path = resolve_path(path)
+
+      error = validate_file(path)
+      return error if error
+
+      edit_file(path, old_text, new_text)
+    end
+
+    private
+
+    def extract_params(input)
+      path = input["path"].to_s.strip
+      old_text = input["old_text"].to_s
+      new_text = input["new_text"].to_s
+      [path, old_text, new_text]
+    end
+
+    def resolve_path(path)
+      if @working_directory
+        File.expand_path(path, @working_directory)
+      else
+        File.expand_path(path)
+      end
+    end
+
+    def validate_file(path)
+      return {error: "File not found: #{path}"} unless File.exist?(path)
+      return {error: "Is a directory: #{path}"} if File.directory?(path)
+      return {error: "Permission denied: #{path}"} unless File.readable?(path) && File.writable?(path)
+      size = File.size(path)
+      if size > MAX_FILE_SIZE
+        {error: "File is #{size} bytes (#{size / 1_048_576} MB). " \
+                "Max editable size is #{MAX_FILE_SIZE / 1_048_576} MB. Use bash tool with sed instead."}
+      end
+    end
+
+    def edit_file(path, old_text, new_text)
+      raw = File.binread(path)
+      bom = extract_bom(raw)
+      content = raw[bom.length..].force_encoding("UTF-8")
+      had_crlf = content.include?("\r\n")
+      normalized = had_crlf ? content.gsub("\r\n", "\n") : content
+
+      match = find_unique_match(normalized, old_text, path)
+      return match if match.is_a?(Hash)
+
+      position, matched_text, fuzzy = match
+      new_content = normalized[0...position] + new_text + normalized[(position + matched_text.length)..]
+
+      if normalized == new_content
+        return {error: "old_text and new_text are identical. No changes made to #{path}."}
+      end
+
+      output = had_crlf ? new_content.gsub("\n", "\r\n") : new_content
+      File.binwrite(path, bom + output.b)
+
+      build_diff(path, normalized, new_content, fuzzy)
+    rescue Errno::EACCES
+      {error: "Permission denied: #{path}"}
+    rescue Errno::ENOSPC
+      {error: "No space left on device: #{path}"}
+    rescue Errno::EROFS
+      {error: "Read-only file system: #{path}"}
+    end
+
+    # @return [String] UTF-8 BOM bytes if present, empty binary string otherwise
+    def extract_bom(raw)
+      bytes = raw.b
+      bytes.start_with?("\xEF\xBB\xBF".b) ? bytes[0, 3] : "".b
+    end
+
+    # Finds exactly one match for old_text in content.
+    # Tries exact match first, then whitespace-normalized fuzzy match.
+    # @return [Array(Integer, String, Boolean)] position, matched text, fuzzy flag
+    # @return [Hash] error hash if zero or multiple matches found
+    def find_unique_match(content, old_text, path)
+      exact = find_all_positions(content, old_text)
+      return [exact[0], old_text, false] if exact.one?
+      return ambiguity_error(exact, content, path) if exact.length > 1
+
+      fuzzy = find_fuzzy_matches(content, old_text)
+      return [fuzzy[0][0], fuzzy[0][1], true] if fuzzy.one?
+      return ambiguity_error(fuzzy.map(&:first), content, path, fuzzy: true) if fuzzy.length > 1
+
+      {error: "Could not find old_text in #{path}. " \
+              "Verify the text exists and matches exactly (including whitespace). " \
+              "Use the read tool to check current file contents."}
+    end
+
+    def ambiguity_error(positions, content, path, fuzzy: false)
+      kind = fuzzy ? "fuzzy matches" : "matches"
+      line_numbers = positions.map { |pos| line_number_at(content, pos) }
+      {error: "Found #{positions.length} #{kind} for old_text in #{path}. " \
+              "Provide more surrounding context to uniquely identify the location. " \
+              "Matches at lines: #{line_numbers.join(", ")}"}
+    end
+
+    def line_number_at(content, position)
+      content[0...position].count("\n") + 1
+    end
+
+    def find_all_positions(content, text)
+      positions = []
+      offset = 0
+      while (pos = content.index(text, offset))
+        positions << pos
+        offset = pos + 1
+      end
+      positions
+    end
+
+    # Finds old_text in content using whitespace-normalized line comparison.
+    # @return [Array<Array(Integer, String)>] array of [position, matched_text] pairs
+    def find_fuzzy_matches(content, old_text)
+      content_lines = content.split("\n", -1)
+      search_lines = old_text.split("\n", -1)
+      search_lines.pop if search_lines.last&.empty? && old_text.end_with?("\n")
+      trailing_newline = old_text.end_with?("\n")
+
+      normalized_search = search_lines.map { |line| collapse_whitespace(line) }
+      return [] if normalized_search.all?(&:empty?)
+
+      window_size = search_lines.length
+      matches = []
+      (0..content_lines.length - window_size).each do |start_idx|
+        window = content_lines[start_idx, window_size]
+        next unless window.map { |line| collapse_whitespace(line) } == normalized_search
+
+        pos = start_idx.zero? ? 0 : content_lines[0...start_idx].sum { |line| line.length + 1 }
+        matched = window.join("\n")
+        matched += "\n" if trailing_newline
+        matches << [pos, matched]
+      end
+
+      matches
+    end
+
+    def collapse_whitespace(text)
+      text.gsub(/[[:blank:]]+/, " ").strip
+    end
+
+    # Generates a unified diff between old and new content with 3 lines of context.
+    DIFF_CONTEXT = 3
+
+    def build_diff(path, old_content, new_content, fuzzy)
+      before = old_content.lines(chomp: true)
+      after = new_content.lines(chomp: true)
+
+      first = 0
+      first += 1 while first < before.length && first < after.length && before[first] == after[first]
+
+      old_end = before.length - 1
+      new_end = after.length - 1
+      while old_end > first && new_end > first && before[old_end] == after[new_end]
+        old_end -= 1
+        new_end -= 1
+      end
+
+      ctx_start = [first - DIFF_CONTEXT, 0].max
+      old_ctx_end = [old_end + DIFF_CONTEXT, before.length - 1].min
+      new_ctx_end = [new_end + DIFF_CONTEXT, after.length - 1].min
+
+      hunk = []
+      hunk << "--- #{path}"
+      hunk << "+++ #{path}"
+      hunk << "@@ -#{ctx_start + 1},#{old_ctx_end - ctx_start + 1} +#{ctx_start + 1},#{new_ctx_end - ctx_start + 1} @@"
+      (ctx_start...first).each { |idx| hunk << " #{before[idx]}" }
+      (first..old_end).each { |idx| hunk << "-#{before[idx]}" }
+      (first..new_end).each { |idx| hunk << "+#{after[idx]}" }
+      ((old_end + 1)..old_ctx_end).each { |idx| hunk << " #{before[idx]}" }
+
+      diff = hunk.join("\n")
+      fuzzy ? "(fuzzy match — whitespace differences were ignored)\n#{diff}" : diff
+    end
+  end
+end

--- a/spec/lib/tools/edit_spec.rb
+++ b/spec/lib/tools/edit_spec.rb
@@ -1,0 +1,298 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::Edit do
+  subject(:tool) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir("tools-edit-spec") }
+
+  after { FileUtils.remove_entry(tmpdir) }
+
+  def write_file(name, content, mode: "w")
+    path = File.join(tmpdir, name)
+    File.write(path, content, mode: mode)
+    path
+  end
+
+  describe ".tool_name" do
+    it "returns edit" do
+      expect(described_class.tool_name).to eq("edit")
+    end
+  end
+
+  describe ".description" do
+    it "returns a non-empty description" do
+      expect(described_class.description).to be_a(String)
+      expect(described_class.description).not_to be_empty
+    end
+  end
+
+  describe ".input_schema" do
+    it "defines path, old_text, and new_text as required string properties" do
+      schema = described_class.input_schema
+      expect(schema[:type]).to eq("object")
+      expect(schema[:properties][:path][:type]).to eq("string")
+      expect(schema[:properties][:old_text][:type]).to eq("string")
+      expect(schema[:properties][:new_text][:type]).to eq("string")
+      expect(schema[:required]).to contain_exactly("path", "old_text", "new_text")
+    end
+  end
+
+  describe ".schema" do
+    it "builds valid Anthropic tool schema" do
+      schema = described_class.schema
+      expect(schema).to include(name: "edit", description: a_kind_of(String))
+      expect(schema[:input_schema]).to be_a(Hash)
+    end
+  end
+
+  describe "#execute" do
+    context "with exact match" do
+      it "replaces a single line and returns a diff" do
+        path = write_file("single.rb", "def greet\n  'hi'\nend\n")
+
+        result = tool.execute("path" => path, "old_text" => "  'hi'", "new_text" => "  'hello'")
+
+        expect(result).to include("--- #{path}")
+        expect(result).to include("-  'hi'")
+        expect(result).to include("+  'hello'")
+        expect(File.read(path)).to eq("def greet\n  'hello'\nend\n")
+      end
+
+      it "replaces multiple lines" do
+        path = write_file("multi.rb", "class Foo\n  def bar\n    1\n  end\nend\n")
+
+        result = tool.execute(
+          "path" => path,
+          "old_text" => "  def bar\n    1\n  end",
+          "new_text" => "  def bar\n    2\n  end"
+        )
+
+        expect(result).to include("-    1")
+        expect(result).to include("+    2")
+        expect(File.read(path)).to eq("class Foo\n  def bar\n    2\n  end\nend\n")
+      end
+
+      it "deletes text when new_text is empty" do
+        path = write_file("delete.txt", "keep\nremove\nkeep\n")
+
+        result = tool.execute("path" => path, "old_text" => "remove\n", "new_text" => "")
+
+        expect(result).to include("-remove")
+        expect(File.read(path)).to eq("keep\nkeep\n")
+      end
+    end
+
+    context "with uniqueness constraint" do
+      it "returns error when old_text matches zero locations" do
+        path = write_file("nope.txt", "hello world\n")
+
+        result = tool.execute("path" => path, "old_text" => "missing text", "new_text" => "x")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("Could not find old_text")
+        expect(result[:error]).to include("read tool")
+      end
+
+      it "returns error with line numbers when old_text matches multiple locations" do
+        path = write_file("dupes.txt", "foo\nbar\nfoo\n")
+
+        result = tool.execute("path" => path, "old_text" => "foo", "new_text" => "baz")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("2 matches")
+        expect(result[:error]).to include("lines: 1, 3")
+      end
+    end
+
+    context "with fuzzy matching" do
+      it "matches tabs against spaces" do
+        path = write_file("tabs.rb", "def foo\n\tbar\nend\n")
+
+        result = tool.execute(
+          "path" => path,
+          "old_text" => "def foo\n  bar\nend\n",
+          "new_text" => "def foo\n\tbaz\nend\n"
+        )
+
+        expect(result).to include("fuzzy match")
+        expect(File.read(path)).to eq("def foo\n\tbaz\nend\n")
+      end
+
+      it "matches despite extra inline whitespace" do
+        path = write_file("spaces.txt", "x  +  y\n")
+
+        result = tool.execute(
+          "path" => path,
+          "old_text" => "x + y\n",
+          "new_text" => "x + z\n"
+        )
+
+        expect(result).to include("fuzzy match")
+        expect(File.read(path)).to eq("x + z\n")
+      end
+
+      it "returns error with line numbers when multiple fuzzy matches exist" do
+        path = write_file("fuzzy_dupes.rb", "\tbar\nbaz\n\t\tbar\n")
+
+        result = tool.execute("path" => path, "old_text" => "  bar", "new_text" => "  qux")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("fuzzy matches")
+        expect(result[:error]).to include("lines:")
+      end
+    end
+
+    context "with no-op detection" do
+      it "returns error when old_text and new_text are identical" do
+        path = write_file("noop.txt", "unchanged\n")
+
+        result = tool.execute("path" => path, "old_text" => "unchanged", "new_text" => "unchanged")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("identical")
+      end
+    end
+
+    context "with BOM handling" do
+      it "strips BOM for matching and restores it after edit" do
+        bom = "\xEF\xBB\xBF"
+        path = File.join(tmpdir, "bom.txt")
+        File.binwrite(path, "#{bom}hello world\n")
+
+        result = tool.execute("path" => path, "old_text" => "hello", "new_text" => "goodbye")
+
+        expect(result).to include("-hello world")
+        expect(result).to include("+goodbye world")
+        raw = File.binread(path)
+        expect(raw.b[0, 3]).to eq(bom.b)
+        expect(raw[3..].force_encoding("UTF-8")).to eq("goodbye world\n")
+      end
+    end
+
+    context "with CRLF handling" do
+      it "normalizes CRLF for matching and restores after edit" do
+        path = File.join(tmpdir, "crlf.txt")
+        File.binwrite(path, "line one\r\nline two\r\nline three\r\n")
+
+        result = tool.execute("path" => path, "old_text" => "line two", "new_text" => "line TWO")
+
+        expect(result).to include("-line two")
+        expect(result).to include("+line TWO")
+        raw = File.binread(path)
+        expect(raw).to eq("line one\r\nline TWO\r\nline three\r\n")
+      end
+    end
+
+    context "with validation errors" do
+      it "returns error for blank path" do
+        result = tool.execute("path" => "  ", "old_text" => "x", "new_text" => "y")
+
+        expect(result).to eq({error: "Path cannot be blank"})
+      end
+
+      it "returns error for blank old_text" do
+        path = write_file("blank.txt", "data\n")
+
+        result = tool.execute("path" => path, "old_text" => "", "new_text" => "y")
+
+        expect(result).to eq({error: "old_text cannot be blank"})
+      end
+
+      it "returns error for nonexistent file" do
+        result = tool.execute("path" => "/nonexistent/file.txt", "old_text" => "x", "new_text" => "y")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("File not found")
+      end
+
+      it "returns error when path is a directory" do
+        result = tool.execute("path" => tmpdir, "old_text" => "x", "new_text" => "y")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("Is a directory")
+      end
+
+      it "returns error for unwritable file" do
+        path = write_file("locked.txt", "data\n")
+        File.chmod(0o444, path)
+
+        result = tool.execute("path" => path, "old_text" => "data", "new_text" => "new")
+
+        expect(result).to eq({error: "Permission denied: #{path}"})
+      ensure
+        File.chmod(0o644, path)
+      end
+
+      it "returns error for file exceeding size limit" do
+        path = write_file("big.txt", "data\n")
+        allow(File).to receive(:size).with(path).and_return(Tools::Edit::MAX_FILE_SIZE + 1)
+
+        result = tool.execute("path" => path, "old_text" => "data", "new_text" => "new")
+
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("Max editable size")
+      end
+    end
+
+    context "with filesystem errors during write" do
+      it "returns error when disk is full" do
+        path = write_file("full.txt", "old\n")
+        allow(File).to receive(:binwrite).and_raise(Errno::ENOSPC)
+
+        result = tool.execute("path" => path, "old_text" => "old", "new_text" => "new")
+
+        expect(result).to eq({error: "No space left on device: #{path}"})
+      end
+
+      it "returns error on read-only file system" do
+        path = write_file("rofs.txt", "old\n")
+        allow(File).to receive(:binwrite).and_raise(Errno::EROFS)
+
+        result = tool.execute("path" => path, "old_text" => "old", "new_text" => "new")
+
+        expect(result).to eq({error: "Read-only file system: #{path}"})
+      end
+
+      it "returns error when write permission is denied at OS level" do
+        path = write_file("denied.txt", "old\n")
+        allow(File).to receive(:binwrite).and_raise(Errno::EACCES)
+
+        result = tool.execute("path" => path, "old_text" => "old", "new_text" => "new")
+
+        expect(result).to eq({error: "Permission denied: #{path}"})
+      end
+    end
+
+    context "with relative path resolution" do
+      it "resolves relative paths against working directory" do
+        write_file("rel.txt", "before\n")
+        tool_with_wd = described_class.new(shell_session: double(pwd: tmpdir))
+
+        result = tool_with_wd.execute("path" => "rel.txt", "old_text" => "before", "new_text" => "after")
+
+        expect(result).to include("-before")
+        expect(result).to include("+after")
+        expect(File.read(File.join(tmpdir, "rel.txt"))).to eq("after\n")
+      end
+    end
+
+    context "with diff output format" do
+      it "includes context lines around the change" do
+        content = (1..10).map { |i| "line #{i}\n" }.join
+        path = write_file("ctx.txt", content)
+
+        result = tool.execute("path" => path, "old_text" => "line 5", "new_text" => "LINE FIVE")
+
+        expect(result).to include("--- #{path}")
+        expect(result).to include("+++ #{path}")
+        expect(result).to include("@@")
+        expect(result).to include(" line 4")
+        expect(result).to include("-line 5")
+        expect(result).to include("+LINE FIVE")
+        expect(result).to include(" line 6")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements `Tools::Edit` following the `Tools::Base` pattern (sibling of `Tools::Read` and `Tools::Write`)
- oldText/newText surgical text replacement with uniqueness constraint
- Exact match first, whitespace-normalized fuzzy matching fallback
- BOM stripping and CRLF normalization for matching, restored after edit
- Returns unified diff showing the change
- Registers the tool in `AgentLoop#build_tool_registry`

## Test plan

- [x] 26 RSpec examples covering exact/fuzzy matching, uniqueness, BOM/CRLF, validation, filesystem errors, diff output
- [x] Full tools + agent_loop suite passes (137 examples)
- [x] `standardrb` clean
- [x] `reek` warnings comparable to Tools::Read (inherent algorithm complexity)
- [ ] Manual TUI smoke test

Closes #110
**Parent:** #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)