### PR TITLE
#170 feat: Import built-in workflows from RPI commands

### DIFF
--- a/workflows/commit.md
+++ b/workflows/commit.md
@@ -1,0 +1,45 @@
+---
+name: commit
+description: "Create focused git commits with user approval."
+---
+
+# Commit Changes
+
+You are tasked with creating git commits for the changes made during this session.
+
+## Process:
+
+1. **Think about what changed:**
+   - Review the conversation history and understand what was accomplished
+   - Run `git status` to see current changes
+   - Run `git diff` to understand the modifications
+   - Consider whether changes should be one commit or multiple logical commits
+
+2. **Plan your commit(s):**
+   - Identify which files belong together
+   - Draft clear, descriptive commit messages
+   - Use imperative mood in commit messages
+   - Focus on why the changes were made, not just what
+
+3. **Present your plan to the user:**
+   - List the files you plan to add for each commit
+   - Show the commit message(s) you'll use
+   - Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"
+
+4. **Execute upon confirmation:**
+   - Use `git add` with specific files (never use `-A` or `.`)
+   - Create commits with your planned messages
+   - Show the result with `git log --oneline -n [number]`
+
+## Important:
+- **NEVER add co-author information or Claude attribution**
+- Commits should be authored solely by the user
+- Do not include any "Generated with Claude" messages
+- Do not add "Co-Authored-By" lines
+- Write commit messages as if the user wrote them
+
+## Remember:
+- You have the full context of what was done in this session
+- Group related changes together
+- Keep commits focused and atomic when possible
+- The user trusts your judgment - they asked you to commit

--- a/workflows/create_handoff.md
+++ b/workflows/create_handoff.md
@@ -1,0 +1,98 @@
+---
+name: create_handoff
+description: "Create handoff document for transferring work context to another session."
+---
+
+# Create Handoff
+
+You are tasked with writing a handoff document to hand off your work to another agent in a new session. You will create a handoff document that is thorough, but also **concise**. The goal is to compact and summarize your context without losing any of the key details of what you're working on.
+
+
+## Process
+### 1. Gather Metadata
+Run `spec-metadata` (in the PATH) to get date, time, git commit, branch, and repository name.
+
+### 2. Filepath & Naming
+Create your file under `./thoughts/shared/handoffs/<issue-number>/YYYY-MM-DD/HH-MM-SS_<issue-number>_description.md`, where:
+- YYYY-MM-DD is today's date
+- HH-MM-SS is the current time in 24-hour format
+- issue-number is the GitHub issue number (replace with `general` if no issue)
+- issue-number in the filename (omit if no issue)
+- description is a brief kebab-case description
+
+Examples:
+- With issue: `2026-03-15/13-55-22_170_create-context-compaction.md`
+- Without issue: `2026-03-15/13-55-22_create-context-compaction.md`
+
+### 3. Handoff writing
+using the above conventions, write your document. use the defined filepath, and the following YAML frontmatter pattern. Use the metadata gathered in step 1, Structure the document with YAML frontmatter followed by content:
+
+Use the following template structure:
+```markdown
+---
+date: [Current date and time with timezone in ISO format]
+researcher: [Researcher name from thoughts status]
+git_commit: [Current commit hash]
+branch: [Current branch name]
+repository: [Repository name]
+topic: "[Feature/Task Name] Implementation Strategy"
+tags: [implementation, strategy, relevant-component-names]
+status: complete
+last_updated: [Current date in YYYY-MM-DD format]
+last_updated_by: [Researcher name]
+type: implementation_strategy
+---
+
+# Handoff: #NNN {very concise description}
+
+## Task(s)
+{description of the task(s) that you were working on, along with the status of each (completed, work in progress, planned/discussed). If you are working on an implementation plan, make sure to call out which phase you are on. Make sure to reference the plan document and/or research document(s) you are working from that were provided to you at the beginning of the session, if applicable.}
+
+## Critical References
+{List any critical specification documents, architectural decisions, or design docs that must be followed. Include only 2-3 most important file paths. Leave blank if none.}
+
+## Recent changes
+{describe recent changes made to the codebase that you made in line:file syntax}
+
+## Learnings
+{describe important things that you learned - e.g. patterns, root causes of bugs, or other important pieces of information someone that is picking up your work after you should know. consider listing explicit file paths.}
+
+## Artifacts
+{ an exhaustive list of artifacts you produced or updated as filepaths and/or file:line references - e.g. paths to feature documents, implementation plans, etc that should be read in order to resume your work.}
+
+## Action Items & Next Steps
+{ a list of action items and next steps for the next agent to accomplish based on your tasks and their statuses}
+
+## Other Notes
+{ other notes, references, or useful information - e.g. where relevant sections of the codebase are, where relevant documents are, or other important things you leanrned that you want to pass on but that don't fall into the above categories}
+```
+---
+
+### 4. Approve and Sync
+Run `thoughts-sync` to save the document.
+
+Once this is completed, you should respond to the user with the template between <template_response></template_response> XML tags. do NOT include the tags in your response.
+
+<template_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+resume_handoff path/to/handoff.md
+```
+</template_response>
+
+for example (between <example_response></example_response> XML tags - do NOT include these tags in your actual response to the user)
+
+<example_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+resume_handoff ./thoughts/shared/handoffs/170/2026-03-15/13-44-55_170_create-context-compaction.md
+```
+</example_response>
+
+---
+##.  Additional Notes & Instructions
+- **more information, not less**. This is a guideline that defines the minimum of what a handoff should be. Always feel free to include more information if necessary.
+- **be thorough and precise**. include both top-level objectives, and lower-level details as necessary.
+- **avoid excessive code snippets**. While a brief snippet to describe some key change is important, avoid large code blocks or diffs; do not include one unless it's necessary (e.g. pertains to an error you're debugging). Prefer using `/path/to/file.ext:line` references that an agent can follow later when it's ready, e.g. `packages/dashboard/src/app/dashboard/page.tsx:12-24`

--- a/workflows/create_note.md
+++ b/workflows/create_note.md
@@ -1,0 +1,82 @@
+---
+name: create_note
+description: "Capture findings or context as a persistent note in the thoughts system."
+---
+
+# Create Note
+
+You are tasked with capturing content as a persistent note in the thoughts system. This could be findings from a research specialist, insights from the current session, or any content worth preserving for future reference.
+
+## Process
+
+### 1. Gather Metadata
+
+Run `spec-metadata` (in the PATH) to get date, time, git commit, branch, and repository name.
+
+### 2. Filepath & Naming
+
+Create your file under `./thoughts/shared/notes/YYYY-MM-DD/description.md`, where:
+- YYYY-MM-DD is today's date
+- description is a brief kebab-case description of the content
+
+Examples:
+- `2026-02-23/rails-8-turbo-stream-patterns.md`
+- `2026-02-23/sidekiq-retry-best-practices.md`
+- `2026-02-23/authentication-library-comparison.md`
+
+### 3. Note Writing
+
+Using the above conventions, write your document with the following YAML frontmatter pattern. Use the metadata gathered in step 1:
+
+```markdown
+---
+date: [Current date and time with timezone in ISO format]
+author: [Author name from spec-metadata]
+git_commit: [Current commit hash]
+branch: [Current branch name]
+repository: [Repository name]
+topic: "[Brief topic description]"
+tags: [note, relevant-keywords]
+status: complete
+last_updated: [Current date in YYYY-MM-DD format]
+last_updated_by: [Author name]
+---
+
+# [Topic]
+
+## Context
+
+[What prompted this note - the question, task, or goal]
+
+## Content
+
+[The actual content - preserved exactly as provided without summarization or transformation]
+
+## Sources
+
+[Links, file paths, or references - if applicable, omit section if none]
+
+## Related
+
+[Links to related notes, research, or plans in thoughts/ - if applicable, omit section if none]
+```
+
+### 4. Sync and Present
+
+Run `thoughts-sync` to save the document.
+
+Once complete, respond with:
+
+```
+Note captured at: ./thoughts/shared/notes/YYYY-MM-DD/description.md
+
+You can reference this in future sessions or as input to other workflows.
+```
+
+## Additional Notes & Instructions
+
+- **Preserve content exactly**: The value of this note is capturing content losslessly. Do not summarize, synthesize, or transform the content unless explicitly asked.
+- **Include all links**: If content came from web research, documentation lookups, or file analysis, preserve all URLs and file:line references.
+- **Topic from context**: Derive the topic from the content being captured. Only ask the user if genuinely ambiguous.
+- **Sections are flexible**: The Content section is required. Sources and Related sections should be included when applicable, omitted when not.
+- **Follow-up notes**: If adding to an existing topic, consider updating the existing note rather than creating a duplicate. Update `last_updated` and `last_updated_by` fields.

--- a/workflows/create_plan.md
+++ b/workflows/create_plan.md
@@ -1,0 +1,457 @@
+---
+name: create_plan
+description: "Create detailed implementation plans through interactive research and iteration."
+---
+
+# Implementation Plan
+
+You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Check if parameters were provided**:
+   - If a file path or ticket reference was provided as a parameter, skip the default message
+   - Immediately read any provided files FULLY
+   - Begin the research process
+
+2. **If no parameters provided**, respond with:
+```
+I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
+
+Please provide:
+1. The task/ticket description (or reference to a ticket file)
+2. Any relevant context, constraints, or specific requirements
+3. Links to related research or previous implementations
+
+I'll analyze this information and work with you to create a comprehensive plan.
+
+Provide a GitHub issue reference or a description of what needs to be planned.
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Context Gathering & Initial Analysis
+
+1. **Read all mentioned files (if any) immediately and FULLY**:
+   - GitHub issue details (via `gh issue view`)
+   - Research documents
+   - Related implementation plans
+   - Any JSON/data files mentioned
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: If files mentioned, DO NOT spawn sub-tasks before reading these files yourself in the main context
+   - **NEVER** read files partially - if a file is mentioned, read it completely
+
+2. **Gather Historical Context**:
+   Spawn the `thoughts-analyzer` specialist with ticket reference, title, description, and acceptance criteria.
+
+   DO NOT proceed to step 3 until this specialist returns. Its output is required input for step 3.
+
+3. **Spawn codebase research tasks**:
+   After step 2 completes, spawn research specialists in parallel, passing ticket info and historical context output from step 2:
+
+   - Use the **codebase-analyzer** specialist to find and understand how the current implementation works
+   - If a GitHub issue is mentioned, read full details via `gh issue view`
+
+   These agents will:
+   - Find relevant source files, configs, and tests
+   - Identify the specific directories to focus on (e.g., if WUI is mentioned, they'll focus on humanlayer-wui/)
+   - Trace data flow and key functions
+   - Return detailed explanations with file:line references
+
+4. **Read all files identified by research tasks**:
+   - After research tasks complete, read ALL files they identified as relevant
+   - Read them FULLY into the main context
+   - This ensures you have complete understanding before proceeding
+
+5. **Analyze and verify understanding**:
+   - Cross-reference the ticket requirements with actual code
+   - Identify any discrepancies or misunderstandings
+   - Note assumptions that need verification
+   - Determine true scope based on codebase reality
+
+6. **Present informed understanding and focused questions**:
+   ```
+   Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
+
+   I've found that:
+   - [Current implementation detail with file:line reference]
+   - [Relevant pattern or constraint discovered]
+   - [Potential complexity or edge case identified]
+
+   Questions that my research couldn't answer:
+   - [Specific technical question that requires human judgment]
+   - [Business logic clarification]
+   - [Design preference that affects implementation]
+   ```
+
+   Only ask questions that you genuinely cannot answer through code investigation.
+
+### Step 2: Research & Discovery
+
+After getting initial clarifications:
+
+1. **If the user corrects any misunderstanding**:
+   - DO NOT just accept the correction
+   - Spawn new research tasks to verify the correct information
+   - Read the specific files/directories they mention
+   - Only proceed once you've verified the facts yourself
+
+2. **Create a research todo list** to track exploration tasks
+
+3. **Spawn parallel sub-tasks for comprehensive research**:
+   - Create multiple subagents to research different aspects concurrently
+   - Use the right agent for each type of research:
+
+   **For codebase research:**
+   - **codebase-analyzer** — find and understand implementation details (e.g., "analyze how [system] works")
+   - **codebase-pattern-finder** — find similar features we can model after
+
+   **For related issues:**
+   - Search GitHub issues via `gh issue list --search "keyword"`
+
+   Each agent knows how to:
+   - Find the right files and code patterns
+   - Identify conventions and patterns to follow
+   - Look for integration points and dependencies
+   - Return specific file:line references
+   - Find tests and examples
+
+4. **Wait for ALL sub-tasks to complete** before proceeding
+
+5. **Present findings and design options**:
+   ```
+   Based on my research, here's what I found:
+
+   **Current State:**
+   - [Key discovery about existing code]
+   - [Pattern or convention to follow]
+
+   **Design Options:**
+   1. [Option A] - [pros/cons]
+   2. [Option B] - [pros/cons]
+
+   **Open Questions:**
+   - [Technical uncertainty]
+   - [Design decision needed]
+
+   Which approach aligns best with your vision?
+   ```
+
+### Step 3: Plan Structure Development
+
+Once aligned on approach:
+
+**Phase = Commit**
+
+Each phase represents one atomic commit - the smallest meaningful change that leaves the codebase working.
+
+**Atomicity test**: If your phase description needs "and", split it. If specs are in another Phase, merge into one.
+
+**For testable code**, follow RGRC: Red → Green → Refactor → Commit. Your phases should mirror your test cases.
+
+1. **Create initial plan outline**:
+   ```
+   Here's my proposed plan structure:
+
+   ## Overview
+   [1-2 sentence summary]
+
+   ## Implementation Phases:
+   1. [Phase name] - [what it accomplishes]
+   2. [Phase name] - [what it accomplishes]
+   3. [Phase name] - [what it accomplishes]
+
+   Does this phasing make sense? Should I adjust the order or granularity?
+   ```
+
+2. **Get feedback on structure** before writing details
+
+### Step 4: Detailed Plan Writing
+
+After structure approval:
+
+1. **Write the plan** to `./thoughts/shared/plans/YYYY-MM-DD/<issue-number>-description.md`
+   - Format: `YYYY-MM-DD/<issue-number>-description.md` where:
+     - YYYY-MM-DD is today's date
+     - issue-number is the GitHub issue number (omit if no issue)
+     - description is a brief kebab-case description
+   - Examples:
+     - With issue: `2026-03-15/170-import-workflows.md`
+     - Without issue: `2026-03-15/improve-error-handling.md`
+2. **Use this template structure**:
+
+````markdown
+# [Feature/Task Name] Implementation Plan
+
+## Overview
+
+[Brief description of what we're implementing and why]
+
+## Current State Analysis
+
+[What exists now, what's missing, key constraints discovered]
+
+## Desired End State
+
+[A Specification of the desired end state after this plan is complete, and how to verify it]
+
+### Key Discoveries:
+- [Important finding with file:line reference]
+- [Pattern to follow]
+- [Constraint to work within]
+
+## What We're NOT Doing
+
+[Explicitly list out-of-scope items to prevent scope creep]
+
+## Implementation Approach
+
+[High-level strategy and reasoning]
+
+## Phase 1: [Descriptive Name]
+
+### Commit
+`<ticket||type>: <imperative summary>`
+
+### Overview
+[What this phase accomplishes]
+
+### Changes Required:
+
+#### 1. [Component/File Group]
+**File**: `path/to/file.ext`
+**Changes**: [Summary of changes]
+
+```[language]
+// Specific code to add/modify
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Migration applies cleanly: `make migrate`
+- [ ] Unit tests pass: `make test-component`
+- [ ] Type checking passes: `npm run typecheck`
+- [ ] Linting passes: `make lint`
+- [ ] Integration tests pass: `make test-integration`
+
+#### Manual Verification:
+- [ ] Feature works as expected when tested via UI
+- [ ] Performance is acceptable under load
+- [ ] Edge case handling verified manually
+- [ ] No regressions in related features
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 2: [Descriptive Name]
+
+[Similar structure with both automated and manual success criteria...]
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- [What to test]
+- [Key edge cases]
+
+### Integration Tests:
+- [End-to-end scenarios]
+
+### Manual Testing Steps:
+1. [Specific step to verify feature]
+2. [Another verification step]
+3. [Edge case to test manually]
+
+## Performance Considerations
+
+[Any performance implications or optimizations needed]
+
+## Migration Notes
+
+[If applicable, how to handle existing data/systems]
+
+## References
+
+- Original issue: GitHub issue #NNN
+- Related research: `./thoughts/shared/research/[relevant].md`
+- Similar implementation: `[file:line]`
+````
+
+### Step 5: Sync and Review
+
+1. **Sync the thoughts directory**:
+   - Run `thoughts-sync` to sync the newly created plan
+   - This ensures the plan is properly indexed and available
+
+2. **Present the draft plan location**:
+   ```
+   I've created the initial implementation plan at:
+   `./thoughts/shared/plans/YYYY-MM-DD/<issue-number>-description.md`
+
+   Please review it and let me know:
+   - Are the phases properly scoped?
+   - Are the success criteria specific enough?
+   - Any technical details that need adjustment?
+   - Missing edge cases or considerations?
+   ```
+
+3. **Iterate based on feedback** - be ready to:
+   - Add missing phases
+   - Adjust technical approach
+   - Clarify success criteria (both automated and manual)
+   - Add/remove scope items
+   - After making changes, run `thoughts-sync` again
+
+4. **Continue refining** until the user is satisfied
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Question vague requirements
+   - Identify potential issues early
+   - Ask "why" and "what about"
+   - Don't assume - verify with code
+
+2. **Be Interactive**:
+   - Don't write the full plan in one shot
+   - Get buy-in at each major step
+   - Allow course corrections
+   - Work collaboratively
+
+3. **Be Thorough**:
+   - Read all context files COMPLETELY before planning
+   - Research actual code patterns using parallel sub-tasks
+   - Include specific file paths and line numbers
+   - Write measurable success criteria with clear automated vs manual distinction
+   - automated steps should use `make` whenever possible - for example `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+
+4. **Be Practical**:
+   - Focus on incremental, testable changes
+   - Consider migration and rollback
+   - Think about edge cases
+   - Include "what we're NOT doing"
+
+5. **Track Progress**:
+   - Track planning tasks as you go
+   - Update todos as you complete research
+   - Mark planning tasks complete when done
+
+6. **No Open Questions in Final Plan**:
+   - If you encounter open questions during planning, STOP
+   - Research or ask for clarification immediately
+   - Do NOT write the plan with unresolved questions
+   - The implementation plan must be complete and actionable
+   - Every decision must be made before finalizing the plan
+
+## Success Criteria Guidelines
+
+**Always separate success criteria into two categories:**
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Specific files that should exist
+   - Code compilation/type checking
+   - Automated test suites
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+**Format example:**
+```markdown
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Database migration runs successfully: `make migrate`
+- [ ] All unit tests pass: `go test ./...`
+- [ ] No linting errors: `golangci-lint run`
+- [ ] API endpoint returns 200: `curl localhost:8080/api/new-endpoint`
+
+#### Manual Verification:
+- [ ] New feature appears correctly in the UI
+- [ ] Performance is acceptable with 1000+ items
+- [ ] Error messages are user-friendly
+- [ ] Feature works correctly on mobile devices
+```
+
+## Common Patterns
+
+### For Database Changes:
+- Start with schema/migration
+- Add store methods
+- Update business logic
+- Expose via API
+- Update clients
+
+### For New Features:
+- Research existing patterns first
+- Start with data model
+- Build backend logic
+- Add API endpoints
+- Implement UI last
+
+### For Refactoring:
+- Document current behavior
+- Plan incremental changes
+- Maintain backwards compatibility
+- Include migration strategy
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Spawn multiple tasks in parallel** for efficiency
+2. **Each task should be focused** on a specific area
+3. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+4. **Be EXTREMELY specific about directories**:
+   - If the ticket mentions "WUI", specify `humanlayer-wui/` directory
+   - If it mentions "daemon", specify `hld/` directory
+   - Never use generic terms like "UI" when you mean "WUI"
+   - Include the full path context in your prompts
+5. **Specify read-only tools** to use
+6. **Request specific file:line references** in responses
+7. **Wait for all tasks to complete** before synthesizing
+8. **Verify sub-task results**:
+   - If a sub-task returns unexpected results, spawn follow-up tasks
+   - Cross-check findings against the actual codebase
+   - Don't accept results that seem incorrect
+
+Example of spawning multiple tasks:
+```python
+# Spawn these tasks concurrently:
+tasks = [
+    Task("Research database schema", db_research_prompt),
+    Task("Find API patterns", api_research_prompt),
+    Task("Investigate UI components", ui_research_prompt),
+    Task("Check test patterns", test_research_prompt)
+]
+```
+
+## Example Interaction Flow
+
+```
+User: /implementation_plan
+Assistant: I'll help you create a detailed implementation plan...
+
+User: We need to add parent-child tracking for Claude sub-tasks. See ./thoughts/username/tickets/ENG-1234.md
+Assistant: Let me read that ticket file completely first...
+
+[Reads file fully]
+
+Based on the ticket, I understand we need to track parent-child relationships for Claude sub-task events in the hld daemon. Before I start planning, I have some questions...
+
+[Interactive process continues...]
+```

--- a/workflows/decompose_ticket.md
+++ b/workflows/decompose_ticket.md
@@ -1,0 +1,109 @@
+---
+name: decompose_ticket
+description: "Decompose a feature ticket into vertical slices — testable, deliverable units ordered by dependency."
+---
+
+# Decompose Ticket
+
+Break a feature ticket into vertical slices. Each slice is a testable, deliverable unit that can be implemented, reviewed, and merged independently.
+
+## The Principle
+
+**Never decompose by layer. Always decompose by function.**
+
+Horizontal (wrong):
+- Task 1: Routes
+- Task 2: Model
+- Task 3: Controller
+- Task 4: Views
+
+Each piece is untestable in isolation. Nothing is deliverable until everything is done.
+
+Vertical (correct):
+- Slice 1: Model + index action + seeds → immediately visible
+- Slice 2: Show action → testable independently
+- Slice 3: Edit/update actions → independently deliverable
+- Slice 4: Delete action → independently deliverable
+
+Each slice = working functionality that can be tested and reviewed on its own.
+
+## Process
+
+### Step 1: Understand the Ticket
+
+Read the GitHub issue thoroughly. Identify:
+- What is the desired end state?
+- What are the acceptance criteria?
+- What components are involved (models, controllers, views, services, jobs)?
+
+Spawn the `thoughts-analyzer` specialist to find historical context about the feature area.
+
+### Step 2: Identify the Minimum Viable Slice
+
+The first slice must be the smallest unit that produces something visible/testable:
+
+**For Rails features:**
+- Model + migration + seeds + one controller action + route + minimal view
+- This is the "can I see something working?" threshold
+
+**For API features:**
+- Model + migration + one endpoint + request spec
+- This is the "can I call it and get a response?" threshold
+
+**For library/gem features:**
+- Core class + public method + unit spec
+- This is the "can I use it from a console?" threshold
+
+### Step 3: Slice by Function
+
+After the minimum slice, decompose remaining work by function:
+
+1. **Read-only first**: index, show, list, get — safe, easy to verify
+2. **Mutations second**: create, update, delete — each independently
+3. **Edge cases last**: error handling, validations, authorization — after happy path works
+
+Each slice must:
+- Build on previous slices (no orphaned dependencies)
+- Be independently testable
+- Have clear acceptance criteria
+- Be small enough for a single PR
+
+### Step 4: Create Sub-Issues
+
+For each slice, create a GitHub sub-issue:
+- Title: `Slice N: <what it delivers>`
+- Body: What's included, what's NOT included, acceptance criteria, dependencies
+- Link as sub-issue to the parent ticket
+
+```bash
+# Create sub-issue
+gh issue create --title "Slice 1: Model + index" --body "..."
+
+# Link as sub-issue to parent
+ISSUE_ID=$(gh api repos/{owner}/{repo}/issues/{new_number} --jq '.id')
+gh api repos/{owner}/{repo}/issues/{parent_number}/sub_issues -X POST -F sub_issue_id=$ISSUE_ID
+```
+
+### Step 5: Order and Verify
+
+Review the full sequence:
+- Does each slice build on the previous?
+- Is the first slice the smallest possible visible unit?
+- Can each slice be tested without the ones after it?
+- Are there any horizontal slices disguised as vertical? (e.g., "all migrations" is horizontal)
+
+Present the decomposition for review before creating issues.
+
+## Anti-Patterns
+
+- **"Set up the database first"** — horizontal. Include only the migration needed for slice 1.
+- **"Add all routes"** — horizontal. Add routes as each action is implemented.
+- **"Write all tests at the end"** — horizontal. Tests live with their slice.
+- **"Refactor before building"** — unless blocking, refactoring is its own slice.
+
+## Guidelines
+
+- Fewer, larger slices are better than many tiny ones — each slice has PR overhead
+- The first slice should be demonstrable within hours, not days
+- When in doubt about order: read before write, simple before complex, core before edge
+- Each slice should leave the codebase in a working state (green tests)

--- a/workflows/feature.md
+++ b/workflows/feature.md
@@ -1,0 +1,91 @@
+---
+name: feature
+description: "Implement a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review."
+---
+
+## Context
+
+Create and complete a new feature or chore from branch creation to PR readiness.
+
+Read the GitHub issue to understand requirements. If no issue exists, create one via `gh issue create`.
+
+## Workflow
+
+### Step 1: Setup
+
+Pull latest base branch (usually `main` or `master`)
+Create feature branch: `<type>/<issue-number>-<short-description>` (e.g., `feature/42-add-api-endpoint`)
+Assign GitHub issue to self via `gh issue edit <number> --add-assignee @me`
+
+### Step 2: Gather Historical Context
+
+Spawn the `thoughts-analyzer` specialist with ticket reference, title, description, acceptance criteria, and any additional instructions from user input.
+
+DO NOT proceed to Step 3 until this specialist returns. Its output is required input for Step 3.
+
+### Step 3: Research Codebase
+
+After Step 2 completes, spawn research specialists in parallel, passing ticket info and historical context output from Step 2:
+
+`codebase-pattern-finder` — find similar implementations to model after
+`codebase-analyzer` — analyze the area being modified
+
+Wait for both specialists to complete before proceeding.
+
+### Step 4: Implementation
+
+Follow project conventions (CLAUDE.md) and best practices.
+Keep code clean, DRY, well-documented.
+When modifying code: fix lurking bugs, refactor, add missing tests and regression tests.
+Ensure solid test coverage with well-documented business logic (viewable with `--format documentation`).
+Review changes for completeness.
+
+### Step 5: Testing & Quality
+
+Run specs for changed/affected files only (never full suite locally): `bundle exec rspec spec/path/to/changed_spec.rb`
+`bundle exec reek` – Code smell detection
+`bundle exec standardrb --fix`
+`npx @herb-tools/linter --fix app/views/**/*.erb` (if views changed)
+Fix all issues, even flaky tests.
+
+### Step 6: Translations (i18n)
+
+`bundle exec i18n-tasks missing` – Check for missing translations
+`bundle exec i18n-tasks normalize` – Normalize locale files
+Add missing translations (manually or via OpenAI)
+
+### Step 7: Pull Request
+
+Push branch.
+`gh pr create --draft`
+Title: `#<issue-number> feat: <description>` or `#<issue-number> chore: <description>` or `#<issue-number> fix: <description>`
+Description: summary, test plan, breaking changes. Link to GitHub issue.
+
+### Step 8: CI Monitoring
+
+Monitor checks until all pass.
+If tests fail, investigate root cause vs flakiness.
+Fix flaky tests – don't just retry; stabilize the test.
+
+### Step 9: Finalization
+
+Update PR title/description if needed.
+
+## Requirements
+
+No direct pushes to `master`.
+Always branch per task.
+All tests must pass.
+All i18n translations must be present and normalized.
+Flaky tests must be fixed, not ignored.
+
+## Conventions (Beautiful Code)
+
+Boy Scout Rule: Leave the code cleaner than you found it.
+Favor Plain Old Ruby Objects (POROs) and service objects; keep controllers and models thin.
+Avoid N+1 queries by using includes (and consider Bullet for detection).
+Use clear, explicit naming; avoid magic values.
+Document all public APIs.
+Use squash merges to keep commit history clean.
+Write small, focused commits using Conventional Commits (feat:, chore:, fix:)
+

--- a/workflows/implement_plan.md
+++ b/workflows/implement_plan.md
@@ -1,0 +1,87 @@
+---
+name: implement_plan
+description: "Implement an approved technical plan phase by phase with verification."
+---
+
+# Implement Plan
+
+You are tasked with implementing an approved technical plan from `./thoughts/shared/plans/`. These plans contain phases with specific changes and success criteria.
+
+## Getting Started
+
+When given a plan path:
+- Read the plan completely and check for any existing checkmarks (- [x])
+- Read the original ticket and all files mentioned in the plan
+- **Read files fully** - never use limit/offset parameters, you need complete context
+- Think deeply about how the pieces fit together
+- Create a todo list to track your progress
+- Start implementing if you understand what needs to be done
+
+If no plan path provided, ask for one.
+
+## Implementation Philosophy
+
+Plans are carefully designed, but reality can be messy. Your job is to:
+- Follow the plan's intent while adapting to what you find
+- Implement each phase fully before moving to the next
+- Verify your work makes sense in the broader codebase context
+- Update checkboxes in the plan as you complete sections
+
+When things don't match the plan exactly, think about why and communicate clearly. The plan is your guide, but your judgment matters too.
+
+If you encounter a mismatch:
+- STOP and think deeply about why the plan can't be followed
+- Present the issue clearly:
+  ```
+  Issue in Phase [N]:
+  Expected: [what the plan says]
+  Found: [actual situation]
+  Why this matters: [explanation]
+
+  How should I proceed?
+  ```
+
+## Verification Approach
+
+After implementing a phase:
+- Run the success criteria checks (usually `make check test` covers everything)
+- Fix any issues before proceeding
+- Update your progress in both the plan and your todos
+- Check off completed items in the plan file itself using Edit
+- **Pause for human verification**: After completing all automated verification for a phase, pause and inform the human that the phase is ready for manual testing. Use this format:
+  ```
+  Phase [N] Complete - Ready for Manual Verification
+
+  Automated verification passed:
+  - [List automated checks that passed]
+
+  Please perform the manual verification steps listed in the plan:
+  - [List manual verification items from the plan]
+
+  Let me know when manual testing is complete so I can proceed to Phase [N+1].
+  ```
+
+If instructed to execute multiple phases consecutively, skip the pause until the last phase. Otherwise, assume you are just doing one phase.
+
+do not check off items in the manual testing steps until confirmed by the user.
+
+
+## If You Get Stuck
+
+When something isn't working as expected:
+- First, make sure you've read and understood all the relevant code
+- Consider if the codebase has evolved since the plan was written
+- Present the mismatch clearly and ask for guidance
+
+Use sub-tasks sparingly - mainly for targeted debugging or exploring unfamiliar territory.
+
+## Resuming Work
+
+If no existing checkmarks, create feature branch from updated main. **Make sure you're on a feature branch before implementing!**
+
+If the plan has existing checkmarks:
+- Trust that completed work is done
+- Pick up from the first unchecked item
+- Verify previous work only if something seems off
+
+Remember: You're implementing a solution, not just checking boxes. Keep the end goal in mind and maintain forward momentum.

--- a/workflows/iterate_plan.md
+++ b/workflows/iterate_plan.md
@@ -1,0 +1,247 @@
+---
+name: iterate_plan
+description: "Iterate on existing implementation plans with research and targeted updates."
+---
+
+# Iterate Implementation Plan
+
+You are tasked with updating existing implementation plans based on user feedback. You should be skeptical, thorough, and ensure changes are grounded in actual codebase reality.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Parse the input to identify**:
+   - Plan file path (e.g., `./thoughts/shared/plans/2025-10-16/feature.md`)
+   - Requested changes/feedback
+
+2. **Handle different input scenarios**:
+
+   **If NO plan file provided**:
+   ```
+   I'll help you iterate on an existing implementation plan.
+
+   Which plan would you like to update? Please provide the path to the plan file (e.g., `./thoughts/shared/plans/2025-10-16/feature.md`).
+
+   Tip: You can list recent plans with `ls -lt ./thoughts/shared/plans/ | head`
+   ```
+   Wait for user input, then re-check for feedback.
+
+   **If plan file provided but NO feedback**:
+   ```
+   I've found the plan at [path]. What changes would you like to make?
+
+   For example:
+   - "Add a phase for migration handling"
+   - "Update the success criteria to include performance tests"
+   - "Adjust the scope to exclude feature X"
+   - "Split Phase 2 into two separate phases"
+   ```
+   Wait for user input.
+
+   **If BOTH plan file AND feedback provided**:
+   - Proceed immediately to Step 1
+   - No preliminary questions needed
+
+## Process Steps
+
+### Step 1: Read and Understand Current Plan
+
+1. **Read the existing plan file COMPLETELY**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Understand the current structure, phases, and scope
+   - Note the success criteria and implementation approach
+
+2. **Understand the requested changes**:
+   - Parse what the user wants to add/modify/remove
+   - Identify if changes require codebase research
+   - Determine scope of the update
+
+### Step 2: Research If Needed
+
+**Only spawn research tasks if the changes require new technical understanding.**
+
+If the user's feedback requires understanding new code patterns or validating assumptions:
+
+1. **Create a research todo list**
+
+2. **Spawn parallel sub-tasks for research**:
+   Use the right agent for each type of research:
+
+   **For code investigation:**
+   - **codebase-analyzer** — find and understand implementation details
+   - **codebase-pattern-finder** — find similar patterns
+
+   **For historical context:**
+   - **thoughts-analyzer** — discover and extract insights from documents
+
+   **Be EXTREMELY specific about directories**:
+   - If the change involves "WUI", specify `humanlayer-wui/` directory
+   - If it involves "daemon", specify `hld/` directory
+   - Include full path context in prompts
+
+3. **Read any new files identified by research**:
+   - Read them FULLY into the main context
+   - Cross-reference with the plan requirements
+
+4. **Wait for ALL sub-tasks to complete** before proceeding
+
+### Step 3: Present Understanding and Approach
+
+Before making changes, confirm your understanding:
+
+```
+Based on your feedback, I understand you want to:
+- [Change 1 with specific detail]
+- [Change 2 with specific detail]
+
+My research found:
+- [Relevant code pattern or constraint]
+- [Important discovery that affects the change]
+
+I plan to update the plan by:
+1. [Specific modification to make]
+2. [Another modification]
+
+Does this align with your intent?
+```
+
+Get user confirmation before proceeding.
+
+### Step 4: Update the Plan
+
+1. **Make focused, precise edits** to the existing plan:
+   - Use the Edit tool for surgical changes
+   - Maintain the existing structure unless explicitly changing it
+   - Keep all file:line references accurate
+   - Update success criteria if needed
+
+2. **Ensure consistency**:
+   - If adding a new phase, ensure it follows the existing pattern
+   - If modifying scope, update "What We're NOT Doing" section
+   - If changing approach, update "Implementation Approach" section
+   - Maintain the distinction between automated vs manual success criteria
+
+3. **Preserve quality standards**:
+   - Include specific file paths and line numbers for new content
+   - Write measurable success criteria
+   - Use `make` commands for automated verification
+   - Keep language clear and actionable
+
+### Step 5: Sync and Review
+
+1. **Sync the updated plan**:
+   - Run `thoughts-sync`
+   - This ensures changes are properly indexed
+
+2. **Present the changes made**:
+   ```
+   I've updated the plan at `./thoughts/shared/plans/[filename].md`
+
+   Changes made:
+   - [Specific change 1]
+   - [Specific change 2]
+
+   The updated plan now:
+   - [Key improvement]
+   - [Another improvement]
+
+   Would you like any further adjustments?
+   ```
+
+3. **Be ready to iterate further** based on feedback
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Don't blindly accept change requests that seem problematic
+   - Question vague feedback - ask for clarification
+   - Verify technical feasibility with code research
+   - Point out potential conflicts with existing plan phases
+
+2. **Be Surgical**:
+   - Make precise edits, not wholesale rewrites
+   - Preserve good content that doesn't need changing
+   - Only research what's necessary for the specific changes
+   - Don't over-engineer the updates
+
+3. **Be Thorough**:
+   - Read the entire existing plan before making changes
+   - Research code patterns if changes require new technical understanding
+   - Ensure updated sections maintain quality standards
+   - Verify success criteria are still measurable
+
+4. **Be Interactive**:
+   - Confirm understanding before making changes
+   - Show what you plan to change before doing it
+   - Allow course corrections
+   - Don't disappear into research without communicating
+
+5. **Track Progress**:
+   - Track update tasks if complex
+   - Update todos as you complete research
+   - Mark tasks complete when done
+
+6. **No Open Questions**:
+   - If the requested change raises questions, ASK
+   - Research or get clarification immediately
+   - Do NOT update the plan with unresolved questions
+   - Every change must be complete and actionable
+
+## Success Criteria Guidelines
+
+When updating success criteria, always maintain the two-category structure:
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Prefer `make` commands: `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+   - Specific files that should exist
+   - Code compilation/type checking
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Only spawn if truly needed** - don't research for simple changes
+2. **Spawn multiple tasks in parallel** for efficiency
+3. **Each task should be focused** on a specific area
+4. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+5. **Request specific file:line references** in responses
+6. **Wait for all tasks to complete** before synthesizing
+7. **Verify sub-task results** - if something seems off, spawn follow-up tasks
+
+## Example Interaction Flows
+
+**Scenario 1: User provides everything upfront**
+```
+User: iterate_plan ./thoughts/shared/plans/2025-10-16/feature.md - add phase for error handling
+Assistant: [Reads plan, researches error handling patterns, updates plan]
+```
+
+**Scenario 2: User provides just plan file**
+```
+User: iterate_plan ./thoughts/shared/plans/2025-10-16/feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Split Phase 2 into two phases - one for backend, one for frontend
+Assistant: [Proceeds with update]
+```
+
+**Scenario 3: User provides no arguments**
+```
+User: iterate_plan
+Assistant: Which plan would you like to update? Please provide the path...
+User: ./thoughts/shared/plans/2025-10-16/feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Add more specific success criteria
+Assistant: [Proceeds with update]
+```

--- a/workflows/research_codebase.md
+++ b/workflows/research_codebase.md
@@ -1,0 +1,210 @@
+---
+name: research_codebase
+description: "Comprehensive codebase research by spawning parallel specialists and synthesizing findings."
+---
+
+# Research Codebase
+
+You are tasked with conducting comprehensive research across the codebase to answer user questions by spawning parallel sub-agents and synthesizing their findings.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+- DO NOT suggest improvements or changes unless the user explicitly asks for them
+- DO NOT perform root cause analysis unless the user explicitly asks for them
+- DO NOT propose future enhancements unless the user explicitly asks for them
+- DO NOT critique the implementation or identify problems
+- DO NOT recommend refactoring, optimization, or architectural changes
+- ONLY describe what exists, where it exists, how it works, and how components interact
+- You are creating a technical map/documentation of the existing system
+
+## Initial Setup:
+
+When this command is invoked, respond with:
+```
+I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
+```
+
+Then wait for the user's research query.
+
+## Steps to follow after receiving the research query:
+
+1. **Read any directly mentioned files first:**
+   - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
+   - This ensures you have full context before decomposing the research
+
+2. **Analyze and decompose the research question:**
+   - Break down the user's query into composable research areas
+   - Take time to ultrathink about the underlying patterns, connections, and architectural implications the user might be seeking
+   - Identify specific components, patterns, or concepts to investigate
+   - Create a research plan to track all subtasks
+   - Consider which directories, files, or architectural patterns are relevant
+
+3. **Spawn parallel sub-agent tasks for comprehensive research:**
+   - Create multiple subagents to research different aspects concurrently
+   - We now have specialized agents that know how to do specific research tasks:
+
+   **For codebase research:**
+   - Use the **codebase-analyzer** specialist to find and understand HOW specific code works (without critiquing it)
+   - Use the **codebase-pattern-finder** specialist to find examples of existing patterns (without evaluating them)
+
+   **IMPORTANT**: All agents are documentarians, not critics. They will describe what exists without suggesting improvements or identifying issues.
+
+   **For thoughts directory:**
+   - Use the **thoughts-analyzer** specialist to discover and extract key insights from documents (only the most relevant ones)
+
+   **For web research (only if user explicitly asks):**
+   - Use the **web-search-researcher** specialist for external documentation and resources
+   - IF you use web-research agents, instruct them to return LINKS with their findings, and please INCLUDE those links in your final report
+
+   **For GitHub issues (if relevant):**
+   - Read issue details via `gh issue view <number>`
+   - Search related issues via `gh issue list --search "keyword"`
+
+   The key is to use these agents intelligently:
+   - Use analyzer agents to find relevant files and document how they work
+   - Run multiple agents in parallel when they're searching for different things
+   - Each agent knows its job - just tell it what you're looking for
+   - Don't write detailed prompts about HOW to search - the agents already know
+   - Remind agents they are documenting, not evaluating or improving
+
+4. **Wait for all sub-agents to complete and synthesize findings:**
+   - IMPORTANT: Wait for ALL sub-agent tasks to complete before proceeding
+   - Compile all sub-agent results (both codebase and thoughts findings)
+   - Prioritize live codebase findings as primary source of truth
+   - Use thoughts/ findings as supplementary historical context
+   - Connect findings across different components
+   - Include specific file paths and line numbers for reference
+   - Verify all thoughts/ paths are correct (e.g., ./thoughts/username/ not ./thoughts/shared/ for personal files)
+   - Highlight patterns, connections, and architectural decisions
+   - Answer the user's specific questions with concrete evidence
+
+5. **Gather metadata for the research document:**
+   - Run `spec-metadata` (in the PATH) to generate all relevant metadata
+   - Filename: `./thoughts/shared/research/YYYY-MM-DD/<issue-number>-description.md`
+     - Format: `YYYY-MM-DD/<issue-number>-description.md` where:
+       - YYYY-MM-DD is today's date
+       - issue-number is the GitHub issue number (omit if no issue)
+       - description is a brief kebab-case description of the research topic
+     - Examples:
+       - With issue: `2026-03-15/170-import-workflows.md`
+       - Without issue: `2026-03-15/authentication-flow.md`
+
+6. **Generate research document:**
+   - Use the metadata gathered in step 4
+   - Structure the document with YAML frontmatter followed by content:
+     ```markdown
+     ---
+     date: [Current date and time with timezone in ISO format]
+     researcher: [Researcher name from thoughts status]
+     git_commit: [Current commit hash]
+     branch: [Current branch name]
+     repository: [Repository name]
+     topic: "[User's Question/Topic]"
+     tags: [research, codebase, relevant-component-names]
+     status: complete
+     last_updated: [Current date in YYYY-MM-DD format]
+     last_updated_by: [Researcher name]
+     ---
+
+     # Research: [User's Question/Topic]
+
+     **Date**: [Current date and time with timezone from step 4]
+     **Researcher**: [Researcher name from thoughts status]
+     **Git Commit**: [Current commit hash from step 4]
+     **Branch**: [Current branch name from step 4]
+     **Repository**: [Repository name]
+
+     ## Research Question
+     [Original user query]
+
+     ## Summary
+     [High-level documentation of what was found, answering the user's question by describing what exists]
+
+     ## Detailed Findings
+
+     ### [Component/Area 1]
+     - Description of what exists ([file.ext:line](link))
+     - How it connects to other components
+     - Current implementation details (without evaluation)
+
+     ### [Component/Area 2]
+     ...
+
+     ## Code References
+     - `path/to/file.py:123` - Description of what's there
+     - `another/file.ts:45-67` - Description of the code block
+
+     ## Architecture Documentation
+     [Current patterns, conventions, and design implementations found in the codebase]
+
+     ## Historical Context (from thoughts/)
+     [Relevant insights from thoughts/ directory with references]
+     - `./thoughts/shared/something.md` - Historical decision about X
+     - `./thoughts/local/notes.md` - Past exploration of Y
+     Note: Paths exclude "searchable/" even if found there
+
+     ## Related Research
+     [Links to other research documents in ./thoughts/shared/research/]
+
+     ## Open Questions
+     [Any areas that need further investigation]
+     ```
+
+7. **Add GitHub permalinks (if applicable):**
+   - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
+   - If on main/master or pushed, generate GitHub permalinks:
+     - Get repo info: `gh repo view --json owner,name`
+     - Create permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - Replace local file references with permalinks in the document
+
+8. **Sync and present findings:**
+   - Run `thoughts-sync` to sync the thoughts directory
+   - Present a concise summary of findings to the user
+   - Include key file references for easy navigation
+   - Ask if they have follow-up questions or need clarification
+
+9. **Handle follow-up questions:**
+   - If the user has follow-up questions, append to the same research document
+   - Update the frontmatter fields `last_updated` and `last_updated_by` to reflect the update
+   - Add `last_updated_note: "Added follow-up research for [brief description]"` to frontmatter
+   - Add a new section: `## Follow-up Research [timestamp]`
+   - Spawn new sub-agents as needed for additional investigation
+   - Continue updating the document and syncing
+
+## Important notes:
+- Always use parallel subagents to maximize efficiency and minimize context usage
+- Always run fresh codebase research - never rely solely on existing research documents
+- The thoughts/ directory provides historical context to supplement live findings
+- Focus on finding concrete file paths and line numbers for developer reference
+- Research documents should be self-contained with all necessary context
+- Each sub-agent prompt should be specific and focused on read-only documentation operations
+- Document cross-component connections and how systems interact
+- Include temporal context (when the research was conducted)
+- Link to GitHub when possible for permanent references
+- Keep the main agent focused on synthesis, not deep file reading
+- Have sub-agents document examples and usage patterns as they exist
+- Explore all of thoughts/ directory, not just research subdirectory
+- **CRITICAL**: You and all sub-agents are documentarians, not evaluators
+- **REMEMBER**: Document what IS, not what SHOULD BE
+- **NO RECOMMENDATIONS**: Only describe the current state of the codebase
+- **File reading**: Always read mentioned files FULLY (no limit/offset) before spawning sub-tasks
+- **Critical ordering**: Follow the numbered steps exactly
+  - ALWAYS read mentioned files first before spawning sub-tasks (step 1)
+  - ALWAYS wait for all sub-agents to complete before synthesizing (step 4)
+  - ALWAYS gather metadata before writing the document (step 5 before step 6)
+  - NEVER write the research document with placeholder values
+- **Path handling**: The ./thoughts/searchable/ directory contains hard links for searching
+  - Always document paths by removing ONLY "searchable/" - preserve all other subdirectories
+  - Examples of correct transformations:
+    - `./thoughts/searchable/username/old_stuff/notes.md` → `./thoughts/username/old_stuff/notes.md`
+    - `./thoughts/searchable/shared/prs/123.md` → `./thoughts/shared/prs/123.md`
+    - `./thoughts/searchable/global/shared/templates.md` → `./thoughts/global/shared/templates.md`
+  - NEVER change username/ to shared/ or vice versa - preserve the exact directory structure
+  - This ensures paths are correct for editing and navigation
+- **Frontmatter consistency**:
+  - Always include frontmatter at the beginning of research documents
+  - Keep frontmatter fields consistent across all research documents
+  - Update frontmatter when adding follow-up research
+  - Use snake_case for multi-word field names (e.g., `last_updated`, `git_commit`)
+  - Tags should be relevant to the research topic and components studied

--- a/workflows/resume_handoff.md
+++ b/workflows/resume_handoff.md
@@ -1,0 +1,217 @@
+---
+name: resume_handoff
+description: "Resume work from a handoff document with context analysis and validation."
+---
+
+# Resume work from a handoff document
+
+You are tasked with resuming work from a handoff document through an interactive process. These handoffs contain critical context, learnings, and next steps from previous work sessions that need to be understood and continued.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **If the path to a handoff document was provided**:
+   - If a handoff document path was provided as a parameter, skip the default message
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `./thoughts/shared/plans` or `./thoughts/shared/research`. do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+2. **If a GitHub issue number was provided**:
+   - run `thoughts-sync` to ensure your `./thoughts/` directory is up to date.
+   - locate the most recent handoff document for the issue. Handoffs are located in `./thoughts/shared/handoffs/<issue-number>/`. e.g. for issue #170 the handoffs would be in `./thoughts/shared/handoffs/170/`. **List this directory's contents recursively** (handoffs are in date subdirectories like `YYYY-MM-DD/`).
+   - There may be zero, one or multiple files across the date subdirectories.
+   - **If there are zero files, or the directory does not exist**: tell the user: "I'm sorry, I can't seem to find that handoff document. Can you please provide me with a path to it?"
+   - **If there is only one file**: proceed with that handoff
+   - **If there are multiple files**: using the date from the subdirectory name (`YYYY-MM-DD`) and time from the filename (`HH-MM-SS`), proceed with the _most recent_ handoff document.
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `./thoughts/shared/plans` or `./thoughts/shared/research`; do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+3. **If no parameters provided**, respond with:
+```
+I'll help you resume work from a handoff document. Let me find the available handoffs.
+
+Which handoff would you like to resume from?
+
+Provide a handoff path (e.g., `./thoughts/shared/handoffs/170/2026-03-15/13-44-55_170_description.md`)
+or a GitHub issue number to resume from the most recent handoff for that issue.
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Read and Analyze Handoff
+
+1. **Read handoff document completely**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Extract all sections:
+     - Task(s) and their statuses
+     - Recent changes
+     - Learnings
+     - Artifacts
+     - Action items and next steps
+     - Other notes
+
+2. **Spawn focused research tasks**:
+   Based on the handoff content, spawn parallel research tasks to verify current state:
+
+   ```
+   Task 1 - Gather artifact context:
+   Read all artifacts mentioned in the handoff.
+   1. Read feature documents listed in "Artifacts"
+   2. Read implementation plans referenced
+   3. Read any research documents mentioned
+   4. Extract key requirements and decisions
+   Use tools: Read
+   Return: Summary of artifact contents and key decisions
+   ```
+
+3. **Wait for ALL sub-tasks to complete** before proceeding
+
+4. **Read critical files identified**:
+   - Read files from "Learnings" section completely
+   - Read files from "Recent changes" to understand modifications
+   - Read any new related files discovered during research
+
+### Step 2: Synthesize and Present Analysis
+
+1. **Present comprehensive analysis**:
+   ```
+   I've analyzed the handoff from [date] by [researcher]. Here's the current situation:
+
+   **Original Tasks:**
+   - [Task 1]: [Status from handoff] → [Current verification]
+   - [Task 2]: [Status from handoff] → [Current verification]
+
+   **Key Learnings Validated:**
+   - [Learning with file:line reference] - [Still valid/Changed]
+   - [Pattern discovered] - [Still applicable/Modified]
+
+   **Recent Changes Status:**
+   - [Change 1] - [Verified present/Missing/Modified]
+   - [Change 2] - [Verified present/Missing/Modified]
+
+   **Artifacts Reviewed:**
+   - [Document 1]: [Key takeaway]
+   - [Document 2]: [Key takeaway]
+
+   **Recommended Next Actions:**
+   Based on the handoff's action items and current state:
+   1. [Most logical next step based on handoff]
+   2. [Second priority action]
+   3. [Additional tasks discovered]
+
+   **Potential Issues Identified:**
+   - [Any conflicts or regressions found]
+   - [Missing dependencies or broken code]
+
+   Shall I proceed with [recommended action 1], or would you like to adjust the approach?
+   ```
+
+2. **Get confirmation** before proceeding
+
+### Step 3: Create Action Plan
+
+1. **Create task list**:
+   - Convert action items from handoff into todos
+   - Add any new tasks discovered during analysis
+   - Prioritize based on dependencies and handoff guidance
+
+2. **Present the plan**:
+   ```
+   I've created a task list based on the handoff and current analysis:
+
+   [Show todo list]
+
+   Ready to begin with the first task: [task description]?
+   ```
+
+### Step 4: Begin Implementation
+
+1. **Start with the first approved task**
+2. **Reference learnings from handoff** throughout implementation
+3. **Apply patterns and approaches documented** in the handoff
+4. **Update progress** as tasks are completed
+
+## Guidelines
+
+1. **Be Thorough in Analysis**:
+   - Read the entire handoff document first
+   - Verify ALL mentioned changes still exist
+   - Check for any regressions or conflicts
+   - Read all referenced artifacts
+
+2. **Be Interactive**:
+   - Present findings before starting work
+   - Get buy-in on the approach
+   - Allow for course corrections
+   - Adapt based on current state vs handoff state
+
+3. **Leverage Handoff Wisdom**:
+   - Pay special attention to "Learnings" section
+   - Apply documented patterns and approaches
+   - Avoid repeating mistakes mentioned
+   - Build on discovered solutions
+
+4. **Track Continuity**:
+   - Maintain task continuity
+   - Reference the handoff document in commits
+   - Document any deviations from original plan
+   - Consider creating a new handoff when done
+
+5. **Validate Before Acting**:
+   - Never assume handoff state matches current state
+   - Verify all file references still exist
+   - Check for breaking changes since handoff
+   - Confirm patterns are still valid
+
+## Common Scenarios
+
+### Scenario 1: Clean Continuation
+- All changes from handoff are present
+- No conflicts or regressions
+- Clear next steps in action items
+- Proceed with recommended actions
+
+### Scenario 2: Diverged Codebase
+- Some changes missing or modified
+- New related code added since handoff
+- Need to reconcile differences
+- Adapt plan based on current state
+
+### Scenario 3: Incomplete Handoff Work
+- Tasks marked as "in_progress" in handoff
+- Need to complete unfinished work first
+- May need to re-understand partial implementations
+- Focus on completing before new work
+
+### Scenario 4: Stale Handoff
+- Significant time has passed
+- Major refactoring has occurred
+- Original approach may no longer apply
+- Need to re-evaluate strategy
+
+## Example Interaction Flow
+
+```
+User: resume_handoff specification/feature/handoffs/handoff-0.md
+Assistant: Let me read and analyze that handoff document...
+
+[Reads handoff completely]
+[Spawns research tasks]
+[Waits for completion]
+[Reads identified files]
+
+I've analyzed the handoff from [date]. Here's the current situation...
+
+[Presents analysis]
+
+Shall I proceed with implementing the webhook validation fix, or would you like to adjust the approach?
+
+User: Yes, proceed with the webhook validation
+Assistant: [Creates todo list and begins implementation]
+```

--- a/workflows/review_pr.md
+++ b/workflows/review_pr.md
@@ -1,0 +1,320 @@
+---
+name: review_pr
+description: "Multi-agent PR review with three modes: review, re-review, self-review."
+---
+
+## Modes
+
+- **review** (default): Full review, present findings for approval before posting
+- **re-review**: Also load existing review feedback; verify previously requested changes were addressed
+- **self-review**: Fix findings directly in code instead of posting a review
+
+## Process
+
+### Step 1: Gather PR Metadata
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,body,url,headRefName,baseRefName
+```
+
+Extract from PR body:
+- **Issue reference** (e.g., #123) — if found, fetch full issue details for requirements and acceptance criteria via `gh issue view`
+- **Business context** — why this change is needed
+
+If re-review mode is activated, also save all existing review feedback to `/tmp/` without reading them:
+```bash
+# Review verdicts and bodies (APPROVED, CHANGES_REQUESTED, COMMENTED)
+gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/reviews | tee /tmp/pr_<NUMBER>_reviews.json | jq length
+
+# Inline review comments on specific diff lines
+gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/comments | tee /tmp/pr_<NUMBER>_inline_comments.json | jq length
+
+# Conversation-level comments
+gh api repos/<OWNER>/<REPO>/issues/<PR_NUMBER>/comments | tee /tmp/pr_<NUMBER>_conversation.json | jq length
+```
+
+### Step 2: Fetch and Save Diff
+
+Checkout the PR branch locally and generate the diff. Save it to `/tmp/` — only subagents will read it.
+
+```bash
+git fetch origin
+git checkout <branch>
+
+# Use merge-base for a clean diff (handles diverged base branch)
+BASE=$(git merge-base origin/<baseRefName> HEAD)
+git diff $BASE -- . > /tmp/pr_<NUMBER>_diff.txt
+```
+
+If the user provided file exclusion or inclusion patterns in additional instructions, apply them using git's pathspec syntax:
+
+```bash
+# Exclude specific paths
+git diff $BASE -- . ':(exclude)path/to/noisy/dir' ':(exclude)*.ext' > /tmp/pr_<NUMBER>_diff.txt
+
+# Include only specific directories
+git diff $BASE -- path/to/dir1/ path/to/dir2/ > /tmp/pr_<NUMBER>_diff.txt
+
+# Combine inclusion with exclusion
+git diff $BASE -- path/to/dir/ ':(exclude)path/to/dir/subdir' > /tmp/pr_<NUMBER>_diff.txt
+```
+
+Verify the diff is non-empty: `wc -l < /tmp/pr_<NUMBER>_diff.txt`
+
+### Step 3: Gather Historical Context
+
+Spawn the **thoughts-analyzer** specialist to find historical knowledge about affected features.
+
+```
+specialist: thoughts-analyzer
+
+Prompt: "What do we know about <ticket reference and title from Step 1>? What decisions, constraints, and trade-offs should reviewers be aware of?"
+```
+
+**Wait for this specialist to complete before proceeding.**
+
+### Step 4: Spawn Review Subagents
+
+Spawn all five review subagents **in parallel** using `spawn_subagent`. Each receives:
+- Path to the diff file in `/tmp/`
+- Ticket context (from Step 1)
+- Historical context (from Step 3)
+- Their specific review focus
+- Any additional instructions from the user's input
+
+If re-review mode is activated, each subagent also receives the paths to `/tmp/pr_<NUMBER>_reviews.json`, `/tmp/pr_<NUMBER>_inline_comments.json`, and `/tmp/pr_<NUMBER>_conversation.json` with this modified instruction: "Primary goal: verify that previously requested changes were addressed. Secondary goal: check for new problems introduced."
+
+**Critical:** Spawn all five subagents in parallel to ensure concurrent execution.
+
+#### Subagent 1: RailsGuru
+
+```
+Prompt: "Review PR #<number> for Rails conventions and architecture.
+
+Read the diff from: /tmp/pr_<number>_diff.txt
+
+*Critical:* Activate the `activerecord` skill for AR patterns reference.
+
+## Ticket Context
+<ticket title, acceptance criteria, business context>
+
+## Historical Context
+<output from thoughts-analyzer>
+
+<any additional instructions from user input>
+
+## Focus Areas
+- MVC boundary violations (fat controllers, logic in views)
+- Rails idioms (proper use of scopes, callbacks, concerns)
+- REST conventions and route design
+- ActiveRecord patterns (associations, validations placement)
+- Service object patterns and naming
+
+Output: List findings tagged [major], [minor], or [nit] with file:line references."
+```
+
+#### Subagent 2: SecurityHawk
+
+```
+Prompt: "Review PR #<number> for security vulnerabilities.
+
+Read the diff from: /tmp/pr_<number>_diff.txt
+
+*Critical:* Activate the `activerecord` skill for SQL injection prevention patterns.
+
+## Ticket Context
+<ticket title, acceptance criteria, business context>
+
+## Historical Context
+<output from thoughts-analyzer>
+
+<any additional instructions from user input>
+
+## Focus Areas
+- SQL injection (raw queries, interpolation in where clauses)
+- XSS vulnerabilities (unescaped output, html_safe misuse)
+- CSRF protection gaps
+- Mass assignment vulnerabilities (permit params)
+- Authentication/authorization bypasses
+- Secrets or credentials in code
+- Insecure direct object references
+
+Output: List findings tagged [major], [minor], or [nit] with file:line references."
+```
+
+#### Subagent 3: PerfPro
+
+```
+Prompt: "Review PR #<number> for performance issues.
+
+Read the diff from: /tmp/pr_<number>_diff.txt
+
+*Critical:* Activate the `activerecord` skill for N+1 and query optimization patterns.
+
+## Ticket Context
+<ticket title, acceptance criteria, business context>
+
+## Historical Context
+<output from thoughts-analyzer>
+
+<any additional instructions from user input>
+
+## Focus Areas
+- N+1 query patterns (missing includes/preload/eager_load)
+- Expensive queries in loops
+- Missing database indexes for new queries
+- Inefficient ActiveRecord usage (pluck vs select, find_each vs each)
+- Memory bloat (loading large datasets)
+- Missing caching opportunities
+- Background job considerations (should this be async?)
+
+Output: List findings tagged [major], [minor], or [nit] with file:line references."
+```
+
+#### Subagent 4: TestCoach
+
+```
+Prompt: "Review PR #<number> for test quality and coverage.
+
+Read the diff from: /tmp/pr_<number>_diff.txt
+
+*Critical:* Activate the `rspec` skill for RSpec best practices reference.
+
+## Ticket Context
+<ticket title, acceptance criteria, business context>
+
+## Historical Context
+<output from thoughts-analyzer>
+
+<any additional instructions from user input>
+
+## Focus Areas
+- Missing test coverage for new code paths
+- Flaky test patterns (time-dependent, order-dependent)
+- Factory usage (proper traits, avoiding create when build suffices)
+- Test isolation issues (shared state, missing cleanup)
+- Assertion quality (testing behavior vs implementation)
+- Missing edge case coverage
+
+Output: List findings tagged [major], [minor], or [nit] with file:line references."
+```
+
+#### Subagent 5: DocScribe
+
+```
+Prompt: "Review PR #<number> for documentation and clarity.
+
+Read the diff from: /tmp/pr_<number>_diff.txt
+
+## Ticket Context
+<ticket title, acceptance criteria, business context>
+
+## Historical Context
+<output from thoughts-analyzer>
+
+<any additional instructions from user input>
+
+## Focus Areas
+- Method and class naming clarity
+- Missing YARD documentation on public interfaces
+- Complex logic lacking explanatory comments
+- Changelog updates for notable changes
+- Misleading or outdated comments
+- Magic numbers or strings needing constants
+
+Output: List findings tagged [major], [minor], or [nit] with file:line references."
+```
+
+### Step 5: Merge Results
+
+After all subagents complete, compile findings into a unified review.
+
+**Critical: Subagents are pattern matchers. You are the judgment layer.** Subagents are designed to be paranoid and thorough — they flag everything that matches their heuristics. Your job is to filter their output, not rubber-stamp it. A [major] from a subagent can become a [nit] or be dropped entirely after applying judgment.
+
+For each finding, evaluate:
+- **Real-world probability** — Can this actually happen in practice, or is it purely theoretical? A race condition that requires two users to open a personal link within the same millisecond is not a real issue.
+- **Cost-benefit** — Does the fix add more complexity than the problem warrants? If the "fix" makes the code harder to read without solving a problem a human would encounter, drop it.
+- **Scope** — Review fixes should improve code you're touching, not introduce new artifacts. Clean up, don't build out.
+
+Then compile:
+
+1. **Group by severity** — [major] first, then [minor], then [nit]
+2. **Remove duplicates** — Multiple agents may flag the same issue
+3. **Add actionable suggestions** — Include code snippets where helpful
+4. **Preserve file:line references** — Format as `app/models/user.rb:42`
+
+Determine verdict:
+- **REQUEST_CHANGES** — If any [major] or multiple [minor] issues survive the judgment filter
+- **APPROVE** — If no significant issues remain after filtering
+
+### Step 6: Finalize
+
+If self-review mode is activated, skip to **Self-review** below.
+
+#### Present and Post (review / re-review)
+
+Present the merged review to the user, including:
+- PR reference and ticket (if found)
+- Determined verdict
+- All findings grouped by severity
+
+Ask the user to confirm: "Shall I post this review to the PR? [Yes/Edit/Cancel]"
+- **Yes** — post the review
+- **Edit** — let the user modify the review, then ask again
+- **Cancel** — discard
+
+Once confirmed, post the review:
+
+```bash
+gh pr review <PR_NUMBER> --approve --body "<review body>"
+# or
+gh pr review <PR_NUMBER> --request-changes --body "<review body>"
+```
+
+#### Self-review
+
+Instead of presenting and posting, act on the findings:
+
+1. **Fix findings** — Address [major] and [minor] issues directly in code. Apply [nit]s at own discretion.
+2. **Commit and push** — Commit the fixes with a descriptive message and push to the PR branch.
+3. **Assign reviewer** — Assign the user and request review from anyone mentioned in additional instructions.
+4. **Wait for CI** — Monitor CI status. Once green, mark the PR as ready for review.
+
+```bash
+gh pr edit <PR_NUMBER> --add-assignee <user> --add-reviewer <reviewer>
+# once CI is green:
+gh pr ready <PR_NUMBER>
+```
+
+## Posted Review Format
+
+```markdown
+## PR Review Summary
+
+**Verdict: REQUEST_CHANGES**
+
+### Major Issues
+- `app/models/user.rb:42` - SQL injection via string interpolation in where clause
+  ```ruby
+  # Instead of:
+  User.where("name = '#{params[:name]}'")
+  # Use:
+  User.where(name: params[:name])
+  ```
+
+### Minor Issues
+- `app/controllers/users_controller.rb:15` - Business logic belongs in model or service
+
+### Suggestions
+- `app/services/user_service.rb:8` - Consider more descriptive method name
+
+---
+*Review generated with multi-agent analysis*
+```
+
+## Guidelines
+
+- Focus only on changed lines, not surrounding unchanged code
+- Provide concrete fix suggestions for [major] issues
+- The main agent must never read the diff file — only subagents read it
+- Pass additional instructions from user input through to all subagents

--- a/workflows/thoughts_init.md
+++ b/workflows/thoughts_init.md
@@ -1,0 +1,71 @@
+---
+name: thoughts_init
+description: "Initialize the thoughts system for the current repository."
+---
+
+# Initialize Thoughts System
+
+Initialize the thoughts system for the current repository.
+
+## Process
+
+### Step 1: Diagnostic Checks
+
+Run these checks and collect results:
+
+1. `~/thoughts` exists: `test -d "$HOME/thoughts"`
+2. `~/thoughts` is git repo: `test -d "$HOME/thoughts/.git"`
+3. `~/thoughts/global` structure exists: `test -d "$HOME/thoughts/global"`
+4. Scripts exist: `test -x "$HOME/thoughts/bin/thoughts-sync"`
+5. Scripts in PATH: `command -v thoughts-sync >/dev/null 2>&1`
+6. Current dir is git repo: `test -d ".git"`
+7. `./thoughts/shared` symlinked correctly: `test -L "./thoughts/shared" && readlink "./thoughts/shared" | grep -q "thoughts/repos/"`
+
+### Step 2: Report or Fix
+
+**If all checks pass:**
+```
+Thoughts system ready. Workflow commands will now work correctly.
+
+- ~/thoughts: OK (with global/ structure)
+- Scripts: OK (in PATH)
+- Repository: OK (thoughts/shared → ~/thoughts/repos/{repo}/shared)
+```
+
+**If any check fails:**
+Build todo list of what needs fixing, present to user, wait for authorization.
+
+### Step 3: Execute Fixes (after authorization)
+
+**If ~/thoughts missing:**
+```bash
+mkdir -p "$HOME/thoughts/bin"
+mkdir -p "$HOME/thoughts/global/$(whoami)"
+mkdir -p "$HOME/thoughts/global/shared"
+mkdir -p "$HOME/thoughts/repos"
+git -C "$HOME/thoughts" init
+# Copy thoughts bin scripts from the thoughts repository if available
+chmod +x "$HOME/thoughts/bin/"*
+```
+
+**If PATH not configured:**
+```bash
+RC_FILE="$HOME/.bashrc"
+[[ "$SHELL" == *"zsh"* ]] && RC_FILE="$HOME/.zshrc"
+echo 'export PATH="$HOME/thoughts/bin:$PATH"' >> "$RC_FILE"
+```
+Tell user to run `source ~/.zshrc` or restart terminal.
+
+**If current repo not initialized:**
+```bash
+"$HOME/thoughts/bin/thoughts-init-repo"
+```
+
+### Step 4: Verify and Report
+
+After fixes, re-run checks and report final status.
+
+## Important
+
+- Never make changes without user authorization
+- If current directory is not a git repo, report error and stop

--- a/workflows/validate_plan.md
+++ b/workflows/validate_plan.md
@@ -1,0 +1,166 @@
+---
+name: validate_plan
+description: "Validate implementation against plan, verify success criteria, and identify issues."
+---
+
+# Validate Plan
+
+You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.
+
+## Initial Setup
+
+When invoked:
+1. **Determine context** - Are you in an existing conversation or starting fresh?
+   - If existing: Review what was implemented in this session
+   - If fresh: Need to discover what was done through git and codebase analysis
+
+2. **Locate the plan**:
+   - If plan path provided, use it
+   - Otherwise, search recent commits for plan references or ask user
+
+3. **Gather implementation evidence**:
+   ```bash
+   # Check recent commits
+   git log --oneline -n 20
+   git diff HEAD~N..HEAD  # Where N covers implementation commits
+
+   # Run comprehensive checks
+   cd $(git rev-parse --show-toplevel) && make check test
+   ```
+
+## Validation Process
+
+### Step 1: Context Discovery
+
+If starting fresh or need more context:
+
+1. **Read the implementation plan** completely
+2. **Identify what should have changed**:
+   - List all files that should be modified
+   - Note all success criteria (automated and manual)
+   - Identify key functionality to verify
+
+3. **Spawn parallel research tasks** to discover implementation:
+   ```
+   Task 1 - Verify database changes:
+   Research if migration [N] was added and schema changes match plan.
+   Check: migration files, schema version, table structure
+   Return: What was implemented vs what plan specified
+
+   Task 2 - Verify code changes:
+   Find all modified files related to [feature].
+   Compare actual changes to plan specifications.
+   Return: File-by-file comparison of planned vs actual
+
+   Task 3 - Verify test coverage:
+   Check if tests were added/modified as specified.
+   Run test commands and capture results.
+   Return: Test status and any missing coverage
+   ```
+
+### Step 2: Systematic Validation
+
+For each phase in the plan:
+
+1. **Check completion status**:
+   - Look for checkmarks in the plan (- [x])
+   - Verify the actual code matches claimed completion
+
+2. **Run automated verification**:
+   - Execute each command from "Automated Verification"
+   - Document pass/fail status
+   - If failures, investigate root cause
+
+3. **Assess manual criteria**:
+   - List what needs manual testing
+   - Provide clear steps for user verification
+
+4. **Think deeply about edge cases**:
+   - Were error conditions handled?
+   - Are there missing validations?
+   - Could the implementation break existing functionality?
+
+### Step 3: Generate Validation Report
+
+Create comprehensive validation summary:
+
+```markdown
+## Validation Report: [Plan Name]
+
+### Implementation Status
+✓ Phase 1: [Name] - Fully implemented
+✓ Phase 2: [Name] - Fully implemented
+⚠️ Phase 3: [Name] - Partially implemented (see issues)
+
+### Automated Verification Results
+✓ Build passes: `make build`
+✓ Tests pass: `make test`
+✗ Linting issues: `make lint` (3 warnings)
+
+### Code Review Findings
+
+#### Matches Plan:
+- Database migration correctly adds [table]
+- API endpoints implement specified methods
+- Error handling follows plan
+
+#### Deviations from Plan:
+- Used different variable names in [file:line]
+- Added extra validation in [file:line] (improvement)
+
+#### Potential Issues:
+- Missing index on foreign key could impact performance
+- No rollback handling in migration
+
+### Manual Testing Required:
+1. UI functionality:
+   - [ ] Verify [feature] appears correctly
+   - [ ] Test error states with invalid input
+
+2. Integration:
+   - [ ] Confirm works with existing [component]
+   - [ ] Check performance with large datasets
+
+### Recommendations:
+- Address linting warnings before merge
+- Consider adding integration test for [scenario]
+- Document new API endpoints
+```
+
+## Working with Existing Context
+
+If you were part of the implementation:
+- Review the conversation history
+- Check your todo list for what was completed
+- Focus validation on work done in this session
+- Be honest about any shortcuts or incomplete items
+
+## Important Guidelines
+
+1. **Be thorough but practical** - Focus on what matters
+2. **Run all automated checks** - Don't skip verification commands
+3. **Document everything** - Both successes and issues
+4. **Think critically** - Question if the implementation truly solves the problem
+5. **Consider maintenance** - Will this be maintainable long-term?
+
+## Validation Checklist
+
+Always verify:
+- [ ] All phases marked complete are actually done
+- [ ] Automated tests pass
+- [ ] Code follows existing patterns
+- [ ] No regressions introduced
+- [ ] Error handling is robust
+- [ ] Documentation updated if needed
+- [ ] Manual test steps are clear
+
+## Relationship to Other Commands
+
+Recommended workflow:
+1. `implement_plan` — Execute the implementation
+2. `commit` — Create atomic commits for changes
+3. `validate_plan` — Verify implementation correctness
+
+The validation works best after commits are made, as it can analyze the git history to understand what was implemented.
+
+Remember: Good validation catches issues before they reach production. Be constructive but thorough in identifying gaps or improvements.


### PR DESCRIPTION
## Summary

- Copied 12 RPI command files to `workflows/` and adapted for Anima's architecture
- Created new `decompose_ticket.md` workflow (fills a gap RPI doesn't have)
- 13 workflow files total, all with valid YAML frontmatter (`name` + `description`)

### Adaptation scope

- Added `name` field to frontmatter (some RPI commands lacked frontmatter entirely)
- Replaced `rpi:` subagent prefixes with Anima named specialists (`thoughts-analyzer`, `codebase-analyzer`, etc.)
- Replaced Linear MCP references with GitHub issues (`gh` CLI)
- Replaced Claude Code tools (Task, TodoWrite, AskUserQuestion) with Anima equivalents
- Removed `$ARGUMENTS` placeholders — workflows are read by the analytical brain, not invoked as slash commands
- Removed `model:` field — Anima doesn't support per-workflow model selection

### Files

| Workflow | Source | Notes |
|----------|--------|-------|
| `commit.md` | RPI | Minimal changes |
| `create_handoff.md` | RPI | ENG-XXXX → issue numbers |
| `create_note.md` | RPI | Minimal changes |
| `create_plan.md` | RPI | Linear → GitHub, TodoWrite removed |
| `decompose_ticket.md` | **NEW** | Vertical slicing principle |
| `feature.md` | RPI | Added frontmatter, Linear → GitHub |
| `implement_plan.md` | RPI | Minimal changes |
| `iterate_plan.md` | RPI | rpi: prefixes, TodoWrite removed |
| `research_codebase.md` | RPI | Linear agents → gh CLI |
| `resume_handoff.md` | RPI | ENG-XXXX → issue numbers |
| `review_pr.md` | RPI | Skill refs, AskUserQuestion adapted |
| `thoughts_init.md` | RPI | CLAUDE_PLUGIN_ROOT removed |
| `validate_plan.md` | RPI | /rpi: command refs → workflow names |

## Test plan

- [ ] Verify all files parse with `Workflows::Definition.from_file` (blocked by #171)
- [ ] Verify no references to Claude Code specifics remain
- [ ] Verify `decompose_ticket.md` covers vertical slicing principle

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)