### PR TITLE
#186 chore: increase default max_tool_rounds to 500

### DIFF
--- a/lib/anima/installer.rb
+++ b/lib/anima/installer.rb
@@ -95,7 +95,7 @@ module Anima
         max_tokens = 8192
 
         # Maximum consecutive tool execution rounds per request.
-        max_tool_rounds = 25
+        max_tool_rounds = 500
 
         # Context window budget — tokens reserved for conversation history.
         # Set this based on your model's context window minus system prompt.

--- a/spec/lib/anima/settings_spec.rb
+++ b/spec/lib/anima/settings_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Anima::Settings do
         "model" => "claude-sonnet-4-20250514",
         "fast_model" => "claude-haiku-4-5",
         "max_tokens" => 8192,
-        "max_tool_rounds" => 25,
+        "max_tool_rounds" => 500,
         "token_budget" => 190_000
       },
       "timeouts" => {"api" => 300, "command" => 30, "mcp_response" => 60, "web_request" => 10},
@@ -30,7 +30,7 @@ RSpec.describe Anima::Settings do
       expect(described_class.model).to eq("claude-sonnet-4-20250514")
       expect(described_class.fast_model).to eq("claude-haiku-4-5")
       expect(described_class.max_tokens).to eq(8192)
-      expect(described_class.max_tool_rounds).to eq(25)
+      expect(described_class.max_tool_rounds).to eq(500)
       expect(described_class.token_budget).to eq(190_000)
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ RSpec.configure do |config|
         "model" => "claude-sonnet-4-20250514",
         "fast_model" => "claude-haiku-4-5",
         "max_tokens" => 8192,
-        "max_tool_rounds" => 25,
+        "max_tool_rounds" => 500,
         "token_budget" => 190_000
       },
       "timeouts" => {"api" => 300, "command" => 30, "mcp_response" => 60, "web_request" => 10},


### PR DESCRIPTION
## Summary

- Raise default `[llm] max_tool_rounds` from 25 to 500 in the config template
- Update test stubs and assertions to match
- Existing user configs with explicit values are unaffected (installer skips if config exists)

## Why

25 rounds is too low for autonomous multi-step work (site builds, deep research, complex implementations). The agent hits the ceiling during the research phase before real work even starts (#186).

## Test plan

- [x] `bundle exec rspec spec/lib/anima/settings_spec.rb` — 16 examples, 0 failures
- [x] `bundle exec rspec spec/lib/anima/installer_spec.rb` — 19 examples, 0 failures
- [x] `bundle exec rspec spec/lib/llm/client_spec.rb -e "max_tool_rounds"` — 1 example, 0 failures
- [x] `bundle exec standardrb` — clean

Closes #186