### PR TITLE
#146 feat: Batch command support for bash tool

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -39,6 +39,10 @@ detectors:
       - "Tools::SubagentPrompts#assign_nickname_via_brain"
       # Validation methods naturally reference the validated value more than self.
       - "AnalyticalBrain::Tools::AssignNickname#validate"
+      # Tool execute methods naturally reference input hash and shell result hash.
+      - "Tools::Bash#execute"
+      - "Tools::Bash#execute_single"
+      - "Tools::Bash#execute_batch"
       # Delivery method orchestrates session, event, and agent_loop — inherent.
       - "AgentRequestJob#deliver_persisted_event"
   # Private helpers don't need instance state to be valid.

--- a/lib/tools/bash.rb
+++ b/lib/tools/bash.rb
@@ -6,19 +6,42 @@ module Tools
   # conversation. Output is truncated and timeouts are enforced by the
   # underlying session.
   #
+  # Supports two modes:
+  # - Single command via +command+ (string) — backward compatible
+  # - Batch via +commands+ (array) with +mode+ controlling error handling
+  #
   # @see ShellSession#run
   class Bash < Base
     def self.tool_name = "bash"
 
-    def self.description = "Execute a bash command. Working directory and environment persist across calls within a conversation."
+    def self.description
+      <<~DESC.squish
+        Execute a bash command. Working directory and environment persist across calls within a conversation.
+        Accepts either `command` (string) for a single command, or `commands` (array of strings) to run
+        multiple commands as a batch — each command gets its own timeout and result. Batch `mode` controls
+        error handling: "sequential" (default) stops on the first failure, "parallel" runs all regardless.
+      DESC
+    end
 
     def self.input_schema
       {
         type: "object",
         properties: {
-          command: {type: "string", description: "The bash command to execute"}
-        },
-        required: ["command"]
+          command: {
+            type: "string",
+            description: "The bash command to execute"
+          },
+          commands: {
+            type: "array",
+            items: {type: "string"},
+            description: "Array of bash commands to execute as a batch. Each runs independently with its own timeout and result."
+          },
+          mode: {
+            type: "string",
+            enum: ["sequential", "parallel"],
+            description: 'Batch error handling: "sequential" (default) stops on first non-zero exit; "parallel" runs all commands regardless of failures.'
+          }
+        }
       }
     end
 
@@ -33,16 +56,76 @@ module Tools
     # @return [String] formatted output with stdout, stderr, and exit code
     # @return [Hash] with :error key on failure
     def execute(input)
-      command = input["command"].to_s
+      timeout = input["timeout"]
+      has_command = input.key?("command")
+      has_commands = input.key?("commands")
+
+      if has_command && has_commands
+        {error: "Provide either 'command' or 'commands', not both"}
+      elsif has_commands
+        execute_batch(input["commands"], mode: input.fetch("mode", "sequential"), timeout: timeout)
+      elsif has_command
+        execute_single(input["command"], timeout: timeout)
+      else
+        {error: "Either 'command' (string) or 'commands' (array of strings) is required"}
+      end
+    end
+
+    private
+
+    # Executes a single command — the original code path, preserved for backward compatibility.
+    def execute_single(command, timeout: nil)
+      command = command.to_s
       return {error: "Command cannot be blank"} if command.strip.empty?
 
-      result = @shell_session.run(command, timeout: input["timeout"])
+      result = @shell_session.run(command, timeout: timeout)
       return result if result.key?(:error)
 
       format_result(result[:stdout], result[:stderr], result[:exit_code])
     end
 
-    private
+    # Executes an array of commands, returning a combined result string.
+    # @param commands [Array<String>] commands to execute
+    # @param mode [String] "sequential" (stop on first failure) or "parallel" (run all)
+    # @param timeout [Integer, nil] per-command timeout override
+    # @return [String] combined results with per-command headers
+    # @return [Hash] with :error key if commands array is invalid
+    def execute_batch(commands, mode:, timeout: nil)
+      return {error: "Commands array cannot be empty"} unless commands.is_a?(Array) && commands.any?
+
+      total = commands.size
+      results = []
+      failed = false
+
+      commands.each_with_index do |command, index|
+        position = "[#{index + 1}/#{total}]"
+
+        if failed && mode == "sequential"
+          results << "#{position} $ #{command}\n(skipped)"
+          next
+        end
+
+        command = command.to_s
+        if command.strip.empty?
+          results << "#{position} $ (blank)\n(skipped — blank command)"
+          next
+        end
+
+        result = @shell_session.run(command, timeout: timeout)
+
+        if result.key?(:error)
+          results << "#{position} $ #{command}\n#{result[:error]}"
+          failed = true
+        else
+          exit_code = result[:exit_code]
+          output = format_result(result[:stdout], result[:stderr], exit_code)
+          results << "#{position} $ #{command}\n#{output}"
+          failed = true if exit_code != 0
+        end
+      end
+
+      results.join("\n\n")
+    end
 
     def format_result(stdout, stderr, exit_code)
       parts = []

--- a/spec/lib/tools/bash_spec.rb
+++ b/spec/lib/tools/bash_spec.rb
@@ -20,14 +20,38 @@ RSpec.describe Tools::Bash do
       expect(described_class.description).to be_a(String)
       expect(described_class.description).not_to be_empty
     end
+
+    it "mentions both single and batch modes" do
+      desc = described_class.description
+      expect(desc).to include("command")
+      expect(desc).to include("commands")
+    end
   end
 
   describe ".input_schema" do
-    it "defines command as a required string property" do
+    it "defines command as a string property" do
       schema = described_class.input_schema
       expect(schema[:type]).to eq("object")
       expect(schema[:properties][:command][:type]).to eq("string")
-      expect(schema[:required]).to include("command")
+    end
+
+    it "defines commands as an array of strings property" do
+      schema = described_class.input_schema
+      commands_schema = schema[:properties][:commands]
+      expect(commands_schema[:type]).to eq("array")
+      expect(commands_schema[:items][:type]).to eq("string")
+    end
+
+    it "defines mode as an enum property" do
+      schema = described_class.input_schema
+      mode_schema = schema[:properties][:mode]
+      expect(mode_schema[:type]).to eq("string")
+      expect(mode_schema[:enum]).to contain_exactly("sequential", "parallel")
+    end
+
+    it "does not require any specific property" do
+      schema = described_class.input_schema
+      expect(schema[:required]).to be_nil
     end
   end
 
@@ -40,62 +64,176 @@ RSpec.describe Tools::Bash do
   end
 
   describe "#execute" do
-    it "returns stdout and exit code" do
-      result = tool.execute("command" => "echo hello")
-      expect(result).to include("stdout:\nhello")
-      expect(result).to include("exit_code: 0")
+    context "with single command" do
+      it "returns stdout and exit code" do
+        result = tool.execute("command" => "echo hello")
+        expect(result).to include("stdout:\nhello")
+        expect(result).to include("exit_code: 0")
+      end
+
+      it "captures stderr" do
+        result = tool.execute("command" => "echo oops >&2")
+        expect(result).to include("stderr:")
+        expect(result).to include("oops")
+      end
+
+      it "captures both stdout and stderr" do
+        result = tool.execute("command" => "echo out && echo err >&2")
+        expect(result).to include("stdout:\nout")
+        expect(result).to include("err")
+      end
+
+      it "returns non-zero exit code" do
+        result = tool.execute("command" => "(exit 42)")
+        expect(result).to include("exit_code: 42")
+      end
+
+      it "returns only exit code for silent commands" do
+        result = tool.execute("command" => "true")
+        expect(result).to eq("exit_code: 0")
+      end
+
+      it "preserves working directory between calls" do
+        tool.execute("command" => "cd /tmp")
+        result = tool.execute("command" => "pwd")
+        expect(result).to include("stdout:\n/tmp")
+      end
+
+      it "preserves environment variables between calls" do
+        tool.execute("command" => "export MY_PERSIST_VAR=kept")
+        result = tool.execute("command" => "echo $MY_PERSIST_VAR")
+        expect(result).to include("stdout:\nkept")
+      end
+
+      it "passes timeout parameter to shell session" do
+        expect(shell_session).to receive(:run).with("echo hi", timeout: 300).and_return(stdout: "hi\n", stderr: "", exit_code: 0)
+        tool.execute("command" => "echo hi", "timeout" => 300)
+      end
+
+      it "returns error for blank commands" do
+        result = tool.execute("command" => "  ")
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("blank")
+      end
+
+      it "delegates errors from shell session" do
+        shell_session.finalize
+        result = tool.execute("command" => "echo hello")
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("not running")
+      end
     end
 
-    it "captures stderr" do
-      result = tool.execute("command" => "echo oops >&2")
-      expect(result).to include("stderr:")
-      expect(result).to include("oops")
+    context "with batch commands in sequential mode" do
+      it "runs all commands and returns combined results" do
+        result = tool.execute("commands" => ["echo first", "echo second", "echo third"])
+        expect(result).to include("[1/3] $ echo first")
+        expect(result).to include("[2/3] $ echo second")
+        expect(result).to include("[3/3] $ echo third")
+        expect(result).to include("stdout:\nfirst")
+        expect(result).to include("stdout:\nsecond")
+        expect(result).to include("stdout:\nthird")
+      end
+
+      it "defaults to sequential mode" do
+        result = tool.execute("commands" => ["(exit 1)", "echo should-not-run"])
+        expect(result).to include("[1/2] $ (exit 1)")
+        expect(result).to include("exit_code: 1")
+        expect(result).to include("[2/2] $ echo should-not-run\n(skipped)")
+        expect(result).not_to include("should-not-run\nexit_code")
+      end
+
+      it "stops on first non-zero exit code" do
+        result = tool.execute("commands" => ["echo ok", "(exit 2)", "echo never"], "mode" => "sequential")
+        expect(result).to include("[1/3] $ echo ok")
+        expect(result).to include("stdout:\nok")
+        expect(result).to include("[2/3] $ (exit 2)")
+        expect(result).to include("exit_code: 2")
+        expect(result).to include("[3/3] $ echo never\n(skipped)")
+      end
+
+      it "stops on shell session errors" do
+        allow(shell_session).to receive(:run).and_return(
+          {stdout: "ok\n", stderr: "", exit_code: 0},
+          {error: "Command timed out after 30s"},
+          {stdout: "unreachable\n", stderr: "", exit_code: 0}
+        )
+        result = tool.execute("commands" => ["echo ok", "sleep 999", "echo unreachable"])
+        expect(result).to include("[1/3] $ echo ok")
+        expect(result).to include("[2/3] $ sleep 999")
+        expect(result).to include("Command timed out")
+        expect(result).to include("[3/3] $ echo unreachable\n(skipped)")
+      end
+
+      it "preserves working directory across batch commands" do
+        result = tool.execute("commands" => ["cd /tmp", "pwd"])
+        expect(result).to include("stdout:\n/tmp")
+      end
     end
 
-    it "captures both stdout and stderr" do
-      result = tool.execute("command" => "echo out && echo err >&2")
-      expect(result).to include("stdout:\nout")
-      expect(result).to include("err")
+    context "with batch commands in parallel mode" do
+      it "runs all commands regardless of failures" do
+        result = tool.execute("commands" => ["echo first", "(exit 1)", "echo third"], "mode" => "parallel")
+        expect(result).to include("[1/3] $ echo first")
+        expect(result).to include("stdout:\nfirst")
+        expect(result).to include("[2/3] $ (exit 1)")
+        expect(result).to include("exit_code: 1")
+        expect(result).to include("[3/3] $ echo third")
+        expect(result).to include("stdout:\nthird")
+      end
+
+      it "continues past shell session errors" do
+        allow(shell_session).to receive(:run).and_return(
+          {error: "Command timed out after 30s"},
+          {stdout: "still running\n", stderr: "", exit_code: 0}
+        )
+        result = tool.execute("commands" => ["sleep 999", "echo still running"], "mode" => "parallel")
+        expect(result).to include("[1/2] $ sleep 999")
+        expect(result).to include("Command timed out")
+        expect(result).to include("[2/2] $ echo still running")
+        expect(result).to include("stdout:\nstill running")
+      end
     end
 
-    it "returns non-zero exit code" do
-      result = tool.execute("command" => "(exit 42)")
-      expect(result).to include("exit_code: 42")
+    context "with batch edge cases" do
+      it "returns error for empty commands array" do
+        result = tool.execute("commands" => [])
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("empty")
+      end
+
+      it "returns error for non-array commands" do
+        result = tool.execute("commands" => "not an array")
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("empty")
+      end
+
+      it "skips blank commands in batch" do
+        result = tool.execute("commands" => ["echo ok", "  ", "echo done"])
+        expect(result).to include("[1/3] $ echo ok")
+        expect(result).to include("[2/3] $ (blank)\n(skipped — blank command)")
+        expect(result).to include("[3/3] $ echo done")
+      end
+
+      it "passes timeout to each command in batch" do
+        expect(shell_session).to receive(:run).with("echo a", timeout: 60).and_return(stdout: "a\n", stderr: "", exit_code: 0)
+        expect(shell_session).to receive(:run).with("echo b", timeout: 60).and_return(stdout: "b\n", stderr: "", exit_code: 0)
+        tool.execute("commands" => ["echo a", "echo b"], "timeout" => 60)
+      end
     end
 
-    it "returns only exit code for silent commands" do
-      result = tool.execute("command" => "true")
-      expect(result).to eq("exit_code: 0")
-    end
+    context "with input validation" do
+      it "returns error when both command and commands are provided" do
+        result = tool.execute("command" => "echo hi", "commands" => ["echo hi"])
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("not both")
+      end
 
-    it "preserves working directory between calls" do
-      tool.execute("command" => "cd /tmp")
-      result = tool.execute("command" => "pwd")
-      expect(result).to include("stdout:\n/tmp")
-    end
-
-    it "preserves environment variables between calls" do
-      tool.execute("command" => "export MY_PERSIST_VAR=kept")
-      result = tool.execute("command" => "echo $MY_PERSIST_VAR")
-      expect(result).to include("stdout:\nkept")
-    end
-
-    it "passes timeout parameter to shell session" do
-      expect(shell_session).to receive(:run).with("echo hi", timeout: 300).and_return(stdout: "hi\n", stderr: "", exit_code: 0)
-      tool.execute("command" => "echo hi", "timeout" => 300)
-    end
-
-    it "returns error for blank commands" do
-      result = tool.execute("command" => "  ")
-      expect(result).to be_a(Hash)
-      expect(result[:error]).to include("blank")
-    end
-
-    it "delegates errors from shell session" do
-      shell_session.finalize
-      result = tool.execute("command" => "echo hello")
-      expect(result).to be_a(Hash)
-      expect(result[:error]).to include("not running")
+      it "returns error when neither command nor commands is provided" do
+        result = tool.execute({})
+        expect(result).to be_a(Hash)
+        expect(result[:error]).to include("required")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Implements Phase 2 of #146 — batch command support for the bash tool.

### Changes

The bash tool now accepts either:
- `command` (string) — single command, backward compatible
- `commands` (array of strings) — batch execution with per-command isolation

Batch mode supports two error handling strategies via the `mode` parameter:
- **sequential** (default) — stops on first non-zero exit code, skips remaining commands
- **parallel** — runs all commands regardless of individual failures

### Why

The agent naturally chains commands with `&&` and `;`. When one command in a chain times out, the entire chain fails — and in the worst case, leaves an orphaned tool_use that corrupts the session. With batch support, each command is isolated: individual timeouts don't kill siblings, and the agent gets granular per-command results.

### Output format

```
[1/3] $ echo hello
stdout:
hello

exit_code: 0

[2/3] $ ls /nonexistent
stderr:
ls: cannot access '/nonexistent': No such file or directory

exit_code: 2

[3/3] $ echo done
(skipped)
```

### Test plan

31 specs covering:
- All existing single-command behavior preserved (backward compat)
- Sequential mode: stop on error, skip remaining
- Parallel mode: run all regardless of failures
- Edge cases: empty arrays, blank commands, non-array input
- Timeout forwarding per command
- Shell session error propagation

### Files changed

- `lib/tools/bash.rb` — schema + batch execution logic
- `spec/lib/tools/bash_spec.rb` — expanded from 12 to 31 examples
- `.reek.yml` — exclusions for tool pattern (FeatureEnvy on input/result refs)

Closes #146

🧬 Built by [Anima Agent](https://github.com/hoblin/anima) (v1.1.0)