### PR TITLE
#422 fix: viewport eviction wipes entire sliding window instead of first third

### DIFF
--- a/lib/mneme/compressed_viewport.rb
+++ b/lib/mneme/compressed_viewport.rb
@@ -52,10 +52,14 @@ module Mneme
     private
 
     # Fetches messages within token budget, starting from from_message_id.
-    # Selects newest-first until budget exhausted, returns chronological.
+    # Walks oldest-first from the boundary so Mneme processes the eviction
+    # zone (oldest messages) rather than the recent zone. This ensures
+    # {Mneme::Runner#advance_boundary} advances past only the oldest third,
+    # preserving recent conversation context in the main viewport.
+    #
     # Caches per-message token costs in @message_costs for reuse by split_into_zones.
     #
-    # @return [Array<Message>]
+    # @return [Array<Message>] chronologically ordered (oldest first)
     def fetch_messages
       scope = @session.messages.context_messages
 
@@ -67,7 +71,7 @@ module Mneme
       @message_costs = {}
       remaining = @token_budget
 
-      scope.reorder(id: :desc).each do |message|
+      scope.reorder(id: :asc).each do |message|
         cost = message_token_cost(message)
         break if cost > remaining && selected.any?
 
@@ -76,7 +80,7 @@ module Mneme
         remaining -= cost
       end
 
-      selected.reverse
+      selected
     end
 
     # Splits messages into three zones by token count.

--- a/spec/lib/mneme/compressed_viewport_spec.rb
+++ b/spec/lib/mneme/compressed_viewport_spec.rb
@@ -154,20 +154,40 @@ RSpec.describe Mneme::CompressedViewport do
   end
 
   describe "token budget" do
-    it "respects the token budget when selecting events" do
+    it "respects the token budget, selecting oldest messages first" do
       10.times do |i|
         create_message(type: "user_message", content: "message #{i}", token_count: 1000)
       end
 
-      # Budget for 3 events (3000 tokens)
+      # Budget for 3 events (3000 tokens) — walks oldest-first from boundary
       viewport = described_class.new(session, token_budget: 3000)
       result = viewport.render
 
-      # Should include recent events but not all
-      expect(result).to include("message 9")
-      expect(result).to include("message 8")
-      expect(result).to include("message 7")
-      expect(result).not_to include("message 0")
+      # Should include oldest events (eviction zone) — not newest
+      expect(result).to include("message 0")
+      expect(result).to include("message 1")
+      expect(result).to include("message 2")
+      expect(result).not_to include("message 9")
+    end
+
+    it "selects oldest messages from boundary, not newest (regression: #422)" do
+      # Simulate a long session: 10 messages at 1000 tokens each.
+      # Mneme viewport budget = 3000 (fits 3 messages).
+      # Boundary at the first message.
+      messages = 10.times.map do |i|
+        create_message(type: "user_message", content: "message #{i}", token_count: 1000)
+      end
+
+      viewport = described_class.new(
+        session,
+        token_budget: 3000,
+        from_message_id: messages.first.id
+      )
+
+      # Should select the 3 oldest messages from boundary, not the 3 newest
+      selected_ids = viewport.messages.map(&:id)
+      expect(selected_ids).to eq(messages[0..2].map(&:id))
+      expect(selected_ids).not_to include(messages.last.id)
     end
   end
 

--- a/spec/lib/mneme/integration_spec.rb
+++ b/spec/lib/mneme/integration_spec.rb
@@ -233,4 +233,84 @@ RSpec.describe "Mneme terminal event trigger integration" do
       expect(section_after).to include("L2 meta-summary of all three")
     end
   end
+
+  describe "eviction preserves recent sliding window (regression: #422)" do
+    let(:client) { instance_double(LLM::Client) }
+    # Budget holds 9 messages. Mneme viewport = 33% = 3 messages.
+    # After eviction, the oldest 3 should be gone, newest 6+ should remain.
+    let(:budget) { 9000 }
+    let(:event_size) { 1000 }
+
+    before do
+      allow(Anima::Settings).to receive(:token_budget).and_return(budget)
+      allow(Anima::Settings).to receive(:mneme_pinned_budget_fraction).and_return(0.0)
+    end
+
+    it "evicts only the oldest third, not the entire sliding window" do
+      # Create 12 conversation messages (exceeds budget of 9).
+      # Main viewport (newest-first, budget 9000) shows messages 4-12.
+      # Boundary at message 1.
+      msgs = 12.times.map do |i|
+        type = i.even? ? "user_message" : "agent_message"
+        create_message(type: type, content: "msg #{i}", token_count: event_size)
+      end
+
+      session.update_column(:mneme_boundary_message_id, msgs[0].id)
+      session.recalculate_viewport!
+
+      # Boundary (msg 0) has left the main viewport — Mneme triggers
+      expect(session.viewport_message_ids).not_to include(msgs[0].id)
+
+      # Mneme runs — compressed viewport walks oldest-first from boundary,
+      # fits 3 messages (33% of 9000 = 2970, rounds to 3 × 1000).
+      allow(client).to receive(:chat_with_tools) { |_msgs, **opts|
+        opts[:registry].execute("save_snapshot", {"text" => "Summary of msgs 0-2"})
+        "Done"
+      }
+
+      Mneme::Runner.new(session, client: client).call
+      session.reload
+
+      # Boundary should advance past the eviction zone (~msg 3), NOT past msg 11
+      expect(session.mneme_boundary_message_id).to be <= msgs[3].id
+
+      # Main viewport should still contain recent messages
+      llm_messages = session.messages_for_llm
+      message_texts = llm_messages.flat_map { |m|
+        content = m[:content]
+        content.is_a?(String) ? [content] : []
+      }
+
+      # Recent messages must be present — the sliding window was NOT wiped
+      expect(message_texts.any? { |t| t.include?("msg 11") }).to be(true),
+        "Expected msg 11 in viewport but sliding window was wiped. " \
+        "Boundary at #{session.mneme_boundary_message_id}, " \
+        "viewport IDs: #{session.viewport_message_ids}"
+
+      expect(message_texts.any? { |t| t.include?("msg 10") }).to be(true)
+      expect(message_texts.any? { |t| t.include?("msg 9") }).to be(true)
+    end
+
+    it "boundary advances by roughly one-third of the viewport, not to the end" do
+      msgs = 12.times.map do |i|
+        type = i.even? ? "user_message" : "agent_message"
+        create_message(type: type, content: "msg #{i}", token_count: event_size)
+      end
+
+      session.update_column(:mneme_boundary_message_id, msgs[0].id)
+
+      allow(client).to receive(:chat_with_tools) { "Done" }
+
+      Mneme::Runner.new(session, client: client).call
+      session.reload
+
+      new_boundary = session.mneme_boundary_message_id
+      # Boundary should be near the start (after evicting ~3 messages),
+      # not near the end (msg 11 or later)
+      expect(new_boundary).to be <= msgs[4].id,
+        "Boundary jumped to #{new_boundary} (msg ids: #{msgs.map(&:id).join(", ")}). " \
+        "Expected it near msg #{msgs[3].id} after evicting ~3 messages."
+      expect(new_boundary).to be > msgs[0].id
+    end
+  end
 end


### PR DESCRIPTION
## Problem

During long sessions, viewport eviction removed ALL messages from the sliding window, leaving only the system prompt + memory snapshot + tools + one last assistant message. The entire conversation history disappeared.

## Root Cause

`CompressedViewport#fetch_messages` walked messages **newest-first** (`scope.reorder(id: :desc)`). With a 33% token budget, this selected the most recent third of the conversation. `Mneme::Runner#advance_boundary` then advanced the boundary past those recent messages, setting `mneme_boundary_message_id` near the end of the session. Since `own_message_scope` filters `id >= mneme_boundary_message_id`, the main viewport could only see 1-2 messages after the boundary — wiping the entire sliding window.

## Fix

Changed `fetch_messages` to walk **oldest-first** (`scope.reorder(id: :asc)`) and removed the now-unnecessary `selected.reverse`. Mneme now processes the true eviction zone (oldest 1/3 from boundary), `advance_boundary` jumps past only that zone, and the main viewport retains the recent 2/3 of conversation history.

**One-line fix** with clear mechanical impact:
- `id: :desc` → `id: :asc` (walk direction)
- Remove `selected.reverse` (already chronological)

## Verification

Confirmed by codebase-analyzer that:
- CompressedViewport is only consumed by Mneme::Runner (no other callers)
- `split_into_zones` requires chronological order (preserved by fix)
- `build_registry` first/last pointers become correct (eviction zone, not recent zone)
- `advance_boundary` fallback still works (reverse_each on chronological array)
- Snapshot range pointers become semantically correct
- Mneme trigger logic is unaffected (checks main viewport, not CompressedViewport)

## Tests

- Updated existing token budget spec to expect oldest-first selection
- Added regression test: budget-limited viewport selects oldest from boundary, not newest
- Added integration test: full eviction cycle preserves recent sliding window (2 scenarios)

All 103 Mneme specs pass. Lint clean.

Closes #422