### PR TITLE
#417 fix: seed env snapshot at shell startup to suppress redundant context footer

### DIFF
--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -447,11 +447,13 @@ class ShellSession
   end
 
   # Captures the initial environment snapshot so the first real Bash call
-  # can diff against the actual shell state instead of a blank sentinel.
-  # Without this, every first call in a new turn would report the full
-  # location as "changed" because EnvironmentSnapshot.blank has pwd: nil.
+  # can diff against the actual shell state rather than a blank sentinel
+  # whose nil pwd would always trigger a "location changed" report.
   #
-  # Called at the end of {#start} after the PTY is initialized and @pwd is set.
+  # Sets {#env_snapshot} to a real snapshot of the current pwd, git branch,
+  # repo, and project files. Called within {#start} after {#update_pwd}
+  # and before the session is marked alive.
+  #
   # @return [void]
   def seed_env_snapshot
     @env_snapshot = take_env_snapshot(EnvironmentSnapshot.blank)
@@ -461,7 +463,7 @@ class ShellSession
   # of what changed since the last snapshot. The agent discovers its
   # environment through these summaries in Bash tool responses.
   #
-  # Subsequent calls only mention what changed. Returns nil when nothing did.
+  # Each call only mentions what changed. Returns nil when nothing did.
   #
   # @return [String, nil] human-readable summary of environment changes
   def update_environment

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -230,52 +230,88 @@ RSpec.describe ShellSession do
   end
 
   describe "environment tracking" do
-    it "omits env_summary on first command when environment matches startup state" do
-      result = shell.run("echo hello")
-      expect(result[:env_summary]).to be_nil
-    end
+    describe "seed_env_snapshot" do
+      it "sets @env_snapshot to real startup state on initialization" do
+        # seed_env_snapshot runs inside start(), called by initialize
+        snapshot = shell.send(:instance_variable_get, :@env_snapshot)
+        expect(snapshot).to be_a(EnvironmentSnapshot)
+        expect(snapshot.pwd).to eq(shell.pwd)
+        expect(snapshot.pwd).not_to be_nil
+      end
 
-    it "returns env_summary when directory changes" do
-      result = shell.run("cd /tmp")
-      expect(result[:env_summary]).to include("You are now in /tmp")
-    end
+      it "is idempotent — calling twice preserves the same state" do
+        snap_before = shell.send(:instance_variable_get, :@env_snapshot)
+        shell.send(:seed_env_snapshot)
+        snap_after = shell.send(:instance_variable_get, :@env_snapshot)
+        expect(snap_after.pwd).to eq(snap_before.pwd)
+        expect(snap_after.branch).to eq(snap_before.branch)
+        expect(snap_after.repo).to eq(snap_before.repo)
+      end
 
-    it "omits env_summary when nothing changes" do
-      shell.run("cd /tmp")
-      result = shell.run("echo hello")
-      expect(result[:env_summary]).to be_nil
-    end
-
-    it "reports branch change without directory change" do
-      Dir.mktmpdir do |tmpdir|
-        shell.run("cd #{tmpdir}")
-        shell.run("git init && git config user.name Test && git config user.email test@test.com && git commit --allow-empty -m init")
-        branch = "test-branch-#{SecureRandom.hex(4)}"
-        result = shell.run("git checkout -b #{branch}")
-        expect(result[:env_summary]).to include("Branch changed to #{branch}.")
+      it "captures nil branch and repo outside a git repo" do
+        Dir.mktmpdir do |tmpdir|
+          non_git_shell = described_class.new(session_id: "non-git-test")
+          non_git_shell.run("cd #{Shellwords.shellescape(tmpdir)}")
+          # Re-seed after cd to capture non-git state
+          non_git_shell.send(:seed_env_snapshot)
+          snapshot = non_git_shell.send(:instance_variable_get, :@env_snapshot)
+          expect(snapshot.branch).to be_nil
+          expect(snapshot.repo).to be_nil
+        ensure
+          non_git_shell&.finalize
+        end
       end
     end
 
-    it "reports project files on first visit to a directory" do
-      Dir.mktmpdir do |tmpdir|
-        File.write(File.join(tmpdir, "CLAUDE.md"), "# Test")
-        result = shell.run("cd #{tmpdir}")
-        expect(result[:env_summary]).to include("Project has instructions in CLAUDE.md")
+    describe "env_summary in tool responses" do
+      it "returns nil when first command does not change environment" do
+        # pwd matches the seeded snapshot — no footer expected
+        result = shell.run("echo hello")
+        expect(result[:env_summary]).to be_nil
       end
-    end
 
-    it "does not include env_summary on error" do
-      result = shell.run("exit 1")
-      expect(result).to have_key(:error)
-      expect(result).not_to have_key(:env_summary)
-    end
+      it "reports location when directory changes" do
+        result = shell.run("cd /tmp")
+        expect(result[:env_summary]).to include("You are now in /tmp")
+      end
 
-    it "does not include env_summary on interrupt" do
-      checker = -> { true }
-      allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
-      result = shell.run("sleep 30", interrupt_check: checker)
-      expect(result[:interrupted]).to be true
-      expect(result).not_to have_key(:env_summary)
+      it "returns nil on subsequent command when environment is unchanged" do
+        shell.run("cd /tmp") # changes env — footer emitted (discarded here)
+        result = shell.run("echo hello")
+        expect(result[:env_summary]).to be_nil
+      end
+
+      it "reports branch change without directory change" do
+        Dir.mktmpdir do |tmpdir|
+          shell.run("cd #{Shellwords.shellescape(tmpdir)}")
+          shell.run("git init && git config user.name Test && git config user.email test@test.com && git commit --allow-empty -m init")
+          branch = "test-branch-#{SecureRandom.hex(4)}"
+          result = shell.run("git checkout -b #{branch}")
+          expect(result[:env_summary]).to include("Branch changed to #{branch}.")
+        end
+      end
+
+      it "reports project files on first visit to a directory" do
+        Dir.mktmpdir do |tmpdir|
+          File.write(File.join(tmpdir, "CLAUDE.md"), "# Test")
+          result = shell.run("cd #{Shellwords.shellescape(tmpdir)}")
+          expect(result[:env_summary]).to include("Project has instructions in CLAUDE.md")
+        end
+      end
+
+      it "returns nil on error" do
+        result = shell.run("exit 1")
+        expect(result).to have_key(:error)
+        expect(result).not_to have_key(:env_summary)
+      end
+
+      it "returns nil on interrupt" do
+        checker = -> { true }
+        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
+        result = shell.run("sleep 30", interrupt_check: checker)
+        expect(result[:interrupted]).to be true
+        expect(result).not_to have_key(:env_summary)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

The bash tool's environment context footer appeared on **every** invocation, even when nothing changed. Each user message creates a new `AgentRequestJob` → new `AgentLoop` → new `ShellSession` → `@env_snapshot = nil`. The first bash call diffed against `EnvironmentSnapshot.blank` (where `pwd: nil`), so any real pwd ≠ nil → full footer every time.

## Solution

Seed `@env_snapshot` during `ShellSession#start` by calling `take_env_snapshot(EnvironmentSnapshot.blank)` right after `update_pwd`. The first bash call now diffs against the actual shell startup state instead of a blank sentinel, so the footer only appears when the command actually changes the environment.

## Changes

- **`lib/shell_session.rb`**: Added `seed_env_snapshot` method called at the end of `start`. Captures initial pwd/branch/repo/project_files so subsequent diffs are accurate.
- **`spec/lib/shell_session_spec.rb`**: Updated environment tracking tests — first call from same directory now correctly omits the footer. Removed unnecessary warmup calls.

## Test plan

- `bundle exec rspec spec/lib/shell_session_spec.rb` — 45 examples, 0 failures
- `bundle exec rspec spec/lib/tools/bash_spec.rb` — 37 examples, 0 failures
- `bundle exec rspec spec/lib/agent_loop_spec.rb` — 39 examples, 0 failures

Closes #417

---
🧬 Built by [Ani](https://github.com/hoblin/anima) (anima-core v1.3.0)