### PR TITLE
#419 fix: Assemble tool pairs by tool_use_id, not message order

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -996,7 +996,6 @@ class Session < ApplicationRecord
   # @return [Array<Hash>] Anthropic API message format
   def assemble_messages(msgs)
     response_index = build_tool_response_index(msgs)
-    consumed_response_ids = Set.new
 
     result = []
     i = 0
@@ -1011,10 +1010,10 @@ class Session < ApplicationRecord
         result << {role: "assistant", content: msg.payload["content"].to_s}
         i += 1
       when "tool_call"
-        i = assemble_tool_pair(msgs, i, response_index, consumed_response_ids, result)
+        i = assemble_tool_pair(msgs, i, response_index, result)
       when "tool_response"
         # Already emitted by assemble_tool_pair via tool_use_id lookup.
-        # Any unconsumed response here was orphaned by viewport eviction
+        # Any response still here was orphaned by viewport eviction
         # and should have been stripped by ensure_atomic_tool_pairs.
         i += 1
       when "system_message"
@@ -1032,8 +1031,12 @@ class Session < ApplicationRecord
   # emits one assistant message with all tool_use blocks, then emits one
   # user message with matching tool_result blocks found by tool_use_id.
   #
+  # @param msgs [Array<Message>] the full message list
+  # @param start [Integer] index of the first tool_call in the batch
+  # @param response_index [Hash{String => Message}] tool_use_id → tool_response
+  # @param result [Array<Hash>] accumulator for assembled API messages
   # @return [Integer] index of the first message after the batch
-  def assemble_tool_pair(msgs, start, response_index, consumed_response_ids, result)
+  def assemble_tool_pair(msgs, start, response_index, result)
     # Collect consecutive tool_calls (same LLM turn)
     batch = []
     i = start
@@ -1049,7 +1052,6 @@ class Session < ApplicationRecord
     tool_results = batch.filter_map do |tc|
       response = response_index[tc.tool_use_id]
       next unless response
-      consumed_response_ids << response.tool_use_id
       tool_result_block(response.payload)
     end
     result << {role: "user", content: tool_results} if tool_results.any?

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1312,7 +1312,7 @@ RSpec.describe Session do
         ])
       end
 
-      it "pairs correctly when a non-tool message is interleaved between calls and responses" do
+      it "pairs correctly when tool responses are separated by an agent message" do
         session.messages.create!(
           message_type: "tool_call",
           payload: {"tool_name" => "bash", "tool_input" => {},
@@ -1325,17 +1325,20 @@ RSpec.describe Session do
                     "tool_use_id" => "toolu_b"},
           tool_use_id: "toolu_b", timestamp: 2
         )
-        # A system message lands between calls and responses (e.g. sub-agent delivery)
-        session.messages.create!(
-          message_type: "system_message",
-          payload: {"content" => "MCP: server connected"},
-          timestamp: 3
-        )
+        # Response for toolu_b arrives first
         session.messages.create!(
           message_type: "tool_response",
-          payload: {"content" => "ok", "tool_use_id" => "toolu_b"},
-          tool_use_id: "toolu_b", timestamp: 4
+          payload: {"content" => "page B", "tool_use_id" => "toolu_b"},
+          tool_use_id: "toolu_b", timestamp: 3
         )
+        # An agent message lands between the two tool responses
+        # (e.g. a sub-agent delivery promoted into the conversation)
+        session.messages.create!(
+          message_type: "agent_message",
+          payload: {"content" => "Processing..."},
+          timestamp: 4
+        )
+        # Response for toolu_a arrives last
         session.messages.create!(
           message_type: "tool_response",
           payload: {"content" => "done", "tool_use_id" => "toolu_a"},
@@ -1344,15 +1347,19 @@ RSpec.describe Session do
 
         result = session.messages_for_llm
 
-        # Tool pair is assembled correctly despite interleaving
+        # Tool pair is assembled correctly: calls batched, results paired by ID
         expect(result[0][:role]).to eq("assistant")
-        expect(result[0][:content].length).to eq(2)
+        expect(result[0][:content]).to eq([
+          {type: "tool_use", id: "toolu_a", name: "bash", input: {}},
+          {type: "tool_use", id: "toolu_b", name: "web_get", input: {}}
+        ])
         expect(result[1][:role]).to eq("user")
-        expect(result[1][:content].length).to eq(2)
-        expect(result[1][:content][0][:tool_use_id]).to eq("toolu_a")
-        expect(result[1][:content][1][:tool_use_id]).to eq("toolu_b")
-        # System message follows the tool pair
-        expect(result[2]).to eq({role: "user", content: "[system] MCP: server connected"})
+        expect(result[1][:content]).to eq([
+          {type: "tool_result", tool_use_id: "toolu_a", content: "done"},
+          {type: "tool_result", tool_use_id: "toolu_b", content: "page B"}
+        ])
+        # Agent message follows the tool pair (not interleaved into it)
+        expect(result[2]).to eq({role: "assistant", content: "Processing..."})
       end
 
       it "handles multiple separate tool rounds with interleaved agent responses" do


### PR DESCRIPTION
## Problem

When the LLM issues parallel tool calls, the tool responses may be persisted out of order — interleaved with promoted pending messages, sub-agent deliveries, or other agent turns. The previous `assemble_messages` relied on consecutive same-role grouping by database ID order, so out-of-order responses produced invalid API payloads:

```
✘ Message not delivered: Bad request: messages.177: `tool_use` ids were found
without `tool_result` blocks immediately after
```

This was a session-breaking error requiring manual DB intervention.

## Solution

Rewrote `assemble_messages` to pair tool calls with their responses by `tool_use_id` lookup instead of relying on message order.

### How it works

1. **Build response index**: Pre-build a `{tool_use_id → tool_response}` hash for O(1) lookup
2. **Batch consecutive tool_calls**: When a `tool_call` is encountered, collect all consecutive `tool_call` messages (same LLM turn) into a batch
3. **Emit paired messages**: One assistant message with all `tool_use` blocks, followed by one user message with matching `tool_result` blocks found by `tool_use_id`
4. **Skip consumed responses**: `tool_response` messages encountered later in the walk are skipped (already emitted with their call)

### What changed

| Before | After |
|--------|-------|
| `append_grouped_block` merges by consecutive same-role | `assemble_tool_pair` pairs by `tool_use_id` lookup |
| Response order must match call order | Response order is irrelevant |
| Interleaved messages break pairing | Interleaved messages are handled correctly |

### What stayed

- `ensure_atomic_tool_pairs` — still needed for viewport-eviction protection (token budget can split pairs)
- `tool_use_block` / `tool_result_block` — unchanged serializers

## Test plan

- ✅ All 222 existing session specs pass (no regressions)
- ✅ New: reversed response order → correct pairing
- ✅ New: interleaved system message between calls and responses → correct pairing
- ✅ New: multi-round conversation with parallel tools and reversed responses

## Closes #419