### PR TITLE
#411 feat: Direct sub-agent navigation from HUD panel via arrow keys

### DIFF
--- a/lib/tui/app.rb
+++ b/lib/tui/app.rb
@@ -21,7 +21,7 @@ module TUI
     }.freeze
 
     MENU_LABELS = (COMMAND_KEYS.map { |key, action| "[#{key}] #{action.to_s.tr("_", " ").capitalize}" } +
-      ["[\u2191] Scroll chat", "[\u2193] Return to input", "[\u2192] Scroll HUD"]).freeze
+      ["[\u2191] Scroll chat", "[\u2193] Return to input", "[\u2192] Sub-agents / HUD"]).freeze
 
     # HUD occupies 1/3 of screen width, clamped to a usable minimum.
     HUD_MIN_WIDTH = 24
@@ -88,6 +88,8 @@ module TUI
     attr_reader :hud_visible
     # @return [Boolean] true when the HUD pane has keyboard focus for scrolling
     attr_reader :hud_focused
+    # @return [Integer, nil] index of selected child in HUD navigation, nil when inactive
+    attr_reader :hud_child_index
     # @return [Boolean] true when the token setup popup overlay is visible
     attr_reader :token_setup_active
     # @return [Boolean] true when graceful shutdown has been requested via signal
@@ -109,6 +111,7 @@ module TUI
       @session_picker_parent_id = nil
       @hud_visible = true
       @hud_focused = false
+      @hud_child_index = nil
       @hud_scroll_offset = 0
       @hud_max_scroll = 0
       @hud_visible_height = 0
@@ -418,25 +421,37 @@ module TUI
     end
 
     # Builds the sub-agents section with activity indicators.
+    # Highlights the selected child when HUD child navigation is active.
     # @return [Array<RatatuiRuby::Widgets::Line>, nil]
     def hud_children_section(tui, session)
       children = session[:children]
       return if children.nil? || children.empty?
 
+      header_label = @hud_child_index ? "Sub-agents [\u2190 back]" : "Sub-agents"
+
       lines = [
         tui.line(spans: [tui.span(content: "")]),
         tui.line(spans: [
-          tui.span(content: "\u{1F465} Sub-agents", style: tui.style(fg: "dark_gray"))
+          tui.span(content: "\u{1F465} #{header_label}", style: tui.style(fg: "dark_gray"))
         ])
       ]
 
-      children.each do |child|
+      children.each_with_index do |child, idx|
         icon, color = child_icon_and_color(child)
         name = child["name"] || "sub-agent"
-        lines << tui.line(spans: [
-          tui.span(content: "  #{icon} ", style: tui.style(fg: color)),
-          tui.span(content: "@#{name}", style: tui.style(fg: "white"))
-        ])
+        selected = idx == @hud_child_index
+
+        lines << if selected
+          tui.line(spans: [
+            tui.span(content: "\u25B8 #{icon} ", style: tui.style(fg: "cyan")),
+            tui.span(content: "@#{name}", style: tui.style(fg: "cyan", modifiers: [:bold]))
+          ])
+        else
+          tui.line(spans: [
+            tui.span(content: "  #{icon} ", style: tui.style(fg: color)),
+            tui.span(content: "@#{name}", style: tui.style(fg: "white"))
+          ])
+        end
       end
 
       lines
@@ -674,20 +689,34 @@ module TUI
       @screens[:chat].loading?
     end
 
-    # Switches keyboard focus to the HUD pane for scrolling.
-    # Unfocuses the chat pane if it was focused.
+    # Switches keyboard focus to the HUD pane.
+    # When children exist, enters child navigation mode with the first
+    # child selected; otherwise enters plain scroll mode.
     #
     # @return [void]
     def focus_hud
       @screens[:chat].unfocus_chat if @screens[:chat].chat_focused
       @hud_focused = true
+      children = hud_children
+      if children.any?
+        @hud_child_index = 0
+        @hud_scroll_offset = @hud_max_scroll
+      end
     end
 
-    # Returns keyboard focus from the HUD pane.
+    # Returns keyboard focus from the HUD pane and exits child navigation.
     #
     # @return [void]
     def unfocus_hud
       @hud_focused = false
+      @hud_child_index = nil
+    end
+
+    # Returns the current session's child sessions (sub-agents).
+    #
+    # @return [Array<Hash>] child session hashes, empty when none
+    def hud_children
+      @screens[:chat].session_info[:children] || []
     end
 
     # Scrolls the HUD viewport up, clamping at the top.
@@ -808,7 +837,10 @@ module TUI
     end
 
     # Handles keyboard events when the HUD pane has focus.
-    # Arrow keys and Page Up/Down scroll the HUD; Escape and Ctrl+A exit.
+    # When a child is selected (child navigation mode), arrow keys move
+    # between sub-agents and Enter switches to the selected session.
+    # Otherwise, arrow keys and Page Up/Down scroll the HUD content.
+    # Escape and Ctrl+A always exit HUD focus.
     def handle_hud_focused_event(event)
       return nil if event.none?
       return :quit if event.ctrl_c?
@@ -826,6 +858,36 @@ module TUI
         return nil
       end
 
+      if @hud_child_index
+        handle_hud_child_navigation(event)
+      else
+        handle_hud_scroll(event)
+      end
+      nil
+    end
+
+    # Navigates between sub-agent entries in the HUD.
+    # Up/Down move selection, Enter switches to the selected session,
+    # Left exits child navigation back to scroll mode.
+    def handle_hud_child_navigation(event)
+      children = hud_children
+      return if children.empty?
+
+      if event.up?
+        @hud_child_index = [@hud_child_index - 1, 0].max
+      elsif event.down?
+        @hud_child_index = [@hud_child_index + 1, children.size - 1].min
+      elsif event.left?
+        @hud_child_index = nil
+      elsif event.enter?
+        child = children[@hud_child_index]
+        @screens[:chat].switch_session(child["id"]) if child
+        unfocus_hud
+      end
+    end
+
+    # Scrolls the HUD viewport with arrow/page keys.
+    def handle_hud_scroll(event)
       if event.up?
         scroll_hud_up(HUD_SCROLL_STEP)
       elsif event.down?
@@ -839,7 +901,6 @@ module TUI
       elsif event.end?
         scroll_hud_down(@hud_max_scroll)
       end
-      nil
     end
 
     # Routes mouse scroll events to the HUD when the cursor is over the HUD area.

--- a/spec/lib/tui/app_spec.rb
+++ b/spec/lib/tui/app_spec.rb
@@ -689,6 +689,129 @@ RSpec.describe TUI::App do
       end
     end
 
+    describe "HUD child navigation" do
+      let(:chat) { app.instance_variable_get(:@screens)[:chat] }
+      let(:children) do
+        [
+          {"id" => 101, "name" => "api-scout", "session_state" => "llm_generating"},
+          {"id" => 102, "name" => "loop-sleuth", "session_state" => "idle"},
+          {"id" => 103, "name" => "test-fixer", "session_state" => "tool_executing"}
+        ]
+      end
+
+      before do
+        chat.instance_variable_get(:@session_info)[:children] = children
+        allow(chat).to receive(:switch_session)
+      end
+
+      describe "entering child navigation via command mode" do
+        before { app.instance_variable_set(:@command_mode, true) }
+
+        it "enters child navigation mode on right arrow when children exist" do
+          app.send(:handle_event, key_event(code: "right"))
+
+          expect(app.hud_focused).to be true
+          expect(app.hud_child_index).to eq(0)
+        end
+
+        it "enters plain scroll mode on right arrow when no children" do
+          chat.instance_variable_get(:@session_info)[:children] = []
+
+          app.send(:handle_event, key_event(code: "right"))
+
+          expect(app.hud_focused).to be true
+          expect(app.hud_child_index).to be_nil
+        end
+
+        it "scrolls HUD to bottom to reveal sub-agents" do
+          app.instance_variable_set(:@hud_max_scroll, 15)
+
+          app.send(:handle_event, key_event(code: "right"))
+
+          expect(app.instance_variable_get(:@hud_scroll_offset)).to eq(15)
+        end
+      end
+
+      describe "navigating between children" do
+        before do
+          app.instance_variable_set(:@command_mode, true)
+          app.send(:handle_event, key_event(code: "right"))
+        end
+
+        it "moves selection down" do
+          app.send(:handle_event, key_event(code: "down"))
+          expect(app.hud_child_index).to eq(1)
+        end
+
+        it "moves selection up" do
+          app.send(:handle_event, key_event(code: "down"))
+          app.send(:handle_event, key_event(code: "up"))
+          expect(app.hud_child_index).to eq(0)
+        end
+
+        it "clamps at first child" do
+          app.send(:handle_event, key_event(code: "up"))
+          expect(app.hud_child_index).to eq(0)
+        end
+
+        it "clamps at last child" do
+          2.times { app.send(:handle_event, key_event(code: "down")) }
+          app.send(:handle_event, key_event(code: "down"))
+          expect(app.hud_child_index).to eq(2)
+        end
+      end
+
+      describe "selecting a child" do
+        before do
+          app.instance_variable_set(:@command_mode, true)
+          app.send(:handle_event, key_event(code: "right"))
+        end
+
+        it "switches to selected child session on Enter" do
+          app.send(:handle_event, key_event(code: "down"))
+          app.send(:handle_event, key_event(code: "enter"))
+
+          expect(chat).to have_received(:switch_session).with(102)
+          expect(app.hud_focused).to be false
+          expect(app.hud_child_index).to be_nil
+        end
+
+        it "switches to first child by default" do
+          app.send(:handle_event, key_event(code: "enter"))
+
+          expect(chat).to have_received(:switch_session).with(101)
+        end
+      end
+
+      describe "exiting child navigation" do
+        before do
+          app.instance_variable_set(:@command_mode, true)
+          app.send(:handle_event, key_event(code: "right"))
+        end
+
+        it "exits child navigation on Escape" do
+          app.send(:handle_event, key_event(code: "esc"))
+
+          expect(app.hud_focused).to be false
+          expect(app.hud_child_index).to be_nil
+        end
+
+        it "exits child navigation on left arrow back to scroll mode" do
+          app.send(:handle_event, key_event(code: "left"))
+
+          expect(app.hud_focused).to be true
+          expect(app.hud_child_index).to be_nil
+        end
+
+        it "exits child navigation on Ctrl+A" do
+          app.send(:handle_event, key_event(code: "a", modifiers: ["ctrl"]))
+
+          expect(app.hud_focused).to be false
+          expect(app.hud_child_index).to be_nil
+        end
+      end
+    end
+
     describe "Escape routing" do
       it "unfocuses chat pane on Escape when chat is focused" do
         chat = app.instance_variable_get(:@screens)[:chat]
@@ -1596,6 +1719,41 @@ RSpec.describe TUI::App do
         children = [{"id" => 1, "name" => nil, "processing" => false}]
         result = app.send(:hud_children_section, tui, {children: children})
         expect(result[2][:spans][1][:content]).to eq("@sub-agent")
+      end
+
+      it "highlights selected child in navigation mode" do
+        app.instance_variable_set(:@hud_child_index, 0)
+        children = [
+          {"id" => 1, "name" => "api-scout", "session_state" => "llm_generating"},
+          {"id" => 2, "name" => "loop-sleuth", "session_state" => "idle"}
+        ]
+        result = app.send(:hud_children_section, tui, {children: children})
+
+        selected_spans = result[2][:spans]
+        expect(selected_spans[0][:content]).to include("\u25B8") # ▸ pointer
+        expect(selected_spans[0][:style][:fg]).to eq("cyan")
+        expect(selected_spans[1][:content]).to eq("@api-scout")
+        expect(selected_spans[1][:style][:fg]).to eq("cyan")
+
+        unselected_spans = result[3][:spans]
+        expect(unselected_spans[1][:style][:fg]).to eq("white")
+      end
+
+      it "shows back hint in header during navigation mode" do
+        app.instance_variable_set(:@hud_child_index, 0)
+        children = [{"id" => 1, "name" => "scout", "session_state" => "idle"}]
+        result = app.send(:hud_children_section, tui, {children: children})
+
+        header_spans = result[1][:spans]
+        expect(header_spans[0][:content]).to include("\u2190 back")
+      end
+
+      it "omits back hint when not in navigation mode" do
+        children = [{"id" => 1, "name" => "scout", "session_state" => "idle"}]
+        result = app.send(:hud_children_section, tui, {children: children})
+
+        header_spans = result[1][:spans]
+        expect(header_spans[0][:content]).not_to include("\u2190")
       end
     end
 


### PR DESCRIPTION
## Summary

- **Ctrl+A → → → Enter** switches to a sub-agent in 3 actions (down from 6)
- When children exist, right arrow in command mode enters child navigation mode with first sub-agent selected
- Up/Down move between sub-agents, Enter switches session, Left returns to scroll mode, Esc exits
- Selected child highlighted in cyan with ▸ pointer; header shows ← back hint

Closes #411

## Test plan

- [ ] Verify `Ctrl+A → →` enters child navigation when sub-agents exist
- [ ] Verify `Ctrl+A → →` enters plain scroll mode when no sub-agents
- [ ] Verify Up/Down arrows navigate between sub-agents
- [ ] Verify Enter switches to the selected sub-agent session
- [ ] Verify Left arrow exits child navigation back to scroll mode
- [ ] Verify Esc exits HUD focus entirely
- [ ] Verify selected child is visually highlighted (cyan + bold + ▸)
- [ ] Verify existing HUD scrolling still works when no children

🤖 Generated with [Claude Code](https://claude.com/claude-code)