### PR TITLE
#192 chore: increase API timeout default to 5 minutes

### DIFF
--- a/lib/anima/installer.rb
+++ b/lib/anima/installer.rb
@@ -106,7 +106,7 @@ module Anima
         [timeouts]
 
         # LLM API request timeout.
-        api = 30
+        api = 300
 
         # Shell command execution timeout.
         command = 30

--- a/spec/lib/anima/settings_spec.rb
+++ b/spec/lib/anima/settings_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Anima::Settings do
         "max_tool_rounds" => 25,
         "token_budget" => 190_000
       },
-      "timeouts" => {"api" => 30, "command" => 30, "mcp_response" => 60, "web_request" => 10},
+      "timeouts" => {"api" => 300, "command" => 30, "mcp_response" => 60, "web_request" => 10},
       "shell" => {"max_output_bytes" => 100_000},
       "tools" => {"max_file_size" => 10_485_760, "max_read_lines" => 2_000, "max_read_bytes" => 50_000, "max_web_response_bytes" => 100_000},
       "paths" => {"soul" => "/home/test/.anima/soul.md"},
@@ -35,7 +35,7 @@ RSpec.describe Anima::Settings do
     end
 
     it "reads timeout settings" do
-      expect(described_class.api_timeout).to eq(30)
+      expect(described_class.api_timeout).to eq(300)
       expect(described_class.command_timeout).to eq(30)
       expect(described_class.mcp_response_timeout).to eq(60)
       expect(described_class.web_request_timeout).to eq(10)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
         "max_tool_rounds" => 25,
         "token_budget" => 190_000
       },
-      "timeouts" => {"api" => 30, "command" => 30, "mcp_response" => 60, "web_request" => 10},
+      "timeouts" => {"api" => 300, "command" => 30, "mcp_response" => 60, "web_request" => 10},
       "shell" => {"max_output_bytes" => 100_000},
       "tools" => {"max_file_size" => 10_485_760, "max_read_lines" => 2_000, "max_read_bytes" => 50_000, "max_web_response_bytes" => 100_000},
       "paths" => {"soul" => Rails.root.join("templates/soul.md").to_s},


### PR DESCRIPTION
## Summary

- Increase default `[timeouts] api` from 30s to 300s (5 minutes) in `config.toml` template
- Update test stubs and assertions to match the new default
- Existing user configs with explicit timeout values are unaffected (installer skips if config exists)

## Why

Claude Opus with large context windows routinely takes 60-90+ seconds for complex responses, especially during long tool chains with extended thinking. The 30s default caused frequent `Net::ReadTimeout` errors, and while exponential retry backoff recovered, it wasted time and killed momentum (#187).

## Test plan

- [x] `bundle exec rspec spec/lib/anima/settings_spec.rb` — passes (35 examples, 0 failures)
- [x] `bundle exec rspec spec/lib/anima/installer_spec.rb` — passes
- [x] `bundle exec standardrb` — clean

Closes #192
Closes #187