### PR TITLE
#350 feat: Reframe skill activation from reactive to predictive

### DIFF
--- a/skills/activerecord/SKILL.md
+++ b/skills/activerecord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: activerecord
-description: "Associations, validations, queries, migrations, eager loading. Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load, callbacks, or editing app/models/ or db/migrate/."
+description: "Associations, validations, queries, migrations, eager loading, N+1 queries, scopes, callbacks, app/models/, db/migrate/."
 ---
 
 # ActiveRecord

--- a/skills/dragonruby/SKILL.md
+++ b/skills/dragonruby/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dragonruby
-description: "2D game development — game loops, sprites, input, collisions, scenes. Activate when building games with DRGTK, working with args.outputs/state/inputs, or editing game files."
+description: "2D game development — game loops, sprites, input, collisions, scenes, DRGTK, args.outputs/state/inputs."
 ---
 
 # DragonRuby Game Toolkit

--- a/skills/draper-decorators/SKILL.md
+++ b/skills/draper-decorators/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: draper-decorators
-description: "Decorator patterns for Rails views — presentation logic separated from models. Activate when creating or testing decorators, moving formatting logic out of models/views, editing *_decorator.rb files, or working in app/decorators/."
+description: "Decorator patterns for Rails views — presentation logic separated from models, *_decorator.rb, app/decorators/."
 ---
 
 # Draper Decorators for Rails

--- a/skills/gh-issue.md
+++ b/skills/gh-issue.md
@@ -1,6 +1,6 @@
 ---
 name: gh-issue
-description: "Issue writing with WHAT/WHY/HOW framework. Activate when creating issues, writing tickets, drafting issue descriptions, or when issues lack clear rationale."
+description: "Issue writing with WHAT/WHY/HOW framework — tickets, bug reports, feature requests, issue descriptions, unclear rationale in existing issues."
 ---
 
 # GitHub Issue Writing

--- a/skills/mcp-server/SKILL.md
+++ b/skills/mcp-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-server
-description: "Ruby server development — tools, prompts, resources, transport. Activate when building Model Context Protocol servers, defining MCP tools/prompts/resources, working with the mcp gem, or discussing LLM tool integrations."
+description: "Ruby MCP server development — tools, prompts, resources, transport, the mcp gem, LLM tool integrations."
 ---
 
 # MCP Ruby SDK - Server Development Guide

--- a/skills/ratatui-ruby/SKILL.md
+++ b/skills/ratatui-ruby/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ratatui-ruby
-description: "Terminal UI development — widgets, layouts, events, Tea MVU. Activate when building TUI apps, working with terminal rendering, or editing TUI application files."
+description: "Terminal UI development — widgets, layouts, events, Tea MVU, terminal rendering."
 ---
 
 # RatatuiRuby

--- a/skills/rspec/SKILL.md
+++ b/skills/rspec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rspec
-description: "Testing with FactoryBot — matchers, test doubles, shared examples. Activate when writing specs, fixing failing tests, working with describe/it/expect blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration tests."
+description: "Testing with FactoryBot — matchers, test doubles, shared examples, describe/it/expect blocks, *_spec.rb files, test strategy."
 ---
 
 # RSpec Testing

--- a/spec/cassettes/AnalyticalBrain_Runner/_call/integration_with_real_LLM/does_not_change_an_already-named_session_when_topic_hasn_t_shifted.yml
+++ b/spec/cassettes/AnalyticalBrain_Runner/_call/integration_with_real_LLM/does_not_change_an_already-named_session_when_topic_hasn_t_shifted.yml
@@ -56,25 +56,17 @@ http_interactions:
         STATE\\n──────────────────────────────\\nSession name: \U0001F527 Existing
         Name\\nActive skills: None\\nActive workflow: None\\n\\n──────────────────────────────\\nAVAILABLE
         SKILLS\\n──────────────────────────────\\n- activerecord — Associations, validations,
-        queries, migrations, eager loading. Activate when working with models, database
-        schema, N+1 queries, scopes, includes/preload/eager_load, callbacks, or editing
-        app/models/ or db/migrate/.\\n- dragonruby — 2D game development — game loops,
-        sprites, input, collisions, scenes. Activate when building games with DRGTK,
-        working with args.outputs/state/inputs, or editing game files.\\n- draper-decorators
-        — Decorator patterns for Rails views — presentation logic separated from models.
-        Activate when creating or testing decorators, moving formatting logic out
-        of models/views, editing *_decorator.rb files, or working in app/decorators/.\\n-
-        gh-issue — Issue writing with WHAT/WHY/HOW framework. Activate when creating
-        issues, writing tickets, drafting issue descriptions, or when issues lack
-        clear rationale.\\n- mcp-server — Ruby server development — tools, prompts,
-        resources, transport. Activate when building Model Context Protocol servers,
-        defining MCP tools/prompts/resources, working with the mcp gem, or discussing
-        LLM tool integrations.\\n- ratatui-ruby — Terminal UI development — widgets,
-        layouts, events, Tea MVU. Activate when building TUI apps, working with terminal
-        rendering, or editing TUI application files.\\n- rspec — Testing with FactoryBot
-        — matchers, test doubles, shared examples. Activate when writing specs, fixing
-        failing tests, working with describe/it/expect blocks, editing *_spec.rb files,
-        planning test strategy, or discussing unit/integration tests.\\n\\n──────────────────────────────\\nAVAILABLE
+        queries, migrations, eager loading, N+1 queries, scopes, callbacks, app/models/,
+        db/migrate/.\\n- dragonruby — 2D game development — game loops, sprites, input,
+        collisions, scenes, DRGTK, args.outputs/state/inputs.\\n- draper-decorators
+        — Decorator patterns for Rails views — presentation logic separated from models,
+        *_decorator.rb, app/decorators/.\\n- gh-issue — Issue writing with WHAT/WHY/HOW
+        framework — tickets, bug reports, feature requests, issue descriptions, unclear
+        rationale in existing issues.\\n- mcp-server — Ruby MCP server development
+        — tools, prompts, resources, transport, the mcp gem, LLM tool integrations.\\n-
+        ratatui-ruby — Terminal UI development — widgets, layouts, events, Tea MVU,
+        terminal rendering.\\n- rspec — Testing with FactoryBot — matchers, test doubles,
+        shared examples, describe/it/expect blocks, *_spec.rb files, test strategy.\\n\\n──────────────────────────────\\nAVAILABLE
         WORKFLOWS\\n──────────────────────────────\\n- commit — Create focused git
         commits with user approval.\\n- create_handoff — Preserve current session's
         context, decisions, and next steps so another session can continue the work.\\n-
@@ -116,7 +108,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:46 GMT
+      - Sun, 29 Mar 2026 08:58:12 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -130,13 +122,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -158,57 +150,255 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '3340'
+      - '3552'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=3342
-      Cf-Cache-Status:
-      - DYNAMIC
+      - x-originResponse;dur=3557
       Set-Cookie:
       - "<CLOUDFLARE_COOKIE>"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
       X-Robots-Tag:
       - none
+      Cf-Cache-Status:
+      - DYNAMIC
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Cf-Ray:
       - "<CF_RAY>"
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMVc5NHh2d1AyYThKRGZEYnFUanJiQkwiLCJ0eXBlIjoibWVzc2FnZSIs
+        Z18wMVlZMUhGcG1xajhIWnZ0WjRWNHJyZ20iLCJ0eXBlIjoibWVzc2FnZSIs
         InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIs
-        InRleHQiOiJJIGRvbid0IGhhdmUgZW5vdWdoIGNvbnRleHQgdG8gZGV0ZXJt
-        aW5lIHdoYXQgd29yayBuZWVkcyB0byBiZSByZXN1bWVkIG9yIHdoYXQgYWN0
-        aW9ucyBhcmUgcmVxdWlyZWQuIFRoZSBtZXNzYWdlIFwiQ29udGludWUgd2l0
-        aCB0aGUgZml4XCIgaXMgdmFndWUgYW5kIGNvdWxkIHJlZmVyIHRvOlxuXG4t
-        IEEgcHJldmlvdXMgc2Vzc2lvbidzIHdvcmsgKHdoaWNoIHdvdWxkIHJlcXVp
-        cmUgcmVhZGluZyBhIGhhbmRvZmYpXG4tIEFuIGV4aXN0aW5nIGFjdGl2ZSBn
-        b2FsIG9yIHdvcmtmbG93XG4tIEEgY29kZSBmaXggdGhhdCdzIGFscmVhZHkg
-        aW4gcHJvZ3Jlc3NcblxuRnJvbSB0aGUgY3VycmVudCBzdGF0ZSwgSSBjYW4g
-        c2VlOlxuLSAqKlNlc3Npb24gbmFtZSoqOiDwn5SnIEV4aXN0aW5nIE5hbWUg
-        KGdlbmVyaWMsIG5vdCB0YXNrLXNwZWNpZmljKVxuLSAqKkFjdGl2ZSBza2ls
-        bHMqKjogTm9uZVxuLSAqKkFjdGl2ZSB3b3JrZmxvdyoqOiBOb25lXG5cblRv
-        IHByb2NlZWQgYXBwcm9wcmlhdGVseSwgSSBuZWVkIHRvIGtub3c6XG5cbjEu
-        ICoqV2hhdCBzcGVjaWZpYyBmaXggaXMgYmVpbmcgd29ya2VkIG9uPyoqIChl
-        LmcuLCBhIGJ1ZywgZmVhdHVyZSwgdGVzdCBmYWlsdXJlKVxuMi4gKipJcyB0
-        aGVyZSBhIGhhbmRvZmYgZnJvbSBhIHByZXZpb3VzIHNlc3Npb24qKiBJIHNo
-        b3VsZCByZXN1bWU/XG4zLiAqKldoYXQncyB0aGUgY3VycmVudCBzdGF0dXMq
-        KiDigJQgd2hhdCdzIGJlZW4gZG9uZSBhbmQgd2hhdCdzIG5leHQ/XG5cblBs
-        ZWFzZSBwcm92aWRlIGVpdGhlcjpcbi0gVGhlIHRpY2tldC9pc3N1ZSBkZXRh
-        aWxzIGFuZCBjdXJyZW50IHByb2dyZXNzLCBvclxuLSBDb25maXJtYXRpb24g
-        dGhhdCBJIHNob3VsZCByZWFkIGEgaGFuZG9mZiB3b3JrZmxvdywgb3Jcbi0g
-        Q29udGV4dCBhYm91dCB3aGF0IFwidGhlIGZpeFwiIHJlZmVycyB0b1xuXG5P
-        bmNlIEkgaGF2ZSB0aGF0LCBJIGNhbiBhY3RpdmF0ZSB0aGUgcmlnaHQgc2tp
-        bGxzL3dvcmtmbG93LCBzZXQgdXAgZ29hbHMsIGFuZCBnZXQgdGhlIHNlc3Np
-        b24gcHJvcGVybHkgb3JnYW5pemVkLiJ9XSwic3RvcF9yZWFzb24iOiJlbmRf
-        dHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7ImlucHV0X3Rv
-        a2VucyI6MjU2NiwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5zIjowLCJj
-        YWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRpb24iOnsi
-        ZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFsXzFoX2lu
-        cHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjI2Miwic2VydmljZV90
-        aWVyIjoic3RhbmRhcmQiLCJpbmZlcmVuY2VfZ2VvIjoibm90X2F2YWlsYWJs
-        ZSJ9fQ==
-  recorded_at: Sun, 29 Mar 2026 08:47:46 GMT
+        InRleHQiOiJJJ2xsIGNoZWNrIHRoZSBjdXJyZW50IHN0YXRlIGFuZCB0YWtl
+        IGFueSBuZWVkZWQgYWN0aW9ucy5cblxuTG9va2luZyBhdCB0aGUgY29udGV4
+        dDpcbi0gKipTZXNzaW9uIG5hbWUqKjogXCLwn5SnIEV4aXN0aW5nIE5hbWVc
+        IiAtIGdlbmVyaWMsIG5lZWRzIHVwZGF0aW5nIGJhc2VkIG9uIHdoYXQncyBi
+        ZWluZyBmaXhlZFxuLSAqKkFjdGl2ZSBza2lsbHMqKjogTm9uZSAtIGJ1dCBz
+        aW5jZSB0aGUgdXNlciBpcyBcImNvbnRpbnVpbmcgd2l0aCB0aGUgZml4LFwi
+        IHRoZXJlJ3MgbGlrZWx5IGRvbWFpbi1zcGVjaWZpYyB3b3JrIGluIHByb2dy
+        ZXNzXG4tICoqQWN0aXZlIHdvcmtmbG93Kio6IE5vbmUgLSBzaG91bGQgcHJv
+        YmFibHkgaGF2ZSBvbmUgaWYgdGhpcyBpcyBhIG11bHRpLXN0ZXAgZml4XG5c
+        blRoZSBwcm9ibGVtIGlzIHRoYXQgSSBkb24ndCBoYXZlIHZpc2liaWxpdHkg
+        aW50byB3aGF0IFwidGhlIGZpeFwiIHJlZmVycyB0byBvciB3aGljaCBkb21h
+        aW4gaXQncyBpbi4gV2l0aG91dCB0aGF0IGNvbnRleHQsIEkgY2FuJ3QgaW50
+        ZWxsaWdlbnRseSBhY3RpdmF0ZSBza2lsbHMgb3Igd29ya2Zsb3dzLlxuXG5I
+        b3dldmVyLCBJIGNhbiBzZWUgdGhhdDpcbjEuIFRoZSBzZXNzaW9uIG5hbWUg
+        aXMgZ2VuZXJpYyBhbmQgc2hvdWxkIGJlIHJlbmFtZWQgb25jZSB0aGUgd29y
+        ayBkb21haW4gaXMgY2xlYXJcbjIuIFRoZSBhc3Npc3RhbnQgc2FpZCBcImNv
+        bnRpbnVpbmdcIiB3aGljaCBpbXBsaWVzIHRoZXkncmUgcGlja2luZyB1cCBl
+        eGlzdGluZyB3b3JrXG5cblNpbmNlIHRoZSBhc3Npc3RhbnQgaGFzIGFscmVh
+        ZHkgc3RhcnRlZCBhbmQgdGhlIHVzZXIgaXMganVzdCBhc2tpbmcgbWUgdG8g
+        cmV2aWV3IGFuZCBwcmVwYXJlLCB0aGUgYmVzdCBtb3ZlIGlzIHRvIHdhaXQg
+        Zm9yIHRoZSBjb252ZXJzYXRpb24gdG8gcmV2ZWFsIHdoYXQncyBiZWluZyB3
+        b3JrZWQgb24sIHRoZW4gdXBkYXRlIGNvbnRleHQgYXBwcm9wcmlhdGVseS5c
+        blxuRm9yIG5vdywgdGhlcmUncyBub3RoaW5nIGFjdGlvbmFibGUgd2l0aG91
+        dCBtb3JlIGluZm9ybWF0aW9uIGFib3V0IHRoZSBmaXgncyBkb21haW4uIn0s
+        eyJ0eXBlIjoidG9vbF91c2UiLCJpZCI6InRvb2x1XzAxQ1F6NmpmeHV0ZzJR
+        dENmckVYNkduNSIsIm5hbWUiOiJldmVyeXRoaW5nX2lzX3JlYWR5IiwiaW5w
+        dXQiOnt9LCJjYWxsZXIiOnsidHlwZSI6ImRpcmVjdCJ9fV0sInN0b3BfcmVh
+        c29uIjoidG9vbF91c2UiLCJzdG9wX3NlcXVlbmNlIjpudWxsLCJ1c2FnZSI6
+        eyJpbnB1dF90b2tlbnMiOjI0NDUsImNhY2hlX2NyZWF0aW9uX2lucHV0X3Rv
+        a2VucyI6MCwiY2FjaGVfcmVhZF9pbnB1dF90b2tlbnMiOjAsImNhY2hlX2Ny
+        ZWF0aW9uIjp7ImVwaGVtZXJhbF81bV9pbnB1dF90b2tlbnMiOjAsImVwaGVt
+        ZXJhbF8xaF9pbnB1dF90b2tlbnMiOjB9LCJvdXRwdXRfdG9rZW5zIjoyNzMs
+        InNlcnZpY2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dlbyI6Im5v
+        dF9hdmFpbGFibGUifX0=
+  recorded_at: Sun, 29 Mar 2026 08:58:12 GMT
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: "{\"model\":\"claude-haiku-4-5\",\"messages\":[{\"role\":\"user\",\"content\":\"The
+        main session is working on this:\\n```\\nUser: Continue with the fix\\nAssistant:
+        Sure, continuing.\\n```\\n\\nReview and take any needed actions, then call
+        everything_is_ready.\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll
+        check the current state and take any needed actions.\\n\\nLooking at the context:\\n-
+        **Session name**: \\\"\U0001F527 Existing Name\\\" - generic, needs updating
+        based on what's being fixed\\n- **Active skills**: None - but since the user
+        is \\\"continuing with the fix,\\\" there's likely domain-specific work in
+        progress\\n- **Active workflow**: None - should probably have one if this
+        is a multi-step fix\\n\\nThe problem is that I don't have visibility into
+        what \\\"the fix\\\" refers to or which domain it's in. Without that context,
+        I can't intelligently activate skills or workflows.\\n\\nHowever, I can see
+        that:\\n1. The session name is generic and should be renamed once the work
+        domain is clear\\n2. The assistant said \\\"continuing\\\" which implies they're
+        picking up existing work\\n\\nSince the assistant has already started and
+        the user is just asking me to review and prepare, the best move is to wait
+        for the conversation to reveal what's being worked on, then update context
+        appropriately.\\n\\nFor now, there's nothing actionable without more information
+        about the fix's domain.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01CQz6jfxutg2QtCfrEX6Gn5\",\"name\":\"everything_is_ready\",\"input\":{},\"caller\":{\"type\":\"direct\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01CQz6jfxutg2QtCfrEX6Gn5\",\"content\":\"Acknowledged.
+        No changes needed.\"}]}],\"max_tokens\":4096,\"tools\":[{\"name\":\"rename_session\",\"description\":\"Rename
+        the session.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"emoji\":{\"type\":\"string\"},\"name\":{\"type\":\"string\",\"description\":\"1-3
+        words.\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds (default:
+        180).\"}},\"required\":[\"emoji\",\"name\"]}},{\"name\":\"activate_skill\",\"description\":\"Give
+        the agent domain knowledge relevant to the current conversation.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"skill_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"skill_name\"]}},{\"name\":\"deactivate_skill\",\"description\":\"Remove
+        domain knowledge that is no longer relevant.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"skill_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"skill_name\"]}},{\"name\":\"read_workflow\",\"description\":\"Activate
+        a workflow and return its content for goal planning.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"workflow_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"workflow_name\"]}},{\"name\":\"deactivate_workflow\",\"description\":\"Deactivate
+        the current workflow when it is complete or no longer relevant.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[]}},{\"name\":\"set_goal\",\"description\":\"Create
+        a goal or sub-goal.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"description\":{\"type\":\"string\",\"description\":\"1
+        sentence.\"},\"parent_goal_id\":{\"type\":\"integer\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"description\"]}},{\"name\":\"update_goal\",\"description\":\"Refine
+        a goal's wording as understanding evolves.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"goal_id\":{\"type\":\"integer\"},\"description\":{\"type\":\"string\",\"description\":\"1
+        sentence.\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds (default:
+        180).\"}},\"required\":[\"goal_id\",\"description\"]}},{\"name\":\"finish_goal\",\"description\":\"Mark
+        a goal as completed.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"goal_id\":{\"type\":\"integer\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"goal_id\"]}},{\"name\":\"everything_is_ready\",\"description\":\"Nothing
+        else to do.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[]}}],\"system\":[{\"type\":\"text\",\"text\":\"You
+        are Claude Code, Anthropic's official CLI for Claude.\"},{\"type\":\"text\",\"text\":\"You
+        manage context for the main agent — skills, goals, workflows, and session
+        names.\\nWatch the conversation and act when context needs updating.\\nCommunicate
+        only through tool calls — never output text.\\n\\n──────────────────────────────\\nSESSION
+        NAMING\\n──────────────────────────────\\nName the session when the topic
+        becomes clear. Rename if it shifts.\\nFormat: one emoji + 1-3 descriptive
+        words.\\n\\n──────────────────────────────\\nSKILL MANAGEMENT\\n──────────────────────────────\\nActivate
+        skills when the conversation signals intent — before the agent acts on it.\\nLate
+        activation means the agent works without domain knowledge.\\nDeactivate when
+        the agent moves to a different domain.\\nMultiple skills can be active at
+        once.\\n\\n──────────────────────────────\\nWORKFLOW MANAGEMENT\\n──────────────────────────────\\nActivate
+        a workflow when the user starts a multi-step task that matches one.\\nRead
+        the returned content and use judgment to create goals — not a mechanical 1:1
+        mapping.\\nAdapt to context: skip irrelevant steps, add extra steps for unfamiliar
+        areas.\\nDeactivate the workflow when it completes or the user shifts focus.\\nOnly
+        one workflow active at a time — activating a new one replaces the previous.\\n\\n──────────────────────────────\\nGOAL
+        TRACKING\\n──────────────────────────────\\nCreate a root goal when the user
+        starts a multi-step task.\\nBreak it into sub-goals as the plan becomes clear.\\nRefine
+        goal wording as understanding evolves.\\nMark goals complete when the agent
+        finishes the work they describe.\\nCompleting a root goal cascades — all sub-goals
+        are finished too.\\nNever duplicate an existing goal — check the active goals
+        list first.\\n\\n──────────────────────────────\\nCOMPLETION\\n──────────────────────────────\\nAlways
+        finish with everything_is_ready.\\nIf nothing needs attention, call it immediately.\\n\\n──────────────────────────────\\nCURRENT
+        STATE\\n──────────────────────────────\\nSession name: \U0001F527 Existing
+        Name\\nActive skills: None\\nActive workflow: None\\n\\n──────────────────────────────\\nAVAILABLE
+        SKILLS\\n──────────────────────────────\\n- activerecord — Associations, validations,
+        queries, migrations, eager loading, N+1 queries, scopes, callbacks, app/models/,
+        db/migrate/.\\n- dragonruby — 2D game development — game loops, sprites, input,
+        collisions, scenes, DRGTK, args.outputs/state/inputs.\\n- draper-decorators
+        — Decorator patterns for Rails views — presentation logic separated from models,
+        *_decorator.rb, app/decorators/.\\n- gh-issue — Issue writing with WHAT/WHY/HOW
+        framework — tickets, bug reports, feature requests, issue descriptions, unclear
+        rationale in existing issues.\\n- mcp-server — Ruby MCP server development
+        — tools, prompts, resources, transport, the mcp gem, LLM tool integrations.\\n-
+        ratatui-ruby — Terminal UI development — widgets, layouts, events, Tea MVU,
+        terminal rendering.\\n- rspec — Testing with FactoryBot — matchers, test doubles,
+        shared examples, describe/it/expect blocks, *_spec.rb files, test strategy.\\n\\n──────────────────────────────\\nAVAILABLE
+        WORKFLOWS\\n──────────────────────────────\\n- commit — Create focused git
+        commits with user approval.\\n- create_handoff — Preserve current session's
+        context, decisions, and next steps so another session can continue the work.\\n-
+        create_note — Persist findings, insights, or decisions as a note in the thoughts
+        system for future sessions.\\n- create_plan — For epics and multi-ticket efforts
+        — research the problem space and design a phased implementation strategy before
+        writing code.\\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\\n- feature —
+        Implement a GitHub issue end-to-end: branch, research, code, test, commit,
+        PR, self-review.\\n- implement_plan — Execute an approved implementation plan
+        — work through each phase, verify success criteria before moving on.\\n- iterate_plan
+        — Revise an existing implementation plan based on feedback, new findings,
+        or changed requirements.\\n- research_codebase — Deep-dive into a large or
+        unfamiliar codebase — delegate research to parallel specialists and synthesize
+        findings.\\n- resume_handoff — Continue work left by a previous session —
+        read its handoff, verify assumptions, and pick up where it stopped.\\n- review_pr
+        — All PR review operations — review, re-review, self-review, or address reviewer
+        feedback.\\n- thoughts_init — Bootstrap ./thoughts for a new project that
+        doesn't have one yet.\\n- validate_plan — Check whether the implementation
+        satisfies the plan — compare success criteria against what was actually built.\\n\"}]}"
+    headers:
+      Authorization:
+      - "<AUTHORIZATION>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Anthropic-Beta:
+      - oauth-2025-04-20
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Mar 2026 08:58:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Unified-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-5h-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-5h-Reset:
+      - '1774782000'
+      Anthropic-Ratelimit-Unified-5h-Utilization:
+      - '0.55'
+      Anthropic-Ratelimit-Unified-7d-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-7d-Reset:
+      - '1775196000'
+      Anthropic-Ratelimit-Unified-7d-Utilization:
+      - '0.45'
+      Anthropic-Ratelimit-Unified-Representative-Claim:
+      - five_hour
+      Anthropic-Ratelimit-Unified-Fallback-Percentage:
+      - '0.5'
+      Anthropic-Ratelimit-Unified-Fallback:
+      - available
+      Anthropic-Ratelimit-Unified-Reset:
+      - '1774782000'
+      Anthropic-Ratelimit-Unified-Overage-Disabled-Reason:
+      - org_level_disabled
+      Anthropic-Ratelimit-Unified-Overage-Status:
+      - rejected
+      Request-Id:
+      - "<REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - "<ANTHROPIC_ORG_ID>"
+      Server:
+      - cloudflare
+      X-Envoy-Upstream-Service-Time:
+      - '2975'
+      Vary:
+      - Accept-Encoding
+      Server-Timing:
+      - x-originResponse;dur=2977
+      Set-Cookie:
+      - "<CLOUDFLARE_COOKIE>"
+      X-Robots-Tag:
+      - none
+      Cf-Cache-Status:
+      - DYNAMIC
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
+        Z18wMVBraWlwa3VTeHd4ZmpwOTc4bzdMakEiLCJ0eXBlIjoibWVzc2FnZSIs
+        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbXSwic3RvcF9yZWFzb24i
+        OiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7Imlu
+        cHV0X3Rva2VucyI6MjczNiwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
+        IjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRp
+        b24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFs
+        XzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjIsInNlcnZp
+        Y2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dlbyI6Im5vdF9hdmFp
+        bGFibGUifX0=
+  recorded_at: Sun, 29 Mar 2026 08:58:15 GMT
 recorded_with: VCR 6.4.0

--- a/spec/cassettes/AnalyticalBrain_Runner/_call/integration_with_real_LLM/renames_an_unnamed_session_based_on_conversation_topic.yml
+++ b/spec/cassettes/AnalyticalBrain_Runner/_call/integration_with_real_LLM/renames_an_unnamed_session_based_on_conversation_topic.yml
@@ -54,46 +54,38 @@ http_interactions:
         finish with everything_is_ready.\nIf nothing needs attention, call it immediately.\n\n──────────────────────────────\nCURRENT
         STATE\n──────────────────────────────\nSession name: (unnamed)\nActive skills:
         None\nActive workflow: None\n\n──────────────────────────────\nAVAILABLE SKILLS\n──────────────────────────────\n-
-        activerecord — Associations, validations, queries, migrations, eager loading.
-        Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load,
-        callbacks, or editing app/models/ or db/migrate/.\n- dragonruby — 2D game
-        development — game loops, sprites, input, collisions, scenes. Activate when
-        building games with DRGTK, working with args.outputs/state/inputs, or editing
-        game files.\n- draper-decorators — Decorator patterns for Rails views — presentation
-        logic separated from models. Activate when creating or testing decorators,
-        moving formatting logic out of models/views, editing *_decorator.rb files,
-        or working in app/decorators/.\n- gh-issue — Issue writing with WHAT/WHY/HOW
-        framework. Activate when creating issues, writing tickets, drafting issue
-        descriptions, or when issues lack clear rationale.\n- mcp-server — Ruby server
-        development — tools, prompts, resources, transport. Activate when building
-        Model Context Protocol servers, defining MCP tools/prompts/resources, working
-        with the mcp gem, or discussing LLM tool integrations.\n- ratatui-ruby — Terminal
-        UI development — widgets, layouts, events, Tea MVU. Activate when building
-        TUI apps, working with terminal rendering, or editing TUI application files.\n-
-        rspec — Testing with FactoryBot — matchers, test doubles, shared examples.
-        Activate when writing specs, fixing failing tests, working with describe/it/expect
-        blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration
-        tests.\n\n──────────────────────────────\nAVAILABLE WORKFLOWS\n──────────────────────────────\n-
-        commit — Create focused git commits with user approval.\n- create_handoff
-        — Preserve current session''s context, decisions, and next steps so another
-        session can continue the work.\n- create_note — Persist findings, insights,
-        or decisions as a note in the thoughts system for future sessions.\n- create_plan
-        — For epics and multi-ticket efforts — research the problem space and design
-        a phased implementation strategy before writing code.\n- decompose_ticket
-        — Decompose a feature ticket into vertical slices — testable, deliverable
-        units ordered by dependency.\n- feature — Implement a GitHub issue end-to-end:
-        branch, research, code, test, commit, PR, self-review.\n- implement_plan —
-        Execute an approved implementation plan — work through each phase, verify
-        success criteria before moving on.\n- iterate_plan — Revise an existing implementation
-        plan based on feedback, new findings, or changed requirements.\n- research_codebase
-        — Deep-dive into a large or unfamiliar codebase — delegate research to parallel
-        specialists and synthesize findings.\n- resume_handoff — Continue work left
-        by a previous session — read its handoff, verify assumptions, and pick up
-        where it stopped.\n- review_pr — All PR review operations — review, re-review,
-        self-review, or address reviewer feedback.\n- thoughts_init — Bootstrap ./thoughts
-        for a new project that doesn''t have one yet.\n- validate_plan — Check whether
-        the implementation satisfies the plan — compare success criteria against what
-        was actually built.\n"}]}'
+        activerecord — Associations, validations, queries, migrations, eager loading,
+        N+1 queries, scopes, callbacks, app/models/, db/migrate/.\n- dragonruby —
+        2D game development — game loops, sprites, input, collisions, scenes, DRGTK,
+        args.outputs/state/inputs.\n- draper-decorators — Decorator patterns for Rails
+        views — presentation logic separated from models, *_decorator.rb, app/decorators/.\n-
+        gh-issue — Issue writing with WHAT/WHY/HOW framework — tickets, bug reports,
+        feature requests, issue descriptions, unclear rationale in existing issues.\n-
+        mcp-server — Ruby MCP server development — tools, prompts, resources, transport,
+        the mcp gem, LLM tool integrations.\n- ratatui-ruby — Terminal UI development
+        — widgets, layouts, events, Tea MVU, terminal rendering.\n- rspec — Testing
+        with FactoryBot — matchers, test doubles, shared examples, describe/it/expect
+        blocks, *_spec.rb files, test strategy.\n\n──────────────────────────────\nAVAILABLE
+        WORKFLOWS\n──────────────────────────────\n- commit — Create focused git commits
+        with user approval.\n- create_handoff — Preserve current session''s context,
+        decisions, and next steps so another session can continue the work.\n- create_note
+        — Persist findings, insights, or decisions as a note in the thoughts system
+        for future sessions.\n- create_plan — For epics and multi-ticket efforts —
+        research the problem space and design a phased implementation strategy before
+        writing code.\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\n- feature — Implement
+        a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review.\n-
+        implement_plan — Execute an approved implementation plan — work through each
+        phase, verify success criteria before moving on.\n- iterate_plan — Revise
+        an existing implementation plan based on feedback, new findings, or changed
+        requirements.\n- research_codebase — Deep-dive into a large or unfamiliar
+        codebase — delegate research to parallel specialists and synthesize findings.\n-
+        resume_handoff — Continue work left by a previous session — read its handoff,
+        verify assumptions, and pick up where it stopped.\n- review_pr — All PR review
+        operations — review, re-review, self-review, or address reviewer feedback.\n-
+        thoughts_init — Bootstrap ./thoughts for a new project that doesn''t have
+        one yet.\n- validate_plan — Check whether the implementation satisfies the
+        plan — compare success criteria against what was actually built.\n"}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"
@@ -115,7 +107,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:42 GMT
+      - Sun, 29 Mar 2026 08:58:04 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -129,13 +121,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -157,11 +149,11 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '3902'
+      - '1407'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=3909
+      - x-originResponse;dur=1409
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
@@ -176,32 +168,19 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMUE0WEZBUWN6ajIySm93UWVINms1R1oiLCJ0eXBlIjoibWVzc2FnZSIs
-        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIs
-        InRleHQiOiJJJ2xsIHJldmlldyB0aGUgY29udGV4dCBhbmQgc2V0IHVwIHRo
-        ZSBzZXNzaW9uIGFwcHJvcHJpYXRlbHkuXG5cblRoZSB1c2VyIGlzIGFza2lu
-        ZyBhYm91dCBQb3N0Z3JlU1FMIHJlcGxpY2F0aW9uIGZvciBhIFJhaWxzIGFw
-        cC4gVGhpcyBpcyBpbmZyYXN0cnVjdHVyZS9kYXRhYmFzZSBzZXR1cCB3b3Jr
-        LCBub3QgZGlyZWN0bHkgUmFpbHMgT1JNIHdvcmsuIEhvd2V2ZXIsIHRoZXJl
-        J3Mgbm8gZXhpc3Rpbmcgc2tpbGwgdGhhdCBjb3ZlcnMgUG9zdGdyZVNRTCBy
-        ZXBsaWNhdGlvbiBzZXR1cCBzcGVjaWZpY2FsbHkuIFRoZSBgYWN0aXZlcmVj
-        b3JkYCBza2lsbCBjb3ZlcnMgUmFpbHMgbW9kZWxzIGFuZCBkYXRhYmFzZSBz
-        Y2hlbWEsIGJ1dCBub3QgcmVwbGljYXRpb24gY29uZmlndXJhdGlvbi5cblxu
-        TGV0IG1lIHNldCB1cCB0aGUgc2Vzc2lvbjoifSx7InR5cGUiOiJ0b29sX3Vz
-        ZSIsImlkIjoidG9vbHVfMDFIWm9UOVlEdHdBdHBBMzJ2SDFLd0FoIiwibmFt
-        ZSI6InJlbmFtZV9zZXNzaW9uIiwiaW5wdXQiOnsiZW1vamkiOiLwn5CYIiwi
-        bmFtZSI6IlBvc3RncmVTUUwgUmVwbGljYXRpb24ifSwiY2FsbGVyIjp7InR5
-        cGUiOiJkaXJlY3QifX0seyJ0eXBlIjoidG9vbF91c2UiLCJpZCI6InRvb2x1
-        XzAxUmY0bjJMYnpTNk1xWjVkd1cxNkxCUyIsIm5hbWUiOiJldmVyeXRoaW5n
-        X2lzX3JlYWR5IiwiaW5wdXQiOnt9LCJjYWxsZXIiOnsidHlwZSI6ImRpcmVj
-        dCJ9fV0sInN0b3BfcmVhc29uIjoidG9vbF91c2UiLCJzdG9wX3NlcXVlbmNl
-        IjpudWxsLCJ1c2FnZSI6eyJpbnB1dF90b2tlbnMiOjI1ODAsImNhY2hlX2Ny
-        ZWF0aW9uX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfcmVhZF9pbnB1dF90b2tl
-        bnMiOjAsImNhY2hlX2NyZWF0aW9uIjp7ImVwaGVtZXJhbF81bV9pbnB1dF90
-        b2tlbnMiOjAsImVwaGVtZXJhbF8xaF9pbnB1dF90b2tlbnMiOjB9LCJvdXRw
-        dXRfdG9rZW5zIjoxODUsInNlcnZpY2VfdGllciI6InN0YW5kYXJkIiwiaW5m
-        ZXJlbmNlX2dlbyI6Im5vdF9hdmFpbGFibGUifX0=
-  recorded_at: Sun, 29 Mar 2026 08:47:42 GMT
+        Z18wMUJQWTZjcHlwMjFiZUxqcFUzTFdLZUciLCJ0eXBlIjoibWVzc2FnZSIs
+        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbF91
+        c2UiLCJpZCI6InRvb2x1XzAxVXBGWE5oQWRSM2gyNkJaNUZSaFFGNCIsIm5h
+        bWUiOiJyZW5hbWVfc2Vzc2lvbiIsImlucHV0Ijp7ImVtb2ppIjoi8J+QmCIs
+        Im5hbWUiOiJQb3N0Z3JlU1FMIFJlcGxpY2F0aW9uIn0sImNhbGxlciI6eyJ0
+        eXBlIjoiZGlyZWN0In19XSwic3RvcF9yZWFzb24iOiJ0b29sX3VzZSIsInN0
+        b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7ImlucHV0X3Rva2VucyI6MjQ1
+        OSwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5zIjowLCJjYWNoZV9yZWFk
+        X2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRpb24iOnsiZXBoZW1lcmFs
+        XzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFsXzFoX2lucHV0X3Rva2Vu
+        cyI6MH0sIm91dHB1dF90b2tlbnMiOjc3LCJzZXJ2aWNlX3RpZXIiOiJzdGFu
+        ZGFyZCIsImluZmVyZW5jZV9nZW8iOiJub3RfYXZhaWxhYmxlIn19
+  recorded_at: Sun, 29 Mar 2026 08:58:04 GMT
 - request:
     method: post
     uri: https://api.anthropic.com/v1/messages
@@ -211,15 +190,216 @@ http_interactions:
         main session is working on this:\\n```\\nUser: Help me set up PostgreSQL replication
         for our Rails app\\nAssistant: I'll help you configure PostgreSQL streaming
         replication with your Rails app.\\n```\\n\\nReview and take any needed actions,
-        then call everything_is_ready.\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I'll
-        review the context and set up the session appropriately.\\n\\nThe user is
-        asking about PostgreSQL replication for a Rails app. This is infrastructure/database
-        setup work, not directly Rails ORM work. However, there's no existing skill
-        that covers PostgreSQL replication setup specifically. The `activerecord`
-        skill covers Rails models and database schema, but not replication configuration.\\n\\nLet
-        me set up the session:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01HZoT9YDtwAtpA32vH1KwAh\",\"name\":\"rename_session\",\"input\":{\"emoji\":\"\U0001F418\",\"name\":\"PostgreSQL
-        Replication\"},\"caller\":{\"type\":\"direct\"}},{\"type\":\"tool_use\",\"id\":\"toolu_01Rf4n2LbzS6MqZ5dwW16LBS\",\"name\":\"everything_is_ready\",\"input\":{},\"caller\":{\"type\":\"direct\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01HZoT9YDtwAtpA32vH1KwAh\",\"content\":\"Session
-        renamed to: \U0001F418 PostgreSQL Replication\"},{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01Rf4n2LbzS6MqZ5dwW16LBS\",\"content\":\"Acknowledged.
+        then call everything_is_ready.\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01UpFXNhAdR3h26BZ5FRhQF4\",\"name\":\"rename_session\",\"input\":{\"emoji\":\"\U0001F418\",\"name\":\"PostgreSQL
+        Replication\"},\"caller\":{\"type\":\"direct\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01UpFXNhAdR3h26BZ5FRhQF4\",\"content\":\"Session
+        renamed to: \U0001F418 PostgreSQL Replication\"}]}],\"max_tokens\":4096,\"tools\":[{\"name\":\"rename_session\",\"description\":\"Rename
+        the session.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"emoji\":{\"type\":\"string\"},\"name\":{\"type\":\"string\",\"description\":\"1-3
+        words.\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds (default:
+        180).\"}},\"required\":[\"emoji\",\"name\"]}},{\"name\":\"activate_skill\",\"description\":\"Give
+        the agent domain knowledge relevant to the current conversation.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"skill_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"skill_name\"]}},{\"name\":\"deactivate_skill\",\"description\":\"Remove
+        domain knowledge that is no longer relevant.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"skill_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"skill_name\"]}},{\"name\":\"read_workflow\",\"description\":\"Activate
+        a workflow and return its content for goal planning.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"workflow_name\":{\"type\":\"string\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"workflow_name\"]}},{\"name\":\"deactivate_workflow\",\"description\":\"Deactivate
+        the current workflow when it is complete or no longer relevant.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[]}},{\"name\":\"set_goal\",\"description\":\"Create
+        a goal or sub-goal.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"description\":{\"type\":\"string\",\"description\":\"1
+        sentence.\"},\"parent_goal_id\":{\"type\":\"integer\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"description\"]}},{\"name\":\"update_goal\",\"description\":\"Refine
+        a goal's wording as understanding evolves.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"goal_id\":{\"type\":\"integer\"},\"description\":{\"type\":\"string\",\"description\":\"1
+        sentence.\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds (default:
+        180).\"}},\"required\":[\"goal_id\",\"description\"]}},{\"name\":\"finish_goal\",\"description\":\"Mark
+        a goal as completed.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"goal_id\":{\"type\":\"integer\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[\"goal_id\"]}},{\"name\":\"everything_is_ready\",\"description\":\"Nothing
+        else to do.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds
+        (default: 180).\"}},\"required\":[]}}],\"system\":[{\"type\":\"text\",\"text\":\"You
+        are Claude Code, Anthropic's official CLI for Claude.\"},{\"type\":\"text\",\"text\":\"You
+        manage context for the main agent — skills, goals, workflows, and session
+        names.\\nWatch the conversation and act when context needs updating.\\nCommunicate
+        only through tool calls — never output text.\\n\\n──────────────────────────────\\nSESSION
+        NAMING\\n──────────────────────────────\\nName the session when the topic
+        becomes clear. Rename if it shifts.\\nFormat: one emoji + 1-3 descriptive
+        words.\\n\\n──────────────────────────────\\nSKILL MANAGEMENT\\n──────────────────────────────\\nActivate
+        skills when the conversation signals intent — before the agent acts on it.\\nLate
+        activation means the agent works without domain knowledge.\\nDeactivate when
+        the agent moves to a different domain.\\nMultiple skills can be active at
+        once.\\n\\n──────────────────────────────\\nWORKFLOW MANAGEMENT\\n──────────────────────────────\\nActivate
+        a workflow when the user starts a multi-step task that matches one.\\nRead
+        the returned content and use judgment to create goals — not a mechanical 1:1
+        mapping.\\nAdapt to context: skip irrelevant steps, add extra steps for unfamiliar
+        areas.\\nDeactivate the workflow when it completes or the user shifts focus.\\nOnly
+        one workflow active at a time — activating a new one replaces the previous.\\n\\n──────────────────────────────\\nGOAL
+        TRACKING\\n──────────────────────────────\\nCreate a root goal when the user
+        starts a multi-step task.\\nBreak it into sub-goals as the plan becomes clear.\\nRefine
+        goal wording as understanding evolves.\\nMark goals complete when the agent
+        finishes the work they describe.\\nCompleting a root goal cascades — all sub-goals
+        are finished too.\\nNever duplicate an existing goal — check the active goals
+        list first.\\n\\n──────────────────────────────\\nCOMPLETION\\n──────────────────────────────\\nAlways
+        finish with everything_is_ready.\\nIf nothing needs attention, call it immediately.\\n\\n──────────────────────────────\\nCURRENT
+        STATE\\n──────────────────────────────\\nSession name: (unnamed)\\nActive
+        skills: None\\nActive workflow: None\\n\\n──────────────────────────────\\nAVAILABLE
+        SKILLS\\n──────────────────────────────\\n- activerecord — Associations, validations,
+        queries, migrations, eager loading, N+1 queries, scopes, callbacks, app/models/,
+        db/migrate/.\\n- dragonruby — 2D game development — game loops, sprites, input,
+        collisions, scenes, DRGTK, args.outputs/state/inputs.\\n- draper-decorators
+        — Decorator patterns for Rails views — presentation logic separated from models,
+        *_decorator.rb, app/decorators/.\\n- gh-issue — Issue writing with WHAT/WHY/HOW
+        framework — tickets, bug reports, feature requests, issue descriptions, unclear
+        rationale in existing issues.\\n- mcp-server — Ruby MCP server development
+        — tools, prompts, resources, transport, the mcp gem, LLM tool integrations.\\n-
+        ratatui-ruby — Terminal UI development — widgets, layouts, events, Tea MVU,
+        terminal rendering.\\n- rspec — Testing with FactoryBot — matchers, test doubles,
+        shared examples, describe/it/expect blocks, *_spec.rb files, test strategy.\\n\\n──────────────────────────────\\nAVAILABLE
+        WORKFLOWS\\n──────────────────────────────\\n- commit — Create focused git
+        commits with user approval.\\n- create_handoff — Preserve current session's
+        context, decisions, and next steps so another session can continue the work.\\n-
+        create_note — Persist findings, insights, or decisions as a note in the thoughts
+        system for future sessions.\\n- create_plan — For epics and multi-ticket efforts
+        — research the problem space and design a phased implementation strategy before
+        writing code.\\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\\n- feature —
+        Implement a GitHub issue end-to-end: branch, research, code, test, commit,
+        PR, self-review.\\n- implement_plan — Execute an approved implementation plan
+        — work through each phase, verify success criteria before moving on.\\n- iterate_plan
+        — Revise an existing implementation plan based on feedback, new findings,
+        or changed requirements.\\n- research_codebase — Deep-dive into a large or
+        unfamiliar codebase — delegate research to parallel specialists and synthesize
+        findings.\\n- resume_handoff — Continue work left by a previous session —
+        read its handoff, verify assumptions, and pick up where it stopped.\\n- review_pr
+        — All PR review operations — review, re-review, self-review, or address reviewer
+        feedback.\\n- thoughts_init — Bootstrap ./thoughts for a new project that
+        doesn't have one yet.\\n- validate_plan — Check whether the implementation
+        satisfies the plan — compare success criteria against what was actually built.\\n\"}]}"
+    headers:
+      Authorization:
+      - "<AUTHORIZATION>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Anthropic-Beta:
+      - oauth-2025-04-20
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 29 Mar 2026 08:58:06 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Unified-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-5h-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-5h-Reset:
+      - '1774782000'
+      Anthropic-Ratelimit-Unified-5h-Utilization:
+      - '0.55'
+      Anthropic-Ratelimit-Unified-7d-Status:
+      - allowed
+      Anthropic-Ratelimit-Unified-7d-Reset:
+      - '1775196000'
+      Anthropic-Ratelimit-Unified-7d-Utilization:
+      - '0.45'
+      Anthropic-Ratelimit-Unified-Representative-Claim:
+      - five_hour
+      Anthropic-Ratelimit-Unified-Fallback-Percentage:
+      - '0.5'
+      Anthropic-Ratelimit-Unified-Fallback:
+      - available
+      Anthropic-Ratelimit-Unified-Reset:
+      - '1774782000'
+      Anthropic-Ratelimit-Unified-Overage-Disabled-Reason:
+      - org_level_disabled
+      Anthropic-Ratelimit-Unified-Overage-Status:
+      - rejected
+      Request-Id:
+      - "<REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - "<ANTHROPIC_ORG_ID>"
+      Server:
+      - cloudflare
+      X-Envoy-Upstream-Service-Time:
+      - '2134'
+      Vary:
+      - Accept-Encoding
+      Server-Timing:
+      - x-originResponse;dur=2136
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<CLOUDFLARE_COOKIE>"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      X-Robots-Tag:
+      - none
+      Cf-Ray:
+      - "<CF_RAY>"
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
+        Z18wMTducHNNTXlxVDEzdUdlOWZDeHlkcGIiLCJ0eXBlIjoibWVzc2FnZSIs
+        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIs
+        InRleHQiOiJOb3cgY2hlY2tpbmcgd2hhdCdzIG5lZWRlZDogdGhlIHVzZXIg
+        aXMgc2V0dGluZyB1cCBQb3N0Z3JlU1FMIHJlcGxpY2F0aW9uIGZvciBhIFJh
+        aWxzIGFwcC4gVGhpcyBpbnZvbHZlcyBkYXRhYmFzZSBpbmZyYXN0cnVjdHVy
+        ZSBhbmQgY29uZmlndXJhdGlvbiB3b3JrLiBIb3dldmVyLCBub25lIG9mIHRo
+        ZSBhdmFpbGFibGUgc2tpbGxzIGRpcmVjdGx5IGNvdmVyIFBvc3RncmVTUUwg
+        cmVwbGljYXRpb24gb3IgZGF0YWJhc2UgaW5mcmFzdHJ1Y3R1cmUgc2V0dXAu
+        IFRoZSBjbG9zZXN0IHJlbGV2YW50IHNraWxsIHdvdWxkIGJlIGBhY3RpdmVy
+        ZWNvcmRgIGlmIHRoZXJlIGFyZSBSYWlscy1zcGVjaWZpYyBkYXRhYmFzZSBj
+        b25maWd1cmF0aW9uIGNvbmNlcm5zLCBidXQgdGhhdCdzIG5vdCBuZWNlc3Nh
+        cnkgdG8gYWN0aXZhdGUgcmlnaHQgbm93IHNpbmNlIHRoZSBpbml0aWFsIGNv
+        bnZlcnNhdGlvbiBpcyBqdXN0IGZyYW1pbmcgdGhlIHRhc2suXG5cbk5vIHdv
+        cmtmbG93cyBhcHBseSB5ZXQg4oCUIHRoZSB1c2VyIGhhc24ndCBjb21taXR0
+        ZWQgdG8gYSBzcGVjaWZpYyBtdWx0aS1zdGVwIHByb2Nlc3MuIFRoZSBjb252
+        ZXJzYXRpb24gaXMgc3RpbGwgaW4gdGhlIHBsYW5uaW5nIHBoYXNlLiJ9LHsi
+        dHlwZSI6InRvb2xfdXNlIiwiaWQiOiJ0b29sdV8wMVZMckdkaGlkUGpmdXN6
+        R2c4bmpiS2YiLCJuYW1lIjoiZXZlcnl0aGluZ19pc19yZWFkeSIsImlucHV0
+        Ijp7fSwiY2FsbGVyIjp7InR5cGUiOiJkaXJlY3QifX1dLCJzdG9wX3JlYXNv
+        biI6InRvb2xfdXNlIiwic3RvcF9zZXF1ZW5jZSI6bnVsbCwidXNhZ2UiOnsi
+        aW5wdXRfdG9rZW5zIjoyNTYyLCJjYWNoZV9jcmVhdGlvbl9pbnB1dF90b2tl
+        bnMiOjAsImNhY2hlX3JlYWRfaW5wdXRfdG9rZW5zIjowLCJjYWNoZV9jcmVh
+        dGlvbiI6eyJlcGhlbWVyYWxfNW1faW5wdXRfdG9rZW5zIjowLCJlcGhlbWVy
+        YWxfMWhfaW5wdXRfdG9rZW5zIjowfSwib3V0cHV0X3Rva2VucyI6MTU0LCJz
+        ZXJ2aWNlX3RpZXIiOiJzdGFuZGFyZCIsImluZmVyZW5jZV9nZW8iOiJub3Rf
+        YXZhaWxhYmxlIn19
+  recorded_at: Sun, 29 Mar 2026 08:58:06 GMT
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: "{\"model\":\"claude-haiku-4-5\",\"messages\":[{\"role\":\"user\",\"content\":\"The
+        main session is working on this:\\n```\\nUser: Help me set up PostgreSQL replication
+        for our Rails app\\nAssistant: I'll help you configure PostgreSQL streaming
+        replication with your Rails app.\\n```\\n\\nReview and take any needed actions,
+        then call everything_is_ready.\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01UpFXNhAdR3h26BZ5FRhQF4\",\"name\":\"rename_session\",\"input\":{\"emoji\":\"\U0001F418\",\"name\":\"PostgreSQL
+        Replication\"},\"caller\":{\"type\":\"direct\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01UpFXNhAdR3h26BZ5FRhQF4\",\"content\":\"Session
+        renamed to: \U0001F418 PostgreSQL Replication\"}]},{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Now
+        checking what's needed: the user is setting up PostgreSQL replication for
+        a Rails app. This involves database infrastructure and configuration work.
+        However, none of the available skills directly cover PostgreSQL replication
+        or database infrastructure setup. The closest relevant skill would be `activerecord`
+        if there are Rails-specific database configuration concerns, but that's not
+        necessary to activate right now since the initial conversation is just framing
+        the task.\\n\\nNo workflows apply yet — the user hasn't committed to a specific
+        multi-step process. The conversation is still in the planning phase.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01VLrGdhidPjfuszGg8njbKf\",\"name\":\"everything_is_ready\",\"input\":{},\"caller\":{\"type\":\"direct\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01VLrGdhidPjfuszGg8njbKf\",\"content\":\"Acknowledged.
         No changes needed.\"}]}],\"max_tokens\":4096,\"tools\":[{\"name\":\"rename_session\",\"description\":\"Rename
         the session.\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"emoji\":{\"type\":\"string\"},\"name\":{\"type\":\"string\",\"description\":\"1-3
         words.\"},\"timeout\":{\"type\":\"integer\",\"description\":\"Seconds (default:
@@ -268,25 +448,17 @@ http_interactions:
         STATE\\n──────────────────────────────\\nSession name: (unnamed)\\nActive
         skills: None\\nActive workflow: None\\n\\n──────────────────────────────\\nAVAILABLE
         SKILLS\\n──────────────────────────────\\n- activerecord — Associations, validations,
-        queries, migrations, eager loading. Activate when working with models, database
-        schema, N+1 queries, scopes, includes/preload/eager_load, callbacks, or editing
-        app/models/ or db/migrate/.\\n- dragonruby — 2D game development — game loops,
-        sprites, input, collisions, scenes. Activate when building games with DRGTK,
-        working with args.outputs/state/inputs, or editing game files.\\n- draper-decorators
-        — Decorator patterns for Rails views — presentation logic separated from models.
-        Activate when creating or testing decorators, moving formatting logic out
-        of models/views, editing *_decorator.rb files, or working in app/decorators/.\\n-
-        gh-issue — Issue writing with WHAT/WHY/HOW framework. Activate when creating
-        issues, writing tickets, drafting issue descriptions, or when issues lack
-        clear rationale.\\n- mcp-server — Ruby server development — tools, prompts,
-        resources, transport. Activate when building Model Context Protocol servers,
-        defining MCP tools/prompts/resources, working with the mcp gem, or discussing
-        LLM tool integrations.\\n- ratatui-ruby — Terminal UI development — widgets,
-        layouts, events, Tea MVU. Activate when building TUI apps, working with terminal
-        rendering, or editing TUI application files.\\n- rspec — Testing with FactoryBot
-        — matchers, test doubles, shared examples. Activate when writing specs, fixing
-        failing tests, working with describe/it/expect blocks, editing *_spec.rb files,
-        planning test strategy, or discussing unit/integration tests.\\n\\n──────────────────────────────\\nAVAILABLE
+        queries, migrations, eager loading, N+1 queries, scopes, callbacks, app/models/,
+        db/migrate/.\\n- dragonruby — 2D game development — game loops, sprites, input,
+        collisions, scenes, DRGTK, args.outputs/state/inputs.\\n- draper-decorators
+        — Decorator patterns for Rails views — presentation logic separated from models,
+        *_decorator.rb, app/decorators/.\\n- gh-issue — Issue writing with WHAT/WHY/HOW
+        framework — tickets, bug reports, feature requests, issue descriptions, unclear
+        rationale in existing issues.\\n- mcp-server — Ruby MCP server development
+        — tools, prompts, resources, transport, the mcp gem, LLM tool integrations.\\n-
+        ratatui-ruby — Terminal UI development — widgets, layouts, events, Tea MVU,
+        terminal rendering.\\n- rspec — Testing with FactoryBot — matchers, test doubles,
+        shared examples, describe/it/expect blocks, *_spec.rb files, test strategy.\\n\\n──────────────────────────────\\nAVAILABLE
         WORKFLOWS\\n──────────────────────────────\\n- commit — Create focused git
         commits with user approval.\\n- create_handoff — Preserve current session's
         context, decisions, and next steps so another session can continue the work.\\n-
@@ -328,7 +500,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:43 GMT
+      - Sun, 29 Mar 2026 08:58:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -342,13 +514,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -370,33 +542,33 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '675'
+      - '1469'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=677
-      Set-Cookie:
-      - "<CLOUDFLARE_COOKIE>"
-      X-Robots-Tag:
-      - none
+      - x-originResponse;dur=1471
       Cf-Cache-Status:
       - DYNAMIC
+      Set-Cookie:
+      - "<CLOUDFLARE_COOKIE>"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      X-Robots-Tag:
+      - none
       Cf-Ray:
       - "<CF_RAY>"
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMTVvUDh6RmRicnpydVh2UWJiTHlwbVoiLCJ0eXBlIjoibWVzc2FnZSIs
+        Z18wMVd6eTU0YkxGZmlzY2NZcHN4ZUZ0SHAiLCJ0eXBlIjoibWVzc2FnZSIs
         InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbXSwic3RvcF9yZWFzb24i
         OiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7Imlu
-        cHV0X3Rva2VucyI6Mjg1MCwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
+        cHV0X3Rva2VucyI6MjczNCwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
         IjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRp
         b24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFs
         XzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjIsInNlcnZp
         Y2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dlbyI6Im5vdF9hdmFp
         bGFibGUifX0=
-  recorded_at: Sun, 29 Mar 2026 08:47:43 GMT
+  recorded_at: Sun, 29 Mar 2026 08:58:08 GMT
 recorded_with: VCR 6.4.0

--- a/spec/cassettes/AnalyticalBrain_Runner/_call/message_non-persistence/does_not_create_Message_records_during_execution.yml
+++ b/spec/cassettes/AnalyticalBrain_Runner/_call/message_non-persistence/does_not_create_Message_records_during_execution.yml
@@ -52,46 +52,38 @@ http_interactions:
         finish with everything_is_ready.\nIf nothing needs attention, call it immediately.\n\n──────────────────────────────\nCURRENT
         STATE\n──────────────────────────────\nSession name: (unnamed)\nActive skills:
         None\nActive workflow: None\n\n──────────────────────────────\nAVAILABLE SKILLS\n──────────────────────────────\n-
-        activerecord — Associations, validations, queries, migrations, eager loading.
-        Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load,
-        callbacks, or editing app/models/ or db/migrate/.\n- dragonruby — 2D game
-        development — game loops, sprites, input, collisions, scenes. Activate when
-        building games with DRGTK, working with args.outputs/state/inputs, or editing
-        game files.\n- draper-decorators — Decorator patterns for Rails views — presentation
-        logic separated from models. Activate when creating or testing decorators,
-        moving formatting logic out of models/views, editing *_decorator.rb files,
-        or working in app/decorators/.\n- gh-issue — Issue writing with WHAT/WHY/HOW
-        framework. Activate when creating issues, writing tickets, drafting issue
-        descriptions, or when issues lack clear rationale.\n- mcp-server — Ruby server
-        development — tools, prompts, resources, transport. Activate when building
-        Model Context Protocol servers, defining MCP tools/prompts/resources, working
-        with the mcp gem, or discussing LLM tool integrations.\n- ratatui-ruby — Terminal
-        UI development — widgets, layouts, events, Tea MVU. Activate when building
-        TUI apps, working with terminal rendering, or editing TUI application files.\n-
-        rspec — Testing with FactoryBot — matchers, test doubles, shared examples.
-        Activate when writing specs, fixing failing tests, working with describe/it/expect
-        blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration
-        tests.\n\n──────────────────────────────\nAVAILABLE WORKFLOWS\n──────────────────────────────\n-
-        commit — Create focused git commits with user approval.\n- create_handoff
-        — Preserve current session''s context, decisions, and next steps so another
-        session can continue the work.\n- create_note — Persist findings, insights,
-        or decisions as a note in the thoughts system for future sessions.\n- create_plan
-        — For epics and multi-ticket efforts — research the problem space and design
-        a phased implementation strategy before writing code.\n- decompose_ticket
-        — Decompose a feature ticket into vertical slices — testable, deliverable
-        units ordered by dependency.\n- feature — Implement a GitHub issue end-to-end:
-        branch, research, code, test, commit, PR, self-review.\n- implement_plan —
-        Execute an approved implementation plan — work through each phase, verify
-        success criteria before moving on.\n- iterate_plan — Revise an existing implementation
-        plan based on feedback, new findings, or changed requirements.\n- research_codebase
-        — Deep-dive into a large or unfamiliar codebase — delegate research to parallel
-        specialists and synthesize findings.\n- resume_handoff — Continue work left
-        by a previous session — read its handoff, verify assumptions, and pick up
-        where it stopped.\n- review_pr — All PR review operations — review, re-review,
-        self-review, or address reviewer feedback.\n- thoughts_init — Bootstrap ./thoughts
-        for a new project that doesn''t have one yet.\n- validate_plan — Check whether
-        the implementation satisfies the plan — compare success criteria against what
-        was actually built.\n"}]}'
+        activerecord — Associations, validations, queries, migrations, eager loading,
+        N+1 queries, scopes, callbacks, app/models/, db/migrate/.\n- dragonruby —
+        2D game development — game loops, sprites, input, collisions, scenes, DRGTK,
+        args.outputs/state/inputs.\n- draper-decorators — Decorator patterns for Rails
+        views — presentation logic separated from models, *_decorator.rb, app/decorators/.\n-
+        gh-issue — Issue writing with WHAT/WHY/HOW framework — tickets, bug reports,
+        feature requests, issue descriptions, unclear rationale in existing issues.\n-
+        mcp-server — Ruby MCP server development — tools, prompts, resources, transport,
+        the mcp gem, LLM tool integrations.\n- ratatui-ruby — Terminal UI development
+        — widgets, layouts, events, Tea MVU, terminal rendering.\n- rspec — Testing
+        with FactoryBot — matchers, test doubles, shared examples, describe/it/expect
+        blocks, *_spec.rb files, test strategy.\n\n──────────────────────────────\nAVAILABLE
+        WORKFLOWS\n──────────────────────────────\n- commit — Create focused git commits
+        with user approval.\n- create_handoff — Preserve current session''s context,
+        decisions, and next steps so another session can continue the work.\n- create_note
+        — Persist findings, insights, or decisions as a note in the thoughts system
+        for future sessions.\n- create_plan — For epics and multi-ticket efforts —
+        research the problem space and design a phased implementation strategy before
+        writing code.\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\n- feature — Implement
+        a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review.\n-
+        implement_plan — Execute an approved implementation plan — work through each
+        phase, verify success criteria before moving on.\n- iterate_plan — Revise
+        an existing implementation plan based on feedback, new findings, or changed
+        requirements.\n- research_codebase — Deep-dive into a large or unfamiliar
+        codebase — delegate research to parallel specialists and synthesize findings.\n-
+        resume_handoff — Continue work left by a previous session — read its handoff,
+        verify assumptions, and pick up where it stopped.\n- review_pr — All PR review
+        operations — review, re-review, self-review, or address reviewer feedback.\n-
+        thoughts_init — Bootstrap ./thoughts for a new project that doesn''t have
+        one yet.\n- validate_plan — Check whether the implementation satisfies the
+        plan — compare success criteria against what was actually built.\n"}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"
@@ -113,7 +105,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:37 GMT
+      - Sun, 29 Mar 2026 08:58:00 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -127,13 +119,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -155,11 +147,11 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '1393'
+      - '1105'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=1395
+      - x-originResponse;dur=1106
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
@@ -174,24 +166,18 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMVBiNGpHNzFmenE2em9KeXRBanpaU20iLCJ0eXBlIjoibWVzc2FnZSIs
-        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIs
-        InRleHQiOiJUaGUgc2Vzc2lvbiBoYXMganVzdCBzdGFydGVkIHdpdGggYSBn
-        cmVldGluZyBleGNoYW5nZS4gVGhlcmUncyBubyBjbGVhciB0b3BpYyB5ZXQs
-        IHNvIEkgd29uJ3QgbmFtZSB0aGUgc2Vzc2lvbiBvciBhY3RpdmF0ZSBhbnkg
-        c2tpbGxzIG9yIHdvcmtmbG93cy4gVGhlIGNvbnZlcnNhdGlvbiBoYXNuJ3Qg
-        ZXZvbHZlZCBlbm91Z2ggdG8gd2FycmFudCBhbnkgY29udGV4dCBtYW5hZ2Vt
-        ZW50LiJ9LHsidHlwZSI6InRvb2xfdXNlIiwiaWQiOiJ0b29sdV8wMVhKbVpn
-        NmtOdnpIQnZpOU5nVW9ZZWIiLCJuYW1lIjoiZXZlcnl0aGluZ19pc19yZWFk
-        eSIsImlucHV0Ijp7fSwiY2FsbGVyIjp7InR5cGUiOiJkaXJlY3QifX1dLCJz
-        dG9wX3JlYXNvbiI6InRvb2xfdXNlIiwic3RvcF9zZXF1ZW5jZSI6bnVsbCwi
-        dXNhZ2UiOnsiaW5wdXRfdG9rZW5zIjoyNTU1LCJjYWNoZV9jcmVhdGlvbl9p
-        bnB1dF90b2tlbnMiOjAsImNhY2hlX3JlYWRfaW5wdXRfdG9rZW5zIjowLCJj
-        YWNoZV9jcmVhdGlvbiI6eyJlcGhlbWVyYWxfNW1faW5wdXRfdG9rZW5zIjow
-        LCJlcGhlbWVyYWxfMWhfaW5wdXRfdG9rZW5zIjowfSwib3V0cHV0X3Rva2Vu
-        cyI6ODIsInNlcnZpY2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dl
-        byI6Im5vdF9hdmFpbGFibGUifX0=
-  recorded_at: Sun, 29 Mar 2026 08:47:37 GMT
+        Z18wMUJvaXo3ZFRqR3FDcGd3YVN6WGtZU20iLCJ0eXBlIjoibWVzc2FnZSIs
+        InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidG9vbF91
+        c2UiLCJpZCI6InRvb2x1XzAxR2V2dTFkc3NxNUVZOVhZR2RyNFBoYyIsIm5h
+        bWUiOiJldmVyeXRoaW5nX2lzX3JlYWR5IiwiaW5wdXQiOnt9LCJjYWxsZXIi
+        OnsidHlwZSI6ImRpcmVjdCJ9fV0sInN0b3BfcmVhc29uIjoidG9vbF91c2Ui
+        LCJzdG9wX3NlcXVlbmNlIjpudWxsLCJ1c2FnZSI6eyJpbnB1dF90b2tlbnMi
+        OjI0MzQsImNhY2hlX2NyZWF0aW9uX2lucHV0X3Rva2VucyI6MCwiY2FjaGVf
+        cmVhZF9pbnB1dF90b2tlbnMiOjAsImNhY2hlX2NyZWF0aW9uIjp7ImVwaGVt
+        ZXJhbF81bV9pbnB1dF90b2tlbnMiOjAsImVwaGVtZXJhbF8xaF9pbnB1dF90
+        b2tlbnMiOjB9LCJvdXRwdXRfdG9rZW5zIjozOSwic2VydmljZV90aWVyIjoi
+        c3RhbmRhcmQiLCJpbmZlcmVuY2VfZ2VvIjoibm90X2F2YWlsYWJsZSJ9fQ==
+  recorded_at: Sun, 29 Mar 2026 08:58:00 GMT
 - request:
     method: post
     uri: https://api.anthropic.com/v1/messages
@@ -199,10 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"The
         main session is working on this:\n```\nUser: Hello\nAssistant: Hi\n```\n\nReview
-        and take any needed actions, then call everything_is_ready."},{"role":"assistant","content":[{"type":"text","text":"The
-        session has just started with a greeting exchange. There''s no clear topic
-        yet, so I won''t name the session or activate any skills or workflows. The
-        conversation hasn''t evolved enough to warrant any context management."},{"type":"tool_use","id":"toolu_01XJmZg6kNvzHBvi9NgUoYeb","name":"everything_is_ready","input":{},"caller":{"type":"direct"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01XJmZg6kNvzHBvi9NgUoYeb","content":"Acknowledged.
+        and take any needed actions, then call everything_is_ready."},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01Gevu1dssq5EY9XYGdr4Phc","name":"everything_is_ready","input":{},"caller":{"type":"direct"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01Gevu1dssq5EY9XYGdr4Phc","content":"Acknowledged.
         No changes needed."}]}],"max_tokens":4096,"tools":[{"name":"rename_session","description":"Rename
         the session.","input_schema":{"type":"object","properties":{"emoji":{"type":"string"},"name":{"type":"string","description":"1-3
         words."},"timeout":{"type":"integer","description":"Seconds (default: 180)."}},"required":["emoji","name"]}},{"name":"activate_skill","description":"Give
@@ -248,46 +231,38 @@ http_interactions:
         finish with everything_is_ready.\nIf nothing needs attention, call it immediately.\n\n──────────────────────────────\nCURRENT
         STATE\n──────────────────────────────\nSession name: (unnamed)\nActive skills:
         None\nActive workflow: None\n\n──────────────────────────────\nAVAILABLE SKILLS\n──────────────────────────────\n-
-        activerecord — Associations, validations, queries, migrations, eager loading.
-        Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load,
-        callbacks, or editing app/models/ or db/migrate/.\n- dragonruby — 2D game
-        development — game loops, sprites, input, collisions, scenes. Activate when
-        building games with DRGTK, working with args.outputs/state/inputs, or editing
-        game files.\n- draper-decorators — Decorator patterns for Rails views — presentation
-        logic separated from models. Activate when creating or testing decorators,
-        moving formatting logic out of models/views, editing *_decorator.rb files,
-        or working in app/decorators/.\n- gh-issue — Issue writing with WHAT/WHY/HOW
-        framework. Activate when creating issues, writing tickets, drafting issue
-        descriptions, or when issues lack clear rationale.\n- mcp-server — Ruby server
-        development — tools, prompts, resources, transport. Activate when building
-        Model Context Protocol servers, defining MCP tools/prompts/resources, working
-        with the mcp gem, or discussing LLM tool integrations.\n- ratatui-ruby — Terminal
-        UI development — widgets, layouts, events, Tea MVU. Activate when building
-        TUI apps, working with terminal rendering, or editing TUI application files.\n-
-        rspec — Testing with FactoryBot — matchers, test doubles, shared examples.
-        Activate when writing specs, fixing failing tests, working with describe/it/expect
-        blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration
-        tests.\n\n──────────────────────────────\nAVAILABLE WORKFLOWS\n──────────────────────────────\n-
-        commit — Create focused git commits with user approval.\n- create_handoff
-        — Preserve current session''s context, decisions, and next steps so another
-        session can continue the work.\n- create_note — Persist findings, insights,
-        or decisions as a note in the thoughts system for future sessions.\n- create_plan
-        — For epics and multi-ticket efforts — research the problem space and design
-        a phased implementation strategy before writing code.\n- decompose_ticket
-        — Decompose a feature ticket into vertical slices — testable, deliverable
-        units ordered by dependency.\n- feature — Implement a GitHub issue end-to-end:
-        branch, research, code, test, commit, PR, self-review.\n- implement_plan —
-        Execute an approved implementation plan — work through each phase, verify
-        success criteria before moving on.\n- iterate_plan — Revise an existing implementation
-        plan based on feedback, new findings, or changed requirements.\n- research_codebase
-        — Deep-dive into a large or unfamiliar codebase — delegate research to parallel
-        specialists and synthesize findings.\n- resume_handoff — Continue work left
-        by a previous session — read its handoff, verify assumptions, and pick up
-        where it stopped.\n- review_pr — All PR review operations — review, re-review,
-        self-review, or address reviewer feedback.\n- thoughts_init — Bootstrap ./thoughts
-        for a new project that doesn''t have one yet.\n- validate_plan — Check whether
-        the implementation satisfies the plan — compare success criteria against what
-        was actually built.\n"}]}'
+        activerecord — Associations, validations, queries, migrations, eager loading,
+        N+1 queries, scopes, callbacks, app/models/, db/migrate/.\n- dragonruby —
+        2D game development — game loops, sprites, input, collisions, scenes, DRGTK,
+        args.outputs/state/inputs.\n- draper-decorators — Decorator patterns for Rails
+        views — presentation logic separated from models, *_decorator.rb, app/decorators/.\n-
+        gh-issue — Issue writing with WHAT/WHY/HOW framework — tickets, bug reports,
+        feature requests, issue descriptions, unclear rationale in existing issues.\n-
+        mcp-server — Ruby MCP server development — tools, prompts, resources, transport,
+        the mcp gem, LLM tool integrations.\n- ratatui-ruby — Terminal UI development
+        — widgets, layouts, events, Tea MVU, terminal rendering.\n- rspec — Testing
+        with FactoryBot — matchers, test doubles, shared examples, describe/it/expect
+        blocks, *_spec.rb files, test strategy.\n\n──────────────────────────────\nAVAILABLE
+        WORKFLOWS\n──────────────────────────────\n- commit — Create focused git commits
+        with user approval.\n- create_handoff — Preserve current session''s context,
+        decisions, and next steps so another session can continue the work.\n- create_note
+        — Persist findings, insights, or decisions as a note in the thoughts system
+        for future sessions.\n- create_plan — For epics and multi-ticket efforts —
+        research the problem space and design a phased implementation strategy before
+        writing code.\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\n- feature — Implement
+        a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review.\n-
+        implement_plan — Execute an approved implementation plan — work through each
+        phase, verify success criteria before moving on.\n- iterate_plan — Revise
+        an existing implementation plan based on feedback, new findings, or changed
+        requirements.\n- research_codebase — Deep-dive into a large or unfamiliar
+        codebase — delegate research to parallel specialists and synthesize findings.\n-
+        resume_handoff — Continue work left by a previous session — read its handoff,
+        verify assumptions, and pick up where it stopped.\n- review_pr — All PR review
+        operations — review, re-review, self-review, or address reviewer feedback.\n-
+        thoughts_init — Bootstrap ./thoughts for a new project that doesn''t have
+        one yet.\n- validate_plan — Check whether the implementation satisfies the
+        plan — compare success criteria against what was actually built.\n"}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"
@@ -309,7 +284,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:38 GMT
+      - Sun, 29 Mar 2026 08:58:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -323,13 +298,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -351,11 +326,11 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '550'
+      - '2156'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=551
+      - x-originResponse;dur=2158
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
@@ -370,14 +345,14 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMVVIRnhhbVBITkRCc3o5M2VNQUVwVEgiLCJ0eXBlIjoibWVzc2FnZSIs
+        Z18wMVZ0UEZWNXFEbmFnTjFZeUNlRDVLVzIiLCJ0eXBlIjoibWVzc2FnZSIs
         InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbXSwic3RvcF9yZWFzb24i
         OiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7Imlu
-        cHV0X3Rva2VucyI6MjY1NSwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
+        cHV0X3Rva2VucyI6MjQ5MSwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
         IjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRp
         b24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFs
         XzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjIsInNlcnZp
         Y2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dlbyI6Im5vdF9hdmFp
         bGFibGUifX0=
-  recorded_at: Sun, 29 Mar 2026 08:47:38 GMT
+  recorded_at: Sun, 29 Mar 2026 08:58:02 GMT
 recorded_with: VCR 6.4.0

--- a/spec/cassettes/AnalyticalBrain_Runner/default_client_configuration/uses_the_fast_model.yml
+++ b/spec/cassettes/AnalyticalBrain_Runner/default_client_configuration/uses_the_fast_model.yml
@@ -52,46 +52,38 @@ http_interactions:
         finish with everything_is_ready.\nIf nothing needs attention, call it immediately.\n\n──────────────────────────────\nCURRENT
         STATE\n──────────────────────────────\nSession name: (unnamed)\nActive skills:
         None\nActive workflow: None\n\n──────────────────────────────\nAVAILABLE SKILLS\n──────────────────────────────\n-
-        activerecord — Associations, validations, queries, migrations, eager loading.
-        Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load,
-        callbacks, or editing app/models/ or db/migrate/.\n- dragonruby — 2D game
-        development — game loops, sprites, input, collisions, scenes. Activate when
-        building games with DRGTK, working with args.outputs/state/inputs, or editing
-        game files.\n- draper-decorators — Decorator patterns for Rails views — presentation
-        logic separated from models. Activate when creating or testing decorators,
-        moving formatting logic out of models/views, editing *_decorator.rb files,
-        or working in app/decorators/.\n- gh-issue — Issue writing with WHAT/WHY/HOW
-        framework. Activate when creating issues, writing tickets, drafting issue
-        descriptions, or when issues lack clear rationale.\n- mcp-server — Ruby server
-        development — tools, prompts, resources, transport. Activate when building
-        Model Context Protocol servers, defining MCP tools/prompts/resources, working
-        with the mcp gem, or discussing LLM tool integrations.\n- ratatui-ruby — Terminal
-        UI development — widgets, layouts, events, Tea MVU. Activate when building
-        TUI apps, working with terminal rendering, or editing TUI application files.\n-
-        rspec — Testing with FactoryBot — matchers, test doubles, shared examples.
-        Activate when writing specs, fixing failing tests, working with describe/it/expect
-        blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration
-        tests.\n\n──────────────────────────────\nAVAILABLE WORKFLOWS\n──────────────────────────────\n-
-        commit — Create focused git commits with user approval.\n- create_handoff
-        — Preserve current session''s context, decisions, and next steps so another
-        session can continue the work.\n- create_note — Persist findings, insights,
-        or decisions as a note in the thoughts system for future sessions.\n- create_plan
-        — For epics and multi-ticket efforts — research the problem space and design
-        a phased implementation strategy before writing code.\n- decompose_ticket
-        — Decompose a feature ticket into vertical slices — testable, deliverable
-        units ordered by dependency.\n- feature — Implement a GitHub issue end-to-end:
-        branch, research, code, test, commit, PR, self-review.\n- implement_plan —
-        Execute an approved implementation plan — work through each phase, verify
-        success criteria before moving on.\n- iterate_plan — Revise an existing implementation
-        plan based on feedback, new findings, or changed requirements.\n- research_codebase
-        — Deep-dive into a large or unfamiliar codebase — delegate research to parallel
-        specialists and synthesize findings.\n- resume_handoff — Continue work left
-        by a previous session — read its handoff, verify assumptions, and pick up
-        where it stopped.\n- review_pr — All PR review operations — review, re-review,
-        self-review, or address reviewer feedback.\n- thoughts_init — Bootstrap ./thoughts
-        for a new project that doesn''t have one yet.\n- validate_plan — Check whether
-        the implementation satisfies the plan — compare success criteria against what
-        was actually built.\n"}]}'
+        activerecord — Associations, validations, queries, migrations, eager loading,
+        N+1 queries, scopes, callbacks, app/models/, db/migrate/.\n- dragonruby —
+        2D game development — game loops, sprites, input, collisions, scenes, DRGTK,
+        args.outputs/state/inputs.\n- draper-decorators — Decorator patterns for Rails
+        views — presentation logic separated from models, *_decorator.rb, app/decorators/.\n-
+        gh-issue — Issue writing with WHAT/WHY/HOW framework — tickets, bug reports,
+        feature requests, issue descriptions, unclear rationale in existing issues.\n-
+        mcp-server — Ruby MCP server development — tools, prompts, resources, transport,
+        the mcp gem, LLM tool integrations.\n- ratatui-ruby — Terminal UI development
+        — widgets, layouts, events, Tea MVU, terminal rendering.\n- rspec — Testing
+        with FactoryBot — matchers, test doubles, shared examples, describe/it/expect
+        blocks, *_spec.rb files, test strategy.\n\n──────────────────────────────\nAVAILABLE
+        WORKFLOWS\n──────────────────────────────\n- commit — Create focused git commits
+        with user approval.\n- create_handoff — Preserve current session''s context,
+        decisions, and next steps so another session can continue the work.\n- create_note
+        — Persist findings, insights, or decisions as a note in the thoughts system
+        for future sessions.\n- create_plan — For epics and multi-ticket efforts —
+        research the problem space and design a phased implementation strategy before
+        writing code.\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\n- feature — Implement
+        a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review.\n-
+        implement_plan — Execute an approved implementation plan — work through each
+        phase, verify success criteria before moving on.\n- iterate_plan — Revise
+        an existing implementation plan based on feedback, new findings, or changed
+        requirements.\n- research_codebase — Deep-dive into a large or unfamiliar
+        codebase — delegate research to parallel specialists and synthesize findings.\n-
+        resume_handoff — Continue work left by a previous session — read its handoff,
+        verify assumptions, and pick up where it stopped.\n- review_pr — All PR review
+        operations — review, re-review, self-review, or address reviewer feedback.\n-
+        thoughts_init — Bootstrap ./thoughts for a new project that doesn''t have
+        one yet.\n- validate_plan — Check whether the implementation satisfies the
+        plan — compare success criteria against what was actually built.\n"}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"
@@ -113,7 +105,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:52 GMT
+      - Sun, 29 Mar 2026 08:58:18 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -127,13 +119,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -155,11 +147,11 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '4214'
+      - '1738'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=4216
+      - x-originResponse;dur=1739
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
@@ -174,33 +166,23 @@ http_interactions:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMU5FejN0c2h3ell0U1p5VWV2eFNhTlEiLCJ0eXBlIjoibWVzc2FnZSIs
+        Z18wMUt2NFVqMWVMcTNvcXJSSlN6enRuOTkiLCJ0eXBlIjoibWVzc2FnZSIs
         InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbeyJ0eXBlIjoidGV4dCIs
-        InRleHQiOiJJJ2xsIHJldmlldyB0aGUgY3VycmVudCBzdGF0ZTpcblxuKipD
-        dXJyZW50IFNpdHVhdGlvbjoqKlxuLSBTZXNzaW9uIG5hbWU6ICh1bm5hbWVk
-        KVxuLSBBY3RpdmUgc2tpbGxzOiBOb25lXG4tIEFjdGl2ZSB3b3JrZmxvdzog
-        Tm9uZVxuLSBDb252ZXJzYXRpb246IEp1c3QgYSBzaW1wbGUgZ3JlZXRpbmcg
-        ZXhjaGFuZ2VcblxuKipBbmFseXNpczoqKlxuVGhlIGNvbnZlcnNhdGlvbiBp
-        cyBtaW5pbWFsIGFuZCBhdCBhbiBleHBsb3JhdG9yeSBzdGFnZS4gVGhlcmUn
-        cyBubyBjbGVhciB0b3BpYywgdGFzaywgb3IgZGlyZWN0aW9uIHlldCB0aGF0
-        IHdvdWxkIHdhcnJhbnQgbmFtaW5nIHRoZSBzZXNzaW9uLCBhY3RpdmF0aW5n
-        IHNraWxscywgb3Igc3RhcnRpbmcgYSB3b3JrZmxvdy4gVGhlIHVzZXIgaGFz
-        IG9ubHkgc2FpZCBcIkhlbGxvXCIgYW5kIHJlY2VpdmVkIGEgZ3JlZXRpbmcg
-        aW4gcmV0dXJuLlxuXG4qKkFjdGlvbjoqKlxuU2luY2UgdGhlcmUncyBub3Ro
-        aW5nIGNvbmNyZXRlIHRvIHdvcmsgb24geWV0IGFuZCBubyBjb250ZXh0IHRo
-        YXQgcmVxdWlyZXMgc2tpbGwgb3Igd29ya2Zsb3cgYWN0aXZhdGlvbiwgSSds
-        bCBzaWduYWwgdGhhdCB0aGUgc2Vzc2lvbiBpcyByZWFkeS4ifSx7InR5cGUi
-        OiJ0b29sX3VzZSIsImlkIjoidG9vbHVfMDFZU0V4U0pKMmlVWEN6dWNObVpT
-        ZFBnIiwibmFtZSI6ImV2ZXJ5dGhpbmdfaXNfcmVhZHkiLCJpbnB1dCI6e30s
-        ImNhbGxlciI6eyJ0eXBlIjoiZGlyZWN0In19XSwic3RvcF9yZWFzb24iOiJ0
-        b29sX3VzZSIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7ImlucHV0
-        X3Rva2VucyI6MjU1NSwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5zIjow
-        LCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRpb24i
-        OnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFsXzFo
-        X2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjE3Mywic2Vydmlj
-        ZV90aWVyIjoic3RhbmRhcmQiLCJpbmZlcmVuY2VfZ2VvIjoibm90X2F2YWls
-        YWJsZSJ9fQ==
-  recorded_at: Sun, 29 Mar 2026 08:47:52 GMT
+        InRleHQiOiJJJ2xsIHJldmlldyB0aGUgc2Vzc2lvbiBzdGF0ZS4gVGhlIGNv
+        bnZlcnNhdGlvbiBpcyBtaW5pbWFsIChcIkhlbGxvXCIgLyBcIkhpXCIpIHdp
+        dGggbm8gY2xlYXIgdG9waWMgb3IgaW50ZW50IHlldC4gVGhlcmUncyBub3Ro
+        aW5nIHRvIGNvbmZpZ3VyZSB1bnRpbCB0aGUgdXNlcidzIG5lZWRzIGJlY29t
+        ZSBhcHBhcmVudC4ifSx7InR5cGUiOiJ0b29sX3VzZSIsImlkIjoidG9vbHVf
+        MDFHRWVKZjViZERSQkQ1aExIZHFuUFp1IiwibmFtZSI6ImV2ZXJ5dGhpbmdf
+        aXNfcmVhZHkiLCJpbnB1dCI6e30sImNhbGxlciI6eyJ0eXBlIjoiZGlyZWN0
+        In19XSwic3RvcF9yZWFzb24iOiJ0b29sX3VzZSIsInN0b3Bfc2VxdWVuY2Ui
+        Om51bGwsInVzYWdlIjp7ImlucHV0X3Rva2VucyI6MjQzNCwiY2FjaGVfY3Jl
+        YXRpb25faW5wdXRfdG9rZW5zIjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2Vu
+        cyI6MCwiY2FjaGVfY3JlYXRpb24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rv
+        a2VucyI6MCwiZXBoZW1lcmFsXzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1
+        dF90b2tlbnMiOjc4LCJzZXJ2aWNlX3RpZXIiOiJzdGFuZGFyZCIsImluZmVy
+        ZW5jZV9nZW8iOiJub3RfYXZhaWxhYmxlIn19
+  recorded_at: Sun, 29 Mar 2026 08:58:18 GMT
 - request:
     method: post
     uri: https://api.anthropic.com/v1/messages
@@ -209,14 +191,9 @@ http_interactions:
       string: '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"The
         main session is working on this:\n```\nUser: Hello\nAssistant: Hi\n```\n\nReview
         and take any needed actions, then call everything_is_ready."},{"role":"assistant","content":[{"type":"text","text":"I''ll
-        review the current state:\n\n**Current Situation:**\n- Session name: (unnamed)\n-
-        Active skills: None\n- Active workflow: None\n- Conversation: Just a simple
-        greeting exchange\n\n**Analysis:**\nThe conversation is minimal and at an
-        exploratory stage. There''s no clear topic, task, or direction yet that would
-        warrant naming the session, activating skills, or starting a workflow. The
-        user has only said \"Hello\" and received a greeting in return.\n\n**Action:**\nSince
-        there''s nothing concrete to work on yet and no context that requires skill
-        or workflow activation, I''ll signal that the session is ready."},{"type":"tool_use","id":"toolu_01YSExSJJ2iUXCzucNmZSdPg","name":"everything_is_ready","input":{},"caller":{"type":"direct"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01YSExSJJ2iUXCzucNmZSdPg","content":"Acknowledged.
+        review the session state. The conversation is minimal (\"Hello\" / \"Hi\")
+        with no clear topic or intent yet. There''s nothing to configure until the
+        user''s needs become apparent."},{"type":"tool_use","id":"toolu_01GEeJf5bdDRBD5hLHdqnPZu","name":"everything_is_ready","input":{},"caller":{"type":"direct"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01GEeJf5bdDRBD5hLHdqnPZu","content":"Acknowledged.
         No changes needed."}]}],"max_tokens":4096,"tools":[{"name":"rename_session","description":"Rename
         the session.","input_schema":{"type":"object","properties":{"emoji":{"type":"string"},"name":{"type":"string","description":"1-3
         words."},"timeout":{"type":"integer","description":"Seconds (default: 180)."}},"required":["emoji","name"]}},{"name":"activate_skill","description":"Give
@@ -262,46 +239,38 @@ http_interactions:
         finish with everything_is_ready.\nIf nothing needs attention, call it immediately.\n\n──────────────────────────────\nCURRENT
         STATE\n──────────────────────────────\nSession name: (unnamed)\nActive skills:
         None\nActive workflow: None\n\n──────────────────────────────\nAVAILABLE SKILLS\n──────────────────────────────\n-
-        activerecord — Associations, validations, queries, migrations, eager loading.
-        Activate when working with models, database schema, N+1 queries, scopes, includes/preload/eager_load,
-        callbacks, or editing app/models/ or db/migrate/.\n- dragonruby — 2D game
-        development — game loops, sprites, input, collisions, scenes. Activate when
-        building games with DRGTK, working with args.outputs/state/inputs, or editing
-        game files.\n- draper-decorators — Decorator patterns for Rails views — presentation
-        logic separated from models. Activate when creating or testing decorators,
-        moving formatting logic out of models/views, editing *_decorator.rb files,
-        or working in app/decorators/.\n- gh-issue — Issue writing with WHAT/WHY/HOW
-        framework. Activate when creating issues, writing tickets, drafting issue
-        descriptions, or when issues lack clear rationale.\n- mcp-server — Ruby server
-        development — tools, prompts, resources, transport. Activate when building
-        Model Context Protocol servers, defining MCP tools/prompts/resources, working
-        with the mcp gem, or discussing LLM tool integrations.\n- ratatui-ruby — Terminal
-        UI development — widgets, layouts, events, Tea MVU. Activate when building
-        TUI apps, working with terminal rendering, or editing TUI application files.\n-
-        rspec — Testing with FactoryBot — matchers, test doubles, shared examples.
-        Activate when writing specs, fixing failing tests, working with describe/it/expect
-        blocks, editing *_spec.rb files, planning test strategy, or discussing unit/integration
-        tests.\n\n──────────────────────────────\nAVAILABLE WORKFLOWS\n──────────────────────────────\n-
-        commit — Create focused git commits with user approval.\n- create_handoff
-        — Preserve current session''s context, decisions, and next steps so another
-        session can continue the work.\n- create_note — Persist findings, insights,
-        or decisions as a note in the thoughts system for future sessions.\n- create_plan
-        — For epics and multi-ticket efforts — research the problem space and design
-        a phased implementation strategy before writing code.\n- decompose_ticket
-        — Decompose a feature ticket into vertical slices — testable, deliverable
-        units ordered by dependency.\n- feature — Implement a GitHub issue end-to-end:
-        branch, research, code, test, commit, PR, self-review.\n- implement_plan —
-        Execute an approved implementation plan — work through each phase, verify
-        success criteria before moving on.\n- iterate_plan — Revise an existing implementation
-        plan based on feedback, new findings, or changed requirements.\n- research_codebase
-        — Deep-dive into a large or unfamiliar codebase — delegate research to parallel
-        specialists and synthesize findings.\n- resume_handoff — Continue work left
-        by a previous session — read its handoff, verify assumptions, and pick up
-        where it stopped.\n- review_pr — All PR review operations — review, re-review,
-        self-review, or address reviewer feedback.\n- thoughts_init — Bootstrap ./thoughts
-        for a new project that doesn''t have one yet.\n- validate_plan — Check whether
-        the implementation satisfies the plan — compare success criteria against what
-        was actually built.\n"}]}'
+        activerecord — Associations, validations, queries, migrations, eager loading,
+        N+1 queries, scopes, callbacks, app/models/, db/migrate/.\n- dragonruby —
+        2D game development — game loops, sprites, input, collisions, scenes, DRGTK,
+        args.outputs/state/inputs.\n- draper-decorators — Decorator patterns for Rails
+        views — presentation logic separated from models, *_decorator.rb, app/decorators/.\n-
+        gh-issue — Issue writing with WHAT/WHY/HOW framework — tickets, bug reports,
+        feature requests, issue descriptions, unclear rationale in existing issues.\n-
+        mcp-server — Ruby MCP server development — tools, prompts, resources, transport,
+        the mcp gem, LLM tool integrations.\n- ratatui-ruby — Terminal UI development
+        — widgets, layouts, events, Tea MVU, terminal rendering.\n- rspec — Testing
+        with FactoryBot — matchers, test doubles, shared examples, describe/it/expect
+        blocks, *_spec.rb files, test strategy.\n\n──────────────────────────────\nAVAILABLE
+        WORKFLOWS\n──────────────────────────────\n- commit — Create focused git commits
+        with user approval.\n- create_handoff — Preserve current session''s context,
+        decisions, and next steps so another session can continue the work.\n- create_note
+        — Persist findings, insights, or decisions as a note in the thoughts system
+        for future sessions.\n- create_plan — For epics and multi-ticket efforts —
+        research the problem space and design a phased implementation strategy before
+        writing code.\n- decompose_ticket — Decompose a feature ticket into vertical
+        slices — testable, deliverable units ordered by dependency.\n- feature — Implement
+        a GitHub issue end-to-end: branch, research, code, test, commit, PR, self-review.\n-
+        implement_plan — Execute an approved implementation plan — work through each
+        phase, verify success criteria before moving on.\n- iterate_plan — Revise
+        an existing implementation plan based on feedback, new findings, or changed
+        requirements.\n- research_codebase — Deep-dive into a large or unfamiliar
+        codebase — delegate research to parallel specialists and synthesize findings.\n-
+        resume_handoff — Continue work left by a previous session — read its handoff,
+        verify assumptions, and pick up where it stopped.\n- review_pr — All PR review
+        operations — review, re-review, self-review, or address reviewer feedback.\n-
+        thoughts_init — Bootstrap ./thoughts for a new project that doesn''t have
+        one yet.\n- validate_plan — Check whether the implementation satisfies the
+        plan — compare success criteria against what was actually built.\n"}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"
@@ -323,7 +292,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 29 Mar 2026 08:47:53 GMT
+      - Sun, 29 Mar 2026 08:58:19 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -337,13 +306,13 @@ http_interactions:
       Anthropic-Ratelimit-Unified-5h-Reset:
       - '1774782000'
       Anthropic-Ratelimit-Unified-5h-Utilization:
-      - '0.53'
+      - '0.55'
       Anthropic-Ratelimit-Unified-7d-Status:
       - allowed
       Anthropic-Ratelimit-Unified-7d-Reset:
       - '1775196000'
       Anthropic-Ratelimit-Unified-7d-Utilization:
-      - '0.44'
+      - '0.45'
       Anthropic-Ratelimit-Unified-Representative-Claim:
       - five_hour
       Anthropic-Ratelimit-Unified-Fallback-Percentage:
@@ -365,33 +334,33 @@ http_interactions:
       Server:
       - cloudflare
       X-Envoy-Upstream-Service-Time:
-      - '709'
+      - '1299'
       Vary:
       - Accept-Encoding
       Server-Timing:
-      - x-originResponse;dur=714
-      Set-Cookie:
-      - "<CLOUDFLARE_COOKIE>"
-      X-Robots-Tag:
-      - none
+      - x-originResponse;dur=1300
       Cf-Cache-Status:
       - DYNAMIC
+      Set-Cookie:
+      - "<CLOUDFLARE_COOKIE>"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
+      X-Robots-Tag:
+      - none
       Cf-Ray:
       - "<CF_RAY>"
     body:
       encoding: ASCII-8BIT
       base64_string: |
         eyJtb2RlbCI6ImNsYXVkZS1oYWlrdS00LTUtMjAyNTEwMDEiLCJpZCI6Im1z
-        Z18wMUh4N3pRendCQ0tFZnc1NFJWMUFXcE4iLCJ0eXBlIjoibWVzc2FnZSIs
+        Z18wMVNGTVNpZDk4dmtpclBlOU5Xb3dFYm0iLCJ0eXBlIjoibWVzc2FnZSIs
         InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjpbXSwic3RvcF9yZWFzb24i
         OiJlbmRfdHVybiIsInN0b3Bfc2VxdWVuY2UiOm51bGwsInVzYWdlIjp7Imlu
-        cHV0X3Rva2VucyI6Mjc0NiwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
+        cHV0X3Rva2VucyI6MjUzMCwiY2FjaGVfY3JlYXRpb25faW5wdXRfdG9rZW5z
         IjowLCJjYWNoZV9yZWFkX2lucHV0X3Rva2VucyI6MCwiY2FjaGVfY3JlYXRp
         b24iOnsiZXBoZW1lcmFsXzVtX2lucHV0X3Rva2VucyI6MCwiZXBoZW1lcmFs
         XzFoX2lucHV0X3Rva2VucyI6MH0sIm91dHB1dF90b2tlbnMiOjIsInNlcnZp
         Y2VfdGllciI6InN0YW5kYXJkIiwiaW5mZXJlbmNlX2dlbyI6Im5vdF9hdmFp
         bGFibGUifX0=
-  recorded_at: Sun, 29 Mar 2026 08:47:53 GMT
+  recorded_at: Sun, 29 Mar 2026 08:58:19 GMT
 recorded_with: VCR 6.4.0

--- a/spec/lib/analytical_brain/runner_spec.rb
+++ b/spec/lib/analytical_brain/runner_spec.rb
@@ -96,19 +96,6 @@ RSpec.describe AnalyticalBrain::Runner do
         expect(captured_opts[:system]).to include("gh-issue")
       end
 
-      it "frames skill activation as predictive, not reactive" do
-        captured_opts = nil
-        allow(client).to receive(:chat_with_tools) { |_msgs, **opts|
-          captured_opts = opts
-          "Done"
-        }
-
-        runner.call
-
-        expect(captured_opts[:system]).to include("signals intent")
-        expect(captured_opts[:system]).to include("before the agent acts")
-      end
-
       it "includes currently active skills in system prompt" do
         Skills::Registry.reload!
         session.activate_skill("gh-issue")


### PR DESCRIPTION
## Summary

- Shift skill management prompt from reactive ("when the conversation enters their domain") to predictive ("when the conversation signals intent — before the agent acts on it")
- Add consequence line: "Late activation means the agent works without domain knowledge" — gives the brain a reason to be aggressive about early activation
- Reframe all 7 skill frontmatter descriptions: drop "Activate when..." instructions, list domain coverage instead

## Why two changes?

The prompt tells the brain *how* to activate (on intent signals). The descriptions tell it *what* each skill covers (matching surface). Both were reactive — the prompt waited for domain evidence, and the descriptions embedded activation instructions in data. Now the prompt is predictive and the descriptions are pure domain catalogs.

## Prompting-bible principles applied

- **P1 (Say only what the agent doesn't know):** Skill descriptions no longer re-instruct the brain to activate — it already knows that's its job
- **P4 (Intent over mechanics):** "signals intent" replaces "enters their domain"
- **P6 (Consequences beat constraints):** consequence line explains cost of late activation
- **P9 (Each component owns its description):** descriptions describe domain, prompt describes behavior — no mixing

## Context

The analytical brain's blocking architecture was already designed for predictive activation (~200ms Haiku call blocks before the main agent responds). But the prompt wording was reactive — "when" triggers on evidence the agent is already in a domain. The duck-historian incident (#346-#349) showed four issues filed without `gh-issue` skill because the brain waited for domain evidence instead of acting on intent signals.

Closes #350

## Test plan

- [x] All 74 analytical brain + skills specs pass
- [x] VCR cassettes re-recorded with updated prompt and catalog text
- [x] standardrb clean
- [x] reek clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)