### PR TITLE
#168 fix: wrap long session names in HUD panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **TUI session name wrapping in HUD** — long session names now wrap across multiple lines instead of being silently clipped at the panel boundary (#168)
 - **WebGet SSL certificate verification** — bundle Mozilla CA certificates via `certifi` gem so HTTPS requests work on systems with incomplete CA stores (e.g. mise/rbenv-compiled Ruby) (#253)
 
 ### Added

--- a/lib/tui/app.rb
+++ b/lib/tui/app.rb
@@ -236,6 +236,7 @@ module TUI
 
       content = tui.paragraph(
         text: lines,
+        wrap: true,
         block: tui.block(
           borders: [:left, :top, :right],
           border_type: :rounded,


### PR DESCRIPTION
## Summary
- Add `wrap: true` to the HUD content paragraph widget so long session names flow across multiple lines instead of being silently clipped at the panel boundary
- All other HUD content (goals, skills, workflow, sub-agents) also benefits from wrapping

## Test plan
- [ ] Launch TUI with a session that has a long name (e.g. "📚 Network Protocols & Sorting Algorithms")
- [ ] Verify the name wraps to multiple lines in the HUD panel instead of being clipped
- [ ] Verify shorter names still display on a single line
- [ ] Verify goals, skills, and workflow sections render correctly with wrapping enabled

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)