### PR TITLE
#369 fix: Decouple connection status from session loading

### DIFF
--- a/lib/tui/screens/chat.rb
+++ b/lib/tui/screens/chat.rb
@@ -49,6 +49,11 @@ module TUI
       # independent of Rails. Must stay in sync when adding new modes.
       VIEW_MODES = %w[basic verbose debug].freeze
 
+      # @!attribute [r] session_loading
+      #   Whether the TUI is waiting for session history to arrive from the server.
+      #   Independent of cable_client.status (transport) and session_state (LLM processing).
+      #   Set on subscribing/session_changed/view_mode_changed; cleared on first content
+      #   message or connection failure. Drives the "Loading…" input title and yellow border.
       attr_reader :message_store, :scroll_offset, :session_info, :view_mode, :sessions_list,
         :authentication_required, :token_save_result, :parent_session_id,
         :chat_focused, :session_state, :spinner, :session_loading
@@ -425,7 +430,9 @@ module TUI
         new_id = msg["session_id"]
         @cable_client.update_session_id(new_id)
         @message_store.clear
-        @session_loading = true
+        # Only enter loading state when the session has messages to replay.
+        # Empty sessions send no history events, so the flag would never clear.
+        @session_loading = (msg["message_count"] || 0) > 0
         @view_mode = msg["view_mode"] if msg["view_mode"]
         @session_info = {id: new_id, name: msg["name"], agent_name: msg["agent_name"] || "Anima",
                          message_count: msg["message_count"] || 0,
@@ -541,7 +548,9 @@ module TUI
 
         @view_mode = new_mode
         @message_store.clear
-        @session_loading = true
+        # Only enter loading state when there are messages to re-decorate.
+        # Empty sessions send no viewport events after a mode change.
+        @session_loading = (@session_info[:message_count] || 0) > 0
         update_session_state("idle")
         @scroll_offset = 0
         @auto_scroll = true
@@ -1100,6 +1109,10 @@ module TUI
       # Returns the input field title reflecting the current transport and
       # session state. Only shows "Disconnected" when the WebSocket is
       # truly down — not during the subscribe handshake or session loading.
+      #
+      # :connected (pre-subscription) still shows "Connecting…" because
+      # the user can't interact until the Action Cable subscription handshake
+      # completes and the server starts streaming events.
       def input_title
         case @cable_client.status
         when :disconnected

--- a/spec/lib/tui/screens/chat_spec.rb
+++ b/spec/lib/tui/screens/chat_spec.rb
@@ -1353,11 +1353,36 @@ RSpec.describe TUI::Screens::Chat do
       expect(screen.session_loading).to be false
     end
 
-    it "sets session_loading on view_mode_changed" do
+    it "sets session_loading on view_mode_changed when session has messages" do
+      screen.instance_variable_get(:@session_info)[:message_count] = 5
       msg = {"action" => "view_mode_changed", "view_mode" => "verbose"}
       allow(cable_client).to receive(:drain_messages).and_return([msg])
       screen.send(:process_incoming_messages)
       expect(screen.session_loading).to be true
+    end
+
+    it "skips session_loading on view_mode_changed for empty sessions" do
+      screen.instance_variable_get(:@session_info)[:message_count] = 0
+      msg = {"action" => "view_mode_changed", "view_mode" => "verbose"}
+      allow(cable_client).to receive(:drain_messages).and_return([msg])
+      screen.send(:process_incoming_messages)
+      expect(screen.session_loading).to be false
+    end
+
+    it "skips session_loading for empty sessions on session_changed" do
+      msg = {"action" => "session_changed", "session_id" => 99, "message_count" => 0}
+      allow(cable_client).to receive(:drain_messages).and_return([msg])
+      screen.send(:process_incoming_messages)
+      expect(screen.session_loading).to be false
+    end
+
+    it "clears session_loading through full subscribing → message flow" do
+      subscribing = {"type" => "connection", "status" => "subscribing"}
+      session_changed = {"action" => "session_changed", "session_id" => 99, "message_count" => 2}
+      history_msg = {"type" => "user_message", "content" => "hello"}
+      allow(cable_client).to receive(:drain_messages).and_return([subscribing, session_changed, history_msg])
+      screen.send(:process_incoming_messages)
+      expect(screen.session_loading).to be false
     end
 
     it "starts as false" do


### PR DESCRIPTION
## Summary

- **Input title now reflects actual WebSocket state**: "Disconnected" only appears when the WebSocket is truly down. During the subscribe handshake it shows "Connecting…", during reconnection "Reconnecting…", and during session history loading "Loading…".
- **New `@session_loading` flag** tracks session history loading separately from connection status. Set on session_changed, subscribing, and view_mode_changed; cleared when content messages arrive or connection fails.
- **Chat area loading indicator**: `render_empty_or_loading` shows a yellow "Loading session…" message during session loads, distinct from both the processing spinner and the empty-session prompt.
- **Render loop audit**: No blocking I/O found. Full report: `thoughts/shared/notes/2026-03-29/tui-render-loop-blocking-io-audit.md`. TL;DR — all network I/O runs in CableClient's background thread via `Thread::Queue`; the main thread only performs non-blocking queue drains, in-memory state mutations, and CPU-bound FFI rendering calls.

Closes #369

## Test plan

- [ ] Verify `input_title` specs pass (6 examples covering all cable states + session loading)
- [ ] Verify `session_loading` lifecycle specs pass (8 examples: subscribing, session_changed, content arrival, disconnected, failed, view_mode_changed)
- [ ] Full chat spec suite passes (229 examples)
- [ ] Smoke test: start TUI, observe "Connecting…" during initial handshake (not "Disconnected")
- [ ] Smoke test: switch sessions, observe "Loading…" in input and yellow indicator in empty chat
- [ ] Smoke test: kill brain server, observe "Disconnected" only when WebSocket is actually down

🤖 Generated with [Claude Code](https://claude.com/claude-code)