### PR TITLE
#286 feat: Sanitize tool output at ToolDecorator level for LLM consumption

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -80,6 +80,10 @@ detectors:
   TooManyConstants:
     exclude:
       - "EventDecorator"
+  # encode_utf8 is descriptive — the digit triggers a false positive.
+  UncommunicativeMethodName:
+    exclude:
+      - "ToolDecorator#self.encode_utf8"
   # Abstract base class methods declare parameters for the subclass contract.
   UnusedParameters:
     exclude:

--- a/app/decorators/tool_decorator.rb
+++ b/app/decorators/tool_decorator.rb
@@ -41,10 +41,8 @@ class ToolDecorator
     sanitize_for_llm(result)
   end
 
-  # Ensures a tool result string is safe for LLM consumption:
-  #   1. Force-encode to UTF-8, replacing invalid/undefined bytes with U+FFFD
-  #   2. Strip ANSI escape codes (CSI, OSC, and single-character escapes)
-  #   3. Strip C0 control characters except newline and tab
+  # Ensures a tool result string is safe for LLM consumption by
+  # composing {encode_utf8}, {strip_ansi}, and {strip_control_chars}.
   #
   # Non-string results pass through unchanged.
   #
@@ -53,16 +51,44 @@ class ToolDecorator
   def self.sanitize_for_llm(result)
     return result unless result.is_a?(String)
 
-    # ANSI escape codes: CSI (colors, cursor, DEC private modes),
-    # OSC (terminal title), charset designation, single-char commands
-    ansi = /\e\[[?>=<0-9;]*[A-Za-z]|\e\][^\a\e]*(?:\a|\e\\)|\e[()][0-9A-Za-z]|\e[>=<78NOMDEHcn]/
-
-    result
-      .encode("UTF-8", invalid: :replace, undef: :replace, replace: "\uFFFD")
-      .gsub(ansi, "")
-      .gsub(/[\x00-\x08\x0B-\x0D\x0E-\x1F\x7F]/, "")
+    strip_control_chars(strip_ansi(encode_utf8(result)))
   end
   private_class_method :sanitize_for_llm
+
+  # Force-encodes a string to UTF-8, replacing invalid or undefined
+  # bytes with the Unicode replacement character (U+FFFD).
+  #
+  # @param str [String] input in any encoding (commonly ASCII-8BIT from PTY)
+  # @return [String] valid UTF-8 string
+  def self.encode_utf8(str)
+    str.encode("UTF-8", invalid: :replace, undef: :replace, replace: "\uFFFD")
+  end
+  private_class_method :encode_utf8
+
+  # CSI (colors, cursor, DEC private modes), OSC (terminal title),
+  # charset designation, single-char commands
+  ANSI_ESCAPE = /\e\[[?>=<0-9;]*[A-Za-z]|\e\][^\a\e]*(?:\a|\e\\)|\e[()][0-9A-Za-z]|\e[>=<78NOMDEHcn]/
+  private_constant :ANSI_ESCAPE
+
+  # Strips ANSI escape sequences that are meaningless noise to an LLM
+  # but can dominate terminal output payloads.
+  #
+  # @param str [String] UTF-8 string possibly containing escape codes
+  # @return [String] cleaned string
+  def self.strip_ansi(str)
+    str.gsub(ANSI_ESCAPE, "")
+  end
+  private_class_method :strip_ansi
+
+  # Strips C0 control characters (NUL, BEL, BS, CR, etc.) that carry
+  # no meaning for an LLM. Preserves newline (\n) and tab (\t).
+  #
+  # @param str [String] UTF-8 string possibly containing control chars
+  # @return [String] cleaned string
+  def self.strip_control_chars(str)
+    str.gsub(/[\x00-\x08\x0B-\x0D\x0E-\x1F\x7F]/, "")
+  end
+  private_class_method :strip_control_chars
 
   # Subclasses override to transform the raw tool result.
   #

--- a/spec/decorators/tool_decorator_spec.rb
+++ b/spec/decorators/tool_decorator_spec.rb
@@ -27,157 +27,200 @@ RSpec.describe ToolDecorator do
       expect(described_class.call("unknown_tool", result)).to eq("hello")
     end
 
-    context "encoding sanitization" do
-      it "converts ASCII-8BIT strings to valid UTF-8" do
-        binary = (+"hello \x80\xFF world").force_encoding("ASCII-8BIT")
-        result = described_class.call("bash", binary)
+    it "passes through non-error hashes unchanged" do
+      result = described_class.call("unknown_tool", {data: "value"})
+      expect(result).to eq({data: "value"})
+    end
 
-        expect(result.encoding).to eq(Encoding::UTF_8)
-        expect(result).to be_valid_encoding
-        expect(result).to include("hello")
-        expect(result).to include("world")
+    it "composes all sanitizers on dirty input" do
+      messy = (+"\e[32mOK\e[0m\x00\x07 result: café \x80").force_encoding("ASCII-8BIT")
+      result = described_class.call("bash", messy)
+
+      expect(result.encoding).to eq(Encoding::UTF_8)
+      expect(result).to be_valid_encoding
+      expect(result).to include("OK")
+      expect(result).to include("result:")
+      expect(result).not_to include("\e[")
+      expect(result).not_to include("\x00")
+    end
+
+    it "sanitizes decorated tool results too" do
+      html_with_ansi = "<html><body>\e[31mHello\e[0m</body></html>"
+      result = described_class.call("web_get", {body: html_with_ansi, content_type: "text/html"})
+
+      expect(result).not_to include("\e[")
+    end
+  end
+
+  # Unit tests for individual sanitizers — each tested in isolation
+  # via send to avoid going through the full .call pipeline.
+
+  describe ".encode_utf8" do
+    subject(:encode_utf8) { described_class.send(:encode_utf8, input) }
+
+    context "with ASCII-8BIT input" do
+      let(:input) { (+"hello \x80\xFF world").force_encoding("ASCII-8BIT") }
+
+      it "returns valid UTF-8" do
+        expect(encode_utf8.encoding).to eq(Encoding::UTF_8)
+        expect(encode_utf8).to be_valid_encoding
       end
 
-      it "replaces invalid UTF-8 bytes with replacement character" do
-        invalid_utf8 = (+"valid \xC0\xAF text").force_encoding("UTF-8")
-        result = described_class.call("bash", invalid_utf8)
-
-        expect(result).to be_valid_encoding
-        expect(result).to include("valid")
-        expect(result).to include("text")
-        expect(result).to include("\uFFFD")
-      end
-
-      it "preserves valid UTF-8 content unchanged" do
-        utf8 = "Héllo wörld 日本語 🚀"
-        result = described_class.call("bash", utf8)
-
-        expect(result).to eq(utf8)
+      it "replaces unmappable bytes with U+FFFD" do
+        expect(encode_utf8).to include("\uFFFD")
+        expect(encode_utf8).to include("hello")
+        expect(encode_utf8).to include("world")
       end
     end
 
-    context "ANSI escape code stripping" do
-      it "strips SGR color codes" do
-        ansi = "\e[31mERROR\e[0m: something failed"
-        result = described_class.call("bash", ansi)
+    context "with invalid UTF-8 sequences" do
+      let(:input) { (+"valid \xC0\xAF text").force_encoding("UTF-8") }
 
-        expect(result).to eq("ERROR: something failed")
-      end
-
-      it "strips bold, underline, and combined SGR sequences" do
-        ansi = "\e[1;4;33mWarning\e[0m"
-        result = described_class.call("bash", ansi)
-
-        expect(result).to eq("Warning")
-      end
-
-      it "strips cursor movement sequences" do
-        ansi = "\e[2J\e[H\e[10;20Htext here"
-        result = described_class.call("bash", ansi)
-
-        expect(result).to eq("text here")
-      end
-
-      it "strips OSC sequences (e.g. terminal title)" do
-        osc = "\e]0;Window Title\aVisible text"
-        result = described_class.call("bash", osc)
-
-        expect(result).to eq("Visible text")
-      end
-
-      it "strips OSC sequences terminated by ST" do
-        osc = "\e]0;Title\e\\Content"
-        result = described_class.call("bash", osc)
-
-        expect(result).to eq("Content")
-      end
-
-      it "strips DEC private mode sequences (show/hide cursor)" do
-        ansi = "\e[?25lhidden cursor\e[?25h"
-        result = described_class.call("bash", ansi)
-
-        expect(result).to eq("hidden cursor")
-      end
-
-      it "handles gh issue view output with heavy ANSI formatting" do
-        gh_output = "\e[1;34m#42\e[0m \e[1mFix the bug\e[0m\n\e[32mOpen\e[0m · 3 comments"
-        result = described_class.call("bash", gh_output)
-
-        expect(result).to eq("#42 Fix the bug\nOpen · 3 comments")
+      it "replaces invalid bytes with U+FFFD" do
+        expect(encode_utf8).to be_valid_encoding
+        expect(encode_utf8).to include("\uFFFD")
       end
     end
 
-    context "control character stripping" do
-      it "strips NUL bytes" do
-        result = described_class.call("bash", "hello\x00world")
-        expect(result).to eq("helloworld")
-      end
+    context "with valid UTF-8 input" do
+      let(:input) { "Héllo wörld 日本語 🚀" }
 
-      it "strips BEL characters" do
-        result = described_class.call("bash", "alert\x07done")
-        expect(result).to eq("alertdone")
-      end
-
-      it "strips backspace characters" do
-        result = described_class.call("bash", "typo\x08fixed")
-        expect(result).to eq("typofixed")
-      end
-
-      it "preserves newlines" do
-        result = described_class.call("bash", "line1\nline2\n")
-        expect(result).to eq("line1\nline2\n")
-      end
-
-      it "preserves tabs" do
-        result = described_class.call("bash", "col1\tcol2\tcol3")
-        expect(result).to eq("col1\tcol2\tcol3")
-      end
-
-      it "strips DEL character" do
-        result = described_class.call("bash", "text\x7Fmore")
-        expect(result).to eq("textmore")
-      end
-
-      it "strips carriage return characters" do
-        result = described_class.call("bash", "line1\rline2")
-        expect(result).to eq("line1line2")
-      end
-
-      it "normalizes CRLF to LF" do
-        result = described_class.call("bash", "line1\r\nline2\r\n")
-        expect(result).to eq("line1\nline2\n")
+      it "preserves content unchanged" do
+        expect(encode_utf8).to eq(input)
       end
     end
 
-    context "combined sanitization" do
-      it "handles ASCII-8BIT with ANSI codes and control characters" do
-        messy = (+"\e[32mOK\e[0m\x00\x07 result: café \x80").force_encoding("ASCII-8BIT")
-        result = described_class.call("bash", messy)
+    context "with Latin-1 encoded input" do
+      let(:input) { (+"caf\xE9").force_encoding("ISO-8859-1") }
 
-        expect(result.encoding).to eq(Encoding::UTF_8)
-        expect(result).to be_valid_encoding
-        expect(result).to include("OK")
-        expect(result).to include("result:")
-        expect(result).not_to include("\e[")
-        expect(result).not_to include("\x00")
+      it "transcodes to valid UTF-8" do
+        expect(encode_utf8.encoding).to eq(Encoding::UTF_8)
+        expect(encode_utf8).to eq("café")
       end
+    end
+  end
 
-      it "sanitizes decorated tool results too" do
-        # WebGetToolDecorator returns a String; sanitization runs after
-        html_with_ansi = "<html><body>\e[31mHello\e[0m</body></html>"
-        result = described_class.call("web_get", {body: html_with_ansi, content_type: "text/html"})
+  describe ".strip_ansi" do
+    subject(:strip_ansi) { described_class.send(:strip_ansi, input) }
 
-        expect(result).not_to include("\e[")
+    context "with SGR color codes" do
+      let(:input) { "\e[31mERROR\e[0m: something failed" }
+
+      it "strips them" do
+        expect(strip_ansi).to eq("ERROR: something failed")
       end
     end
 
-    context "non-string passthrough" do
-      it "passes through hash results from WebGet decorator" do
-        # WebGetToolDecorator always returns a String, but if a tool
-        # returned a non-error hash for some reason, sanitization skips it
-        result = described_class.call("unknown_tool", {data: "value"})
-        expect(result).to eq({data: "value"})
+    context "with combined SGR attributes" do
+      let(:input) { "\e[1;4;33mWarning\e[0m" }
+
+      it "strips bold, underline, and color in one sequence" do
+        expect(strip_ansi).to eq("Warning")
       end
+    end
+
+    context "with cursor movement" do
+      let(:input) { "\e[2J\e[H\e[10;20Htext here" }
+
+      it "strips clear screen, home, and absolute positioning" do
+        expect(strip_ansi).to eq("text here")
+      end
+    end
+
+    context "with OSC sequences" do
+      it "strips BEL-terminated OSC (terminal title)" do
+        expect(described_class.send(:strip_ansi, "\e]0;Window Title\aVisible text"))
+          .to eq("Visible text")
+      end
+
+      it "strips ST-terminated OSC" do
+        expect(described_class.send(:strip_ansi, "\e]0;Title\e\\Content"))
+          .to eq("Content")
+      end
+    end
+
+    context "with DEC private mode sequences" do
+      let(:input) { "\e[?25lhidden cursor\e[?25h" }
+
+      it "strips show/hide cursor" do
+        expect(strip_ansi).to eq("hidden cursor")
+      end
+    end
+
+    context "with real-world gh output" do
+      let(:input) { "\e[1;34m#42\e[0m \e[1mFix the bug\e[0m\n\e[32mOpen\e[0m · 3 comments" }
+
+      it "produces clean readable text" do
+        expect(strip_ansi).to eq("#42 Fix the bug\nOpen · 3 comments")
+      end
+    end
+
+    context "with no escape codes" do
+      let(:input) { "plain text with no escapes" }
+
+      it "returns input unchanged" do
+        expect(strip_ansi).to eq(input)
+      end
+    end
+  end
+
+  describe ".strip_control_chars" do
+    subject(:strip_control) { described_class.send(:strip_control_chars, input) }
+
+    context "with NUL bytes" do
+      let(:input) { "hello\x00world" }
+
+      it("strips them") { expect(strip_control).to eq("helloworld") }
+    end
+
+    context "with BEL" do
+      let(:input) { "alert\x07done" }
+
+      it("strips them") { expect(strip_control).to eq("alertdone") }
+    end
+
+    context "with backspace" do
+      let(:input) { "typo\x08fixed" }
+
+      it("strips them") { expect(strip_control).to eq("typofixed") }
+    end
+
+    context "with carriage return" do
+      let(:input) { "line1\rline2" }
+
+      it("strips it") { expect(strip_control).to eq("line1line2") }
+    end
+
+    context "with CRLF" do
+      let(:input) { "line1\r\nline2\r\n" }
+
+      it "strips CR but preserves LF" do
+        expect(strip_control).to eq("line1\nline2\n")
+      end
+    end
+
+    context "with DEL" do
+      let(:input) { "text\x7Fmore" }
+
+      it("strips it") { expect(strip_control).to eq("textmore") }
+    end
+
+    context "with newlines" do
+      let(:input) { "line1\nline2\n" }
+
+      it("preserves them") { expect(strip_control).to eq(input) }
+    end
+
+    context "with tabs" do
+      let(:input) { "col1\tcol2\tcol3" }
+
+      it("preserves them") { expect(strip_control).to eq(input) }
+    end
+
+    context "with no control characters" do
+      let(:input) { "clean text" }
+
+      it("returns input unchanged") { expect(strip_control).to eq(input) }
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `sanitize_for_llm` to `ToolDecorator.call` as a universal post-decoration gate
- Force-encode all tool result strings to UTF-8, replacing invalid/undefined bytes with U+FFFD
- Strip ANSI escape codes (CSI, OSC, single-character sequences) that waste tokens
- Strip C0 control characters except `\n` and `\t` which carry meaning

This prevents `Encoding::CompatibilityError` crashes when PTY output (ASCII-8BIT from `read_nonblock`) hits UTF-8 string operations in the debug log and event emission. It also eliminates token waste from terminal formatting noise (e.g. `gh issue view` output is more escape bytes than content).

The sanitization runs after subclass decoration, so new tools and decorators get it for free with zero awareness of the constraint.

Closes #286

## Test plan

- [x] 22 new specs covering encoding, ANSI stripping, control character removal, and combined scenarios
- [x] All 165 decorator specs pass
- [x] standardrb clean
- [x] reek clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)