### PR TITLE
#347 fix: Label parent→child messages with origin attribution

### DIFF
--- a/lib/events/subscribers/subagent_message_router.rb
+++ b/lib/events/subscribers/subagent_message_router.rb
@@ -14,7 +14,8 @@ module Events
     #
     # **Parent → Child:** When a parent agent emits an {Events::AgentMessage}
     # containing `@name` mentions, the router persists the message in each
-    # matching child session and wakes them via {AgentRequestJob}.
+    # matching child session with a +[from parent]:+ origin label and wakes
+    # them via {AgentRequestJob}.
     #
     # Both directions delegate to {Session#enqueue_user_message}, which
     # respects the target session's processing state — persisting directly
@@ -27,6 +28,10 @@ module Events
 
       # @see Tools::ResponseTruncator::ATTRIBUTION_FORMAT
       ATTRIBUTION_FORMAT = Tools::ResponseTruncator::ATTRIBUTION_FORMAT
+
+      # Origin label for messages routed from parent agent to sub-agent.
+      # Lets the sub-agent distinguish delegated work from direct user input.
+      PARENT_ATTRIBUTION_FORMAT = "[from parent]: %s"
 
       # Regex to extract @mention names from parent agent messages.
       MENTION_PATTERN = /@(\w[\w-]*)/
@@ -82,7 +87,7 @@ module Events
       end
 
       # Scans a parent agent's message for @mentions and routes the message
-      # to each mentioned child session.
+      # to each mentioned child session with origin attribution.
       #
       # @param parent [Session] the parent session
       # @param content [String] the parent agent's message text
@@ -93,11 +98,13 @@ module Events
         active_children = parent.child_sessions.where.not(name: nil).index_by(&:name)
         return if active_children.empty?
 
+        attributed = format(PARENT_ATTRIBUTION_FORMAT, content)
+
         mentioned_names.each do |name|
           child = active_children[name]
           next unless child
 
-          child.enqueue_user_message(content)
+          child.enqueue_user_message(attributed)
         end
       end
     end

--- a/spec/lib/events/subscribers/subagent_message_router_spec.rb
+++ b/spec/lib/events/subscribers/subagent_message_router_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Events::Subscribers::SubagentMessageRouter do
     let!(:child_a) { Session.create!(parent_session: parent, prompt: "sub-agent", name: "loop-sleuth") }
     let!(:child_b) { Session.create!(parent_session: parent, prompt: "sub-agent", name: "api-scout") }
 
-    it "routes @mention to the matching child session" do
+    it "routes @mention to the matching child session with parent attribution" do
       event = Events::AgentMessage.new(
         content: "@loop-sleuth Check the edit tool next.",
         session_id: parent.id
@@ -108,7 +108,8 @@ RSpec.describe Events::Subscribers::SubagentMessageRouter do
 
       child_msg = child_a.messages.find_by(message_type: "user_message")
       expect(child_msg).to be_present
-      expect(child_msg.payload["content"]).to include("Check the edit tool next.")
+      expect(child_msg.payload["content"])
+        .to eq("[from parent]: @loop-sleuth Check the edit tool next.")
     end
 
     it "routes to multiple mentioned children" do
@@ -169,7 +170,7 @@ RSpec.describe Events::Subscribers::SubagentMessageRouter do
     context "when child is processing" do
       before { child_a.update!(processing: true) }
 
-      it "creates a PendingMessage on the child session" do
+      it "creates a PendingMessage with parent attribution" do
         event = Events::AgentMessage.new(
           content: "@loop-sleuth Check the edit tool next.",
           session_id: parent.id
@@ -178,7 +179,7 @@ RSpec.describe Events::Subscribers::SubagentMessageRouter do
 
         pm = child_a.pending_messages.last
         expect(pm).to be_present
-        expect(pm.content).to include("Check the edit tool next.")
+        expect(pm.content).to eq("[from parent]: @loop-sleuth Check the edit tool next.")
       end
 
       it "does not enqueue AgentRequestJob" do


### PR DESCRIPTION
## Summary

- Add `[from parent]:` prefix to messages routed from parent agent to sub-agent via @mentions
- Sub-agents can now distinguish delegated parent messages from direct user input
- Mirrors the existing `[sub-agent @name]:` attribution on the child→parent direction

## Design (prompting-bible principles applied)

The prefix `[from parent]:` was chosen over alternatives like `[from @parent]:` to avoid confusion with @mentions. The sub-agent only has one parent — the role label is sufficient without a name. Direct user messages remain unlabeled, making the distinction binary: prefixed = parent, unprefixed = user.

## Test plan

- [x] Existing parent→child routing specs updated to verify attribution format
- [x] PendingMessage path verified with attribution
- [x] All 19 specs pass
- [x] standardrb clean
- [x] reek clean

Closes #347