### PR TITLE
#270 chore: Remove orphaned anima.yml from installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,7 @@ State directory (`~/.anima/`):
 ├── config.toml      # Main settings (hot-reloadable)
 ├── mcp.toml         # MCP server configuration
 ├── config/
-│   ├── credentials/ # Rails encrypted credentials per environment
-│   └── anima.yml    # Placeholder config
+│   └── credentials/ # Rails encrypted credentials per environment
 ├── agents/          # User-defined specialist agents (override built-ins)
 ├── skills/          # User-defined skills (override built-ins)
 ├── workflows/       # User-defined workflows (override built-ins)

--- a/lib/anima/installer.rb
+++ b/lib/anima/installer.rb
@@ -30,7 +30,6 @@ module Anima
       say "Installing Anima to #{anima_home}..."
       create_directories
       create_soul_file
-      create_config_file
       create_settings_config
       create_mcp_config
       generate_credentials
@@ -58,17 +57,6 @@ module Anima
       template = File.join(TEMPLATE_DIR, "soul.md")
       soul_path.write(File.read(template))
       say "  created #{soul_path}"
-    end
-
-    def create_config_file
-      config_path = anima_home.join("config", "anima.yml")
-      return if config_path.exist?
-
-      config_path.write(<<~YAML)
-        # Anima configuration
-        # See https://github.com/hoblin/anima for documentation
-      YAML
-      say "  created #{config_path}"
     end
 
     def create_settings_config

--- a/spec/lib/anima/installer_spec.rb
+++ b/spec/lib/anima/installer_spec.rb
@@ -35,13 +35,6 @@ RSpec.describe Anima::Installer do
       end
     end
 
-    it "creates anima.yml config file" do
-      installer.run
-
-      config_path = tmp_home.join("config", "anima.yml")
-      expect(config_path).to exist
-    end
-
     it "generates credentials for each environment" do
       installer.run
 


### PR DESCRIPTION
## Summary
- Removed `create_config_file` method from `Anima::Installer` — it created `~/.anima/config/anima.yml` with a placeholder comment, but nothing in the codebase reads it
- All configuration lives in `config.toml` via `Anima::Settings`
- Removed corresponding spec and README directory tree reference

## Test plan
- [x] Installer specs pass (20 examples, 0 failures)
- [x] `standardrb` clean
- [x] Verified no remaining references to `anima.yml` in codebase

Closes #270