### PR TITLE
#290 fix: Always grant think tool to sub-agents

### DIFF
--- a/lib/agent_loop.rb
+++ b/lib/agent_loop.rb
@@ -129,6 +129,11 @@ class AgentLoop
   # @return [Array<Class<Tools::Base>>]
   STANDARD_TOOLS = [Tools::Bash, Tools::Read, Tools::Write, Tools::Edit, Tools::WebGet, Tools::Think, Tools::Remember].freeze
 
+  # Tools that bypass {Session#granted_tools} filtering.
+  # The agent's reasoning depends on these regardless of task scope.
+  # @return [Array<Class<Tools::Base>>]
+  ALWAYS_GRANTED_TOOLS = [Tools::Think].freeze
+
   # Name-to-class mapping for tool restriction validation and registry building.
   # @return [Hash{String => Class<Tools::Base>}]
   STANDARD_TOOLS_BY_NAME = STANDARD_TOOLS.index_by(&:tool_name).freeze
@@ -194,12 +199,15 @@ class AgentLoop
 
   # Standard tools available to this session.
   # Returns all when {Session#granted_tools} is nil (no restriction).
-  # Returns only matching tools when granted_tools is an array.
+  # Returns only matching tools when granted_tools is an array,
+  # always including {ALWAYS_GRANTED_TOOLS}.
   #
   # @return [Array<Class<Tools::Base>>] tool classes to register
   def granted_standard_tools
-    return STANDARD_TOOLS unless @session.granted_tools
+    granted = @session.granted_tools
+    return STANDARD_TOOLS unless granted
 
-    @session.granted_tools.filter_map { |name| STANDARD_TOOLS_BY_NAME[name] }
+    explicitly_granted = granted.filter_map { |name| STANDARD_TOOLS_BY_NAME[name] }
+    (ALWAYS_GRANTED_TOOLS + explicitly_granted).uniq
   end
 end

--- a/spec/lib/agent_loop_spec.rb
+++ b/spec/lib/agent_loop_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe AgentLoop do
     end
 
     context "with tool restriction" do
-      it "registers only granted tools for restricted sub-agents" do
+      it "registers only granted tools plus always-granted tools for restricted sub-agents" do
         parent = Session.create!
         child = Session.create!(parent_session: parent, prompt: "reader agent", granted_tools: ["read", "web_get"])
         child.events.create!(event_type: "user_message", payload: {"content" => "task"}, timestamp: 1)
@@ -317,6 +317,7 @@ RSpec.describe AgentLoop do
         allow(client).to receive(:chat_with_tools) do |_msgs, registry:, **_|
           expect(registry.registered?("read")).to be true
           expect(registry.registered?("web_get")).to be true
+          expect(registry.registered?("think")).to be true
           expect(registry.registered?("bash")).to be false
           expect(registry.registered?("write")).to be false
           expect(registry.registered?("edit")).to be false
@@ -327,15 +328,20 @@ RSpec.describe AgentLoop do
         sub_loop.finalize
       end
 
-      it "registers no standard tools for empty tools array (pure reasoning)" do
+      it "registers only always-granted tools for empty tools array (pure reasoning)" do
         parent = Session.create!
         child = Session.create!(parent_session: parent, prompt: "thinker agent", granted_tools: [])
         child.events.create!(event_type: "user_message", payload: {"content" => "think"}, timestamp: 1)
 
         sub_loop = described_class.new(session: child, shell_session: shell_session, client: client)
         allow(client).to receive(:chat_with_tools) do |_msgs, registry:, **_|
+          always_granted = AgentLoop::ALWAYS_GRANTED_TOOLS.map(&:tool_name)
           AgentLoop::STANDARD_TOOLS_BY_NAME.each_key do |name|
-            expect(registry.registered?(name)).to be false
+            if always_granted.include?(name)
+              expect(registry.registered?(name)).to be(true), "expected #{name} to be registered (always granted)"
+            else
+              expect(registry.registered?(name)).to be(false), "expected #{name} not to be registered"
+            end
           end
           "done"
         end


### PR DESCRIPTION
## Summary

- Sub-agent sessions with a `granted_tools` list excluded `think` unless the parent explicitly included it, causing `Tools::UnknownToolError` when the model attempted to reason
- Introduces `ALWAYS_GRANTED_TOOLS` constant — tools that bypass `granted_tools` filtering because the agent's reasoning depends on them regardless of task scope
- `Tools::Think` is always registered, even for pure-reasoning sub-agents with `granted_tools: []`

Closes #290

## Test plan

- [x] Restricted sub-agents (`granted_tools: ["read", "web_get"]`) now also have `think` registered
- [x] Pure reasoning sub-agents (`granted_tools: []`) have only `think` registered
- [x] Unrestricted sub-agents (`granted_tools: nil`) still get all standard tools
- [x] All 37 agent_loop specs pass
- [x] standardrb clean, no new reek warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)