### PR TITLE
#292 fix: Exclude spawn events from sub-agent parent context

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -81,9 +81,11 @@ detectors:
       # Runner checks session type to compose responsibilities — the core dispatch.
       - "AnalyticalBrain::Runner"
   # EventDecorator holds shared rendering constants (icons, markers, dispatch maps).
+  # Event model holds domain type constants (TYPES, CONTEXT_TYPES, SPAWN_TOOLS, etc.).
   TooManyConstants:
     exclude:
       - "EventDecorator"
+      - "Event"
   # encode_utf8 is descriptive — the digit triggers a false positive.
   UncommunicativeMethodName:
     exclude:

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,6 +23,7 @@ class Event < ApplicationRecord
   CONTEXT_TYPES = %w[system_message user_message agent_message tool_call tool_response].freeze
   CONVERSATION_TYPES = %w[user_message agent_message system_message].freeze
   THINK_TOOL = "think"
+  SPAWN_TOOLS = %w[spawn_subagent spawn_specialist].freeze
   PENDING_STATUS = "pending"
 
   ROLE_MAP = {"user_message" => "user", "agent_message" => "assistant"}.freeze
@@ -59,6 +60,17 @@ class Event < ApplicationRecord
   #   NULL status means delivered/processed — the only excluded value is "pending".
   #   @return [ActiveRecord::Relation]
   scope :deliverable, -> { where(status: nil) }
+
+  # @!method self.excluding_spawn_events
+  #   Excludes spawn_subagent/spawn_specialist tool_call and tool_response events.
+  #   Used when building parent context for sub-agents — spawn events cause role
+  #   confusion because the sub-agent sees sibling spawn results and mistakes
+  #   itself for the parent.
+  #   @return [ActiveRecord::Relation]
+  scope :excluding_spawn_events, -> {
+    where.not("event_type IN (?) AND json_extract(payload, '$.tool_name') IN (?)",
+      %w[tool_call tool_response], SPAWN_TOOLS)
+  }
 
   # Maps event_type to the Anthropic Messages API role.
   # @return [String] "user" or "assistant"

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -501,9 +501,14 @@ class Session < ApplicationRecord
   end
 
   # Scopes parent events created before this session's fork point.
+  # Excludes spawn tool events — sub-agents don't need to see sibling
+  # spawn pairs, which cause role confusion (the sub-agent mistakes
+  # itself for the parent when it sees "Specialist @sibling spawned...").
   # @return [ActiveRecord::Relation]
   def parent_event_scope(include_pending)
-    scope = parent_session.events.context_events.where(created_at: ...created_at)
+    scope = parent_session.events.context_events
+      .excluding_spawn_events
+      .where(created_at: ...created_at)
     include_pending ? scope : scope.deliverable
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -210,6 +210,47 @@ RSpec.describe Event do
     end
   end
 
+  describe ".excluding_spawn_events" do
+    it "excludes spawn_subagent tool_call events" do
+      session.events.create!(event_type: "tool_call", payload: {"tool_name" => "spawn_subagent", "content" => "spawning"}, timestamp: 1)
+      kept = session.events.create!(event_type: "tool_call", payload: {"tool_name" => "bash", "content" => "running"}, timestamp: 2)
+
+      expect(session.events.excluding_spawn_events).to eq([kept])
+    end
+
+    it "excludes spawn_specialist tool_call events" do
+      session.events.create!(event_type: "tool_call", payload: {"tool_name" => "spawn_specialist", "content" => "spawning"}, timestamp: 1)
+      kept = session.events.create!(event_type: "user_message", payload: {"content" => "hello"}, timestamp: 2)
+
+      expect(session.events.excluding_spawn_events).to eq([kept])
+    end
+
+    it "excludes spawn tool_response events" do
+      session.events.create!(event_type: "tool_response", payload: {"tool_name" => "spawn_subagent", "content" => "spawned"}, timestamp: 1)
+      session.events.create!(event_type: "tool_response", payload: {"tool_name" => "spawn_specialist", "content" => "spawned"}, timestamp: 2)
+      kept = session.events.create!(event_type: "tool_response", payload: {"tool_name" => "bash", "content" => "output"}, timestamp: 3)
+
+      expect(session.events.excluding_spawn_events).to eq([kept])
+    end
+
+    it "preserves non-tool events" do
+      user_msg = session.events.create!(event_type: "user_message", payload: {"content" => "hello"}, timestamp: 1)
+      agent_msg = session.events.create!(event_type: "agent_message", payload: {"content" => "hi"}, timestamp: 2)
+      sys_msg = session.events.create!(event_type: "system_message", payload: {"content" => "boot"}, timestamp: 3)
+      session.events.create!(event_type: "tool_call", payload: {"tool_name" => "spawn_specialist", "content" => "spawning"}, timestamp: 4)
+
+      expect(session.events.excluding_spawn_events).to eq([user_msg, agent_msg, sys_msg])
+    end
+
+    it "preserves non-spawn tool events" do
+      bash_call = session.events.create!(event_type: "tool_call", payload: {"tool_name" => "bash", "content" => "running"}, timestamp: 1)
+      bash_response = session.events.create!(event_type: "tool_response", payload: {"tool_name" => "bash", "content" => "output"}, timestamp: 2)
+      read_call = session.events.create!(event_type: "tool_call", payload: {"tool_name" => "read", "content" => "reading"}, timestamp: 3)
+
+      expect(session.events.excluding_spawn_events).to eq([bash_call, bash_response, read_call])
+    end
+  end
+
   describe "#conversation_or_think?" do
     it "returns true for user_message" do
       expect(Event.new(event_type: "user_message", payload: {})).to be_conversation_or_think

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1550,6 +1550,78 @@ RSpec.describe Session do
       expect(contents).not_to include("parent continues")
     end
 
+    it "excludes spawn tool events from parent context" do
+      # Sibling spawn events should not appear in sub-agent's viewport
+      parent.events.create!(
+        event_type: "tool_call",
+        payload: {"content" => "Calling spawn_specialist", "tool_name" => "spawn_specialist",
+                  "tool_input" => {"name" => "codebase-analyzer"}, "tool_use_id" => "toolu_sibling"},
+        timestamp: 3, token_count: 10
+      )
+      parent.events.create!(
+        event_type: "tool_response",
+        payload: {"content" => "Specialist @sibling spawned", "tool_name" => "spawn_specialist",
+                  "tool_use_id" => "toolu_sibling"},
+        timestamp: 4, token_count: 10
+      )
+
+      child.events.create!(event_type: "user_message", payload: {"content" => "my task"}, timestamp: 5, token_count: 10)
+
+      events = child.viewport_events
+      tool_names = events.select { |e| e.event_type.in?(%w[tool_call tool_response]) }
+        .map { |e| e.payload["tool_name"] }
+
+      expect(tool_names).not_to include("spawn_specialist")
+      expect(events.map { |e| e.payload["content"] }).to include("parent msg 1", "parent reply 1", "my task")
+    end
+
+    it "excludes own spawn events from parent context" do
+      # The sub-agent's own spawn pair is also noise — the task is already its first user_message
+      parent.events.create!(
+        event_type: "tool_call",
+        payload: {"content" => "Calling spawn_subagent", "tool_name" => "spawn_subagent",
+                  "tool_input" => {"task" => "research"}, "tool_use_id" => "toolu_self"},
+        timestamp: 3, token_count: 10
+      )
+      parent.events.create!(
+        event_type: "tool_response",
+        payload: {"content" => "Sub-agent spawned", "tool_name" => "spawn_subagent",
+                  "tool_use_id" => "toolu_self"},
+        timestamp: 4, token_count: 10
+      )
+
+      child.events.create!(event_type: "user_message", payload: {"content" => "my task"}, timestamp: 5, token_count: 10)
+
+      events = child.viewport_events
+      tool_names = events.select { |e| e.event_type.in?(%w[tool_call tool_response]) }
+        .map { |e| e.payload["tool_name"] }
+
+      expect(tool_names).not_to include("spawn_subagent")
+    end
+
+    it "preserves non-spawn tool events in parent context" do
+      parent.events.create!(
+        event_type: "tool_call",
+        payload: {"content" => "Calling bash", "tool_name" => "bash",
+                  "tool_input" => {"command" => "ls"}, "tool_use_id" => "toolu_bash"},
+        timestamp: 3, token_count: 10
+      )
+      parent.events.create!(
+        event_type: "tool_response",
+        payload: {"content" => "file1.rb", "tool_name" => "bash",
+                  "tool_use_id" => "toolu_bash"},
+        timestamp: 4, token_count: 10
+      )
+
+      child.events.create!(event_type: "user_message", payload: {"content" => "my task"}, timestamp: 5, token_count: 10)
+
+      events = child.viewport_events
+      tool_names = events.select { |e| e.event_type.in?(%w[tool_call tool_response]) }
+        .map { |e| e.payload["tool_name"] }
+
+      expect(tool_names).to eq(%w[bash bash])
+    end
+
     it "trims trailing tool_call events from parent viewport" do
       parent.events.create!(
         event_type: "tool_call",


### PR DESCRIPTION
## Summary

Fixes #292 — sub-agents seeing sibling spawn events in inherited parent context, causing role confusion.

### Problem

When a parent session spawns multiple sub-agents in the same turn, each sub-agent inherits the full parent context — including `spawn_specialist`/`spawn_subagent` tool_call/tool_response pairs for its siblings. The second sub-agent sees "Specialist @sibling spawned, its messages will appear..." and mistakes itself for the parent, echoing the parent's behavior instead of starting its own work.

### Solution

Filter spawn events at the query level in `parent_event_scope`:

1. **`Event.SPAWN_TOOLS`** — constant defining spawn tool names
2. **`Event.excluding_spawn_events`** — scope using `json_extract` to exclude spawn tool events from any relation
3. **`Session#parent_event_scope`** — applies the scope so spawn events never enter the sub-agent's viewport

Filtering at the query level (not Ruby) ensures spawn events don't consume token budget that could hold useful parent context.

### Test plan

8 new specs:
- `Event.excluding_spawn_events` — filters spawn_subagent/spawn_specialist tool_call and tool_response, preserves all other events
- `Session` viewport inheritance — spawn events excluded from parent context, non-spawn tool events preserved

### Files changed

- `app/models/event.rb` — SPAWN_TOOLS constant + excluding_spawn_events scope
- `app/models/session.rb` — apply scope in parent_event_scope
- `spec/models/event_spec.rb` — 5 new examples
- `spec/models/session_spec.rb` — 3 new examples
- `.reek.yml` — TooManyConstants exclusion for Event (9 domain constants)

Closes #292

🧬 Built by [Anima Agent](https://github.com/hoblin/anima) (v1.1.0)