### PR TITLE
#439 feat: PendingMessage kind enum + message_type routing

### DIFF
--- a/app/models/pending_message.rb
+++ b/app/models/pending_message.rb
@@ -16,8 +16,15 @@
 # goal events) become synthetic tool_use/tool_result pairs so the LLM sees
 # "a tool I invoked returned a result" rather than "a user wrote me."
 #
+# Also classifies itself for the event-driven drain pipeline via +kind+
+# (+active+ triggers the drain loop, +background+ enriches context
+# silently) and +message_type+ (selects which pipeline event to emit on
+# create).
+#
 # @see Session#enqueue_user_message
 # @see Session#promote_pending_messages!
+# @see Events::StartMneme
+# @see Events::StartProcessing
 class PendingMessage < ApplicationRecord
   # Phantom tool names follow the `from_<sender>` convention: the prefix
   # tells the LLM these are messages delivered to it by its sisters or
@@ -53,13 +60,38 @@ class PendingMessage < ApplicationRecord
     "goal" => ->(name) { {goal_id: name.to_i} }
   }.freeze
 
+  # The LLM-role classification used by the event-driven drain pipeline.
+  # Distinct from +source_type+ (origin of the pending message): this
+  # describes what the promoted message will become in the LLM conversation.
+  MESSAGE_TYPES = %w[user_message think tool_call tool_response subagent from_mneme from_melete].freeze
+
+  # Routes active message types to the event that begins the drain pipeline.
+  # +user_message+ and +think+ enrich context first (Mneme → Melete →
+  # Processing); everything else bypasses enrichment and goes straight to
+  # the drain loop.
+  MESSAGE_TYPE_ROUTES = {
+    "user_message" => Events::StartMneme,
+    "think" => Events::StartMneme,
+    "tool_call" => Events::StartProcessing,
+    "tool_response" => Events::StartProcessing,
+    "subagent" => Events::StartProcessing
+  }.freeze
+
   belongs_to :session
+
+  # +background+: recalled memories and activated skills/workflows — they
+  # enrich context silently and never start the drain pipeline.
+  # +active+: user input, tool traffic, sub-agent replies — they trigger
+  # the drain loop when the session is idle.
+  enum :kind, {background: "background", active: "active"}
 
   validates :content, presence: true
   validates :source_type, inclusion: {in: %w[user subagent skill workflow recall goal]}
   validates :source_name, presence: true, unless: :user?
+  validates :message_type, inclusion: {in: MESSAGE_TYPES}, allow_nil: true
 
   after_create_commit :broadcast_created
+  after_create_commit :route_to_event_bus
   after_destroy_commit :broadcast_removed
 
   # @return [Boolean] true when this is a plain user message
@@ -190,5 +222,20 @@ class PendingMessage < ApplicationRecord
       "action" => "pending_message_removed",
       "pending_message_id" => id
     })
+  end
+
+  # Emits the event that kicks off the drain pipeline for active messages
+  # landing on an idle session. Background messages never trigger; active
+  # messages landing mid-drain queue silently — the running drain will
+  # pick them up. Legacy callers that don't set +message_type+ are a no-op
+  # until #440/#441/#442/#443 migrate them.
+  def route_to_event_bus
+    return unless active?
+    return unless session.idle?
+
+    event_class = MESSAGE_TYPE_ROUTES[message_type]
+    return unless event_class
+
+    Events::Bus.emit(event_class.new(session_id: session_id, pending_message_id: id))
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -21,7 +21,7 @@ class Session < ApplicationRecord
   # - +no_direct_assignment: true+ blocks +session.aasm_state = ...+, forcing
   #   every transition through a named event so guards always run.
   aasm whiny_transitions: false, no_direct_assignment: true do
-    after_all_transitions :emit_state_change
+    after_all_events :emit_state_change
 
     state :idle, initial: true
     state :awaiting
@@ -530,9 +530,11 @@ class Session < ApplicationRecord
     })
   end
 
-  # AASM after_all_transitions callback — publishes
+  # AASM after_all_events callback — publishes
   # {Events::SessionStateChanged} so the broadcaster subscriber can keep
   # the TUI spinner and parent-session HUD in sync with the state machine.
+  # Fires after the state column is updated and persisted, so +aasm_state+
+  # reliably holds the post-transition value.
   #
   # @return [void]
   def emit_state_change

--- a/db/migrate/20260418150323_add_kind_and_message_type_to_pending_messages.rb
+++ b/db/migrate/20260418150323_add_kind_and_message_type_to_pending_messages.rb
@@ -1,0 +1,6 @@
+class AddKindAndMessageTypeToPendingMessages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :pending_messages, :kind, :string, default: "active", null: false
+    add_column :pending_messages, :message_type, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,53 +1,46 @@
-CREATE TABLE "secrets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "key" varchar NOT NULL, "namespace" varchar NOT NULL, "updated_at" datetime(6) NOT NULL, "value" text NOT NULL);
-CREATE UNIQUE INDEX "index_secrets_on_namespace_and_key" ON "secrets" ("namespace", "key");
-CREATE TABLE "goals" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "completed_at" datetime(6), "created_at" datetime(6) NOT NULL, "description" text NOT NULL, "evicted_at" datetime(6), "parent_goal_id" integer, "session_id" integer NOT NULL, "status" varchar DEFAULT 'active' NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_feeb9df31e"
-FOREIGN KEY ("parent_goal_id")
-  REFERENCES "goals" ("id")
-, CONSTRAINT "fk_rails_874b7534ae"
-FOREIGN KEY ("session_id")
-  REFERENCES "sessions" ("id")
-);
-CREATE INDEX "index_goals_on_parent_goal_id" ON "goals" ("parent_goal_id");
-CREATE INDEX "index_goals_on_session_id_and_status" ON "goals" ("session_id", "status");
-CREATE INDEX "index_goals_on_session_id" ON "goals" ("session_id");
-CREATE TABLE "pending_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "content" text NOT NULL, "created_at" datetime(6) NOT NULL, "session_id" integer NOT NULL, "source_name" varchar, "source_type" varchar DEFAULT 'user' NOT NULL, "updated_at" datetime(6) NOT NULL, "kind" varchar DEFAULT 'active' NOT NULL, "message_type" varchar, CONSTRAINT "fk_rails_007242365b"
-FOREIGN KEY ("session_id")
-  REFERENCES "sessions" ("id")
-);
-CREATE INDEX "index_pending_messages_on_session_id" ON "pending_messages" ("session_id");
 CREATE TABLE "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
 CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE TABLE "messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "api_metrics" json, "created_at" datetime(6) NOT NULL, "message_type" varchar NOT NULL, "payload" json DEFAULT '{}' NOT NULL, "session_id" integer NOT NULL, "status" varchar, "timestamp" integer(8) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "tool_use_id" varchar, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_1ee2a92df0"
+CREATE TABLE "goals" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "parent_goal_id" integer, "description" text NOT NULL, "status" varchar DEFAULT 'active' NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "completed_at" datetime(6), "evicted_at" datetime(6), CONSTRAINT "fk_rails_874b7534ae"
+FOREIGN KEY ("session_id")
+  REFERENCES "sessions" ("id")
+, CONSTRAINT "fk_rails_feeb9df31e"
+FOREIGN KEY ("parent_goal_id")
+  REFERENCES "goals" ("id")
+);
+CREATE INDEX "index_goals_on_session_id" ON "goals" ("session_id");
+CREATE INDEX "index_goals_on_parent_goal_id" ON "goals" ("parent_goal_id");
+CREATE INDEX "index_goals_on_session_id_and_status" ON "goals" ("session_id", "status");
+CREATE TABLE "messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "message_type" varchar NOT NULL, "payload" json DEFAULT '{}' NOT NULL, "timestamp" integer(8) NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "tool_use_id" varchar, "status" varchar, "api_metrics" json, CONSTRAINT "fk_rails_1ee2a92df0"
 FOREIGN KEY ("session_id")
   REFERENCES "sessions" ("id")
 );
 CREATE INDEX "index_messages_on_session_id_and_status" ON "messages" ("session_id", "status");
-CREATE INDEX "index_messages_on_session_id" ON "messages" ("session_id");
 CREATE INDEX "index_messages_on_tool_use_id" ON "messages" ("tool_use_id");
+CREATE INDEX "index_messages_on_session_id" ON "messages" ("session_id");
 CREATE INDEX "index_messages_on_message_type" ON "messages" ("message_type");
 CREATE INDEX "index_messages_on_session_id_and_message_type" ON "messages" ("session_id", "message_type");
-CREATE TABLE "pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "display_text" text NOT NULL, "message_id" integer NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, CONSTRAINT "fk_rails_4a5f237c43"
+CREATE TABLE "pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "message_id" integer NOT NULL, "display_text" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, CONSTRAINT "fk_rails_4a5f237c43"
 FOREIGN KEY ("message_id")
   REFERENCES "messages" ("id")
 );
 CREATE UNIQUE INDEX "index_pinned_messages_on_message_id" ON "pinned_messages" ("message_id");
-CREATE TABLE "goal_pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "goal_id" integer NOT NULL, "pinned_message_id" integer NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_689fd4bf8a"
-FOREIGN KEY ("goal_id")
-  REFERENCES "goals" ("id")
-, CONSTRAINT "fk_rails_fb51bfeebe"
+CREATE TABLE "goal_pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "goal_id" integer NOT NULL, "pinned_message_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_fb51bfeebe"
 FOREIGN KEY ("pinned_message_id")
   REFERENCES "pinned_messages" ("id")
+, CONSTRAINT "fk_rails_689fd4bf8a"
+FOREIGN KEY ("goal_id")
+  REFERENCES "goals" ("id")
 );
 CREATE INDEX "index_goal_pinned_messages_on_goal_id" ON "goal_pinned_messages" ("goal_id");
-CREATE UNIQUE INDEX "index_goal_pinned_messages_on_goal_id_and_pinned_message_id" ON "goal_pinned_messages" ("goal_id", "pinned_message_id");
 CREATE INDEX "index_goal_pinned_messages_on_pinned_message_id" ON "goal_pinned_messages" ("pinned_message_id");
-CREATE TABLE "snapshots" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "from_message_id" integer NOT NULL, "level" integer DEFAULT 1 NOT NULL, "session_id" integer NOT NULL, "text" text NOT NULL, "to_message_id" integer NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_eb2ad51db9"
+CREATE UNIQUE INDEX "index_goal_pinned_messages_on_goal_id_and_pinned_message_id" ON "goal_pinned_messages" ("goal_id", "pinned_message_id");
+CREATE TABLE "snapshots" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "text" text NOT NULL, "from_message_id" integer NOT NULL, "to_message_id" integer NOT NULL, "level" integer DEFAULT 1 NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_eb2ad51db9"
 FOREIGN KEY ("session_id")
   REFERENCES "sessions" ("id")
 );
-CREATE INDEX "index_snapshots_on_session_and_event_range" ON "snapshots" ("session_id", "from_message_id", "to_message_id");
-CREATE INDEX "index_snapshots_on_session_id_and_level" ON "snapshots" ("session_id", "level");
 CREATE INDEX "index_snapshots_on_session_id" ON "snapshots" ("session_id");
+CREATE INDEX "index_snapshots_on_session_id_and_level" ON "snapshots" ("session_id", "level");
+CREATE INDEX "index_snapshots_on_session_and_event_range" ON "snapshots" ("session_id", "from_message_id", "to_message_id");
 CREATE VIRTUAL TABLE messages_fts USING fts5(
   searchable_text,
   content='',
@@ -80,11 +73,18 @@ WHEN OLD.message_type IN ('user_message', 'agent_message', 'system_message')
 BEGIN
   DELETE FROM messages_fts WHERE rowid = OLD.id;
 END;
-CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "granted_tools" text, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "name" varchar, "parent_session_id" integer, "prompt" text, "recalled_message_ids" json DEFAULT '[]' NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, CONSTRAINT "fk_rails_045409ac27"
+CREATE TABLE "secrets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "namespace" varchar NOT NULL, "key" varchar NOT NULL, "value" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE UNIQUE INDEX "index_secrets_on_namespace_and_key" ON "secrets" ("namespace", "key");
+CREATE INDEX "index_goals_on_evicted_at" ON "goals" ("evicted_at");
+CREATE TABLE "pending_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "content" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "source_type" varchar DEFAULT 'user' NOT NULL, "source_name" varchar, "kind" varchar DEFAULT 'active' NOT NULL, "message_type" varchar, CONSTRAINT "fk_rails_007242365b"
+FOREIGN KEY ("session_id")
+  REFERENCES "sessions" ("id")
+);
+CREATE INDEX "index_pending_messages_on_session_id" ON "pending_messages" ("session_id");
+CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "parent_session_id" integer, "prompt" text, "granted_tools" text, "name" varchar, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, CONSTRAINT "fk_rails_045409ac27"
 FOREIGN KEY ("parent_session_id")
   REFERENCES "sessions" ("id")
 );
-CREATE UNIQUE INDEX "index_sessions_on_parent_and_name_unique" ON "sessions" ("parent_session_id", "name") WHERE name IS NOT NULL;
 CREATE INDEX "index_sessions_on_parent_session_id" ON "sessions" ("parent_session_id");
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260418150323'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,46 +1,53 @@
-CREATE TABLE "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
-CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE TABLE "goals" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "parent_goal_id" integer, "description" text NOT NULL, "status" varchar DEFAULT 'active' NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "completed_at" datetime(6), "evicted_at" datetime(6), CONSTRAINT "fk_rails_874b7534ae"
-FOREIGN KEY ("session_id")
-  REFERENCES "sessions" ("id")
-, CONSTRAINT "fk_rails_feeb9df31e"
+CREATE TABLE "secrets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "key" varchar NOT NULL, "namespace" varchar NOT NULL, "updated_at" datetime(6) NOT NULL, "value" text NOT NULL);
+CREATE UNIQUE INDEX "index_secrets_on_namespace_and_key" ON "secrets" ("namespace", "key");
+CREATE TABLE "goals" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "completed_at" datetime(6), "created_at" datetime(6) NOT NULL, "description" text NOT NULL, "evicted_at" datetime(6), "parent_goal_id" integer, "session_id" integer NOT NULL, "status" varchar DEFAULT 'active' NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_feeb9df31e"
 FOREIGN KEY ("parent_goal_id")
   REFERENCES "goals" ("id")
+, CONSTRAINT "fk_rails_874b7534ae"
+FOREIGN KEY ("session_id")
+  REFERENCES "sessions" ("id")
 );
-CREATE INDEX "index_goals_on_session_id" ON "goals" ("session_id");
 CREATE INDEX "index_goals_on_parent_goal_id" ON "goals" ("parent_goal_id");
 CREATE INDEX "index_goals_on_session_id_and_status" ON "goals" ("session_id", "status");
-CREATE TABLE "messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "message_type" varchar NOT NULL, "payload" json DEFAULT '{}' NOT NULL, "timestamp" integer(8) NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "tool_use_id" varchar, "status" varchar, "api_metrics" json, CONSTRAINT "fk_rails_1ee2a92df0"
+CREATE INDEX "index_goals_on_session_id" ON "goals" ("session_id");
+CREATE TABLE "pending_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "content" text NOT NULL, "created_at" datetime(6) NOT NULL, "session_id" integer NOT NULL, "source_name" varchar, "source_type" varchar DEFAULT 'user' NOT NULL, "updated_at" datetime(6) NOT NULL, "kind" varchar DEFAULT 'active' NOT NULL, "message_type" varchar, CONSTRAINT "fk_rails_007242365b"
+FOREIGN KEY ("session_id")
+  REFERENCES "sessions" ("id")
+);
+CREATE INDEX "index_pending_messages_on_session_id" ON "pending_messages" ("session_id");
+CREATE TABLE "schema_migrations" ("version" varchar NOT NULL PRIMARY KEY);
+CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
+CREATE TABLE "messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "api_metrics" json, "created_at" datetime(6) NOT NULL, "message_type" varchar NOT NULL, "payload" json DEFAULT '{}' NOT NULL, "session_id" integer NOT NULL, "status" varchar, "timestamp" integer(8) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "tool_use_id" varchar, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_1ee2a92df0"
 FOREIGN KEY ("session_id")
   REFERENCES "sessions" ("id")
 );
 CREATE INDEX "index_messages_on_session_id_and_status" ON "messages" ("session_id", "status");
-CREATE INDEX "index_messages_on_tool_use_id" ON "messages" ("tool_use_id");
 CREATE INDEX "index_messages_on_session_id" ON "messages" ("session_id");
+CREATE INDEX "index_messages_on_tool_use_id" ON "messages" ("tool_use_id");
 CREATE INDEX "index_messages_on_message_type" ON "messages" ("message_type");
 CREATE INDEX "index_messages_on_session_id_and_message_type" ON "messages" ("session_id", "message_type");
-CREATE TABLE "pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "message_id" integer NOT NULL, "display_text" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, CONSTRAINT "fk_rails_4a5f237c43"
+CREATE TABLE "pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "display_text" text NOT NULL, "message_id" integer NOT NULL, "updated_at" datetime(6) NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, CONSTRAINT "fk_rails_4a5f237c43"
 FOREIGN KEY ("message_id")
   REFERENCES "messages" ("id")
 );
 CREATE UNIQUE INDEX "index_pinned_messages_on_message_id" ON "pinned_messages" ("message_id");
-CREATE TABLE "goal_pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "goal_id" integer NOT NULL, "pinned_message_id" integer NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_fb51bfeebe"
-FOREIGN KEY ("pinned_message_id")
-  REFERENCES "pinned_messages" ("id")
-, CONSTRAINT "fk_rails_689fd4bf8a"
+CREATE TABLE "goal_pinned_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "goal_id" integer NOT NULL, "pinned_message_id" integer NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_689fd4bf8a"
 FOREIGN KEY ("goal_id")
   REFERENCES "goals" ("id")
+, CONSTRAINT "fk_rails_fb51bfeebe"
+FOREIGN KEY ("pinned_message_id")
+  REFERENCES "pinned_messages" ("id")
 );
 CREATE INDEX "index_goal_pinned_messages_on_goal_id" ON "goal_pinned_messages" ("goal_id");
-CREATE INDEX "index_goal_pinned_messages_on_pinned_message_id" ON "goal_pinned_messages" ("pinned_message_id");
 CREATE UNIQUE INDEX "index_goal_pinned_messages_on_goal_id_and_pinned_message_id" ON "goal_pinned_messages" ("goal_id", "pinned_message_id");
-CREATE TABLE "snapshots" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "text" text NOT NULL, "from_message_id" integer NOT NULL, "to_message_id" integer NOT NULL, "level" integer DEFAULT 1 NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_eb2ad51db9"
+CREATE INDEX "index_goal_pinned_messages_on_pinned_message_id" ON "goal_pinned_messages" ("pinned_message_id");
+CREATE TABLE "snapshots" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "from_message_id" integer NOT NULL, "level" integer DEFAULT 1 NOT NULL, "session_id" integer NOT NULL, "text" text NOT NULL, "to_message_id" integer NOT NULL, "token_count" integer DEFAULT 0 NOT NULL, "updated_at" datetime(6) NOT NULL, CONSTRAINT "fk_rails_eb2ad51db9"
 FOREIGN KEY ("session_id")
   REFERENCES "sessions" ("id")
 );
-CREATE INDEX "index_snapshots_on_session_id" ON "snapshots" ("session_id");
-CREATE INDEX "index_snapshots_on_session_id_and_level" ON "snapshots" ("session_id", "level");
 CREATE INDEX "index_snapshots_on_session_and_event_range" ON "snapshots" ("session_id", "from_message_id", "to_message_id");
+CREATE INDEX "index_snapshots_on_session_id_and_level" ON "snapshots" ("session_id", "level");
+CREATE INDEX "index_snapshots_on_session_id" ON "snapshots" ("session_id");
 CREATE VIRTUAL TABLE messages_fts USING fts5(
   searchable_text,
   content='',
@@ -73,20 +80,14 @@ WHEN OLD.message_type IN ('user_message', 'agent_message', 'system_message')
 BEGIN
   DELETE FROM messages_fts WHERE rowid = OLD.id;
 END;
-CREATE TABLE "secrets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "namespace" varchar NOT NULL, "key" varchar NOT NULL, "value" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL);
-CREATE UNIQUE INDEX "index_secrets_on_namespace_and_key" ON "secrets" ("namespace", "key");
-CREATE INDEX "index_goals_on_evicted_at" ON "goals" ("evicted_at");
-CREATE TABLE "pending_messages" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "session_id" integer NOT NULL, "content" text NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "source_type" varchar DEFAULT 'user' NOT NULL, "source_name" varchar, CONSTRAINT "fk_rails_007242365b"
-FOREIGN KEY ("session_id")
-  REFERENCES "sessions" ("id")
-);
-CREATE INDEX "index_pending_messages_on_session_id" ON "pending_messages" ("session_id");
-CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "parent_session_id" integer, "prompt" text, "granted_tools" text, "name" varchar, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, CONSTRAINT "fk_rails_045409ac27"
+CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "granted_tools" text, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "name" varchar, "parent_session_id" integer, "prompt" text, "recalled_message_ids" json DEFAULT '[]' NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, CONSTRAINT "fk_rails_045409ac27"
 FOREIGN KEY ("parent_session_id")
   REFERENCES "sessions" ("id")
 );
+CREATE UNIQUE INDEX "index_sessions_on_parent_and_name_unique" ON "sessions" ("parent_session_id", "name") WHERE name IS NOT NULL;
 CREATE INDEX "index_sessions_on_parent_session_id" ON "sessions" ("parent_session_id");
 INSERT INTO "schema_migrations" (version) VALUES
+('20260418150323'),
 ('20260412110625'),
 ('20260411172926'),
 ('20260411120553'),

--- a/lib/events/start_mneme.rb
+++ b/lib/events/start_mneme.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Events
+  # Emitted when a new +user_message+ or +think+ PendingMessage lands on an
+  # idle session. Mneme subscribes and performs associative recall, then
+  # enqueues its memories as background PendingMessages and emits
+  # {Events::StartMelete} to continue the pipeline.
+  #
+  # First stage of the +start_mneme → start_melete → start_processing+
+  # chain that orchestrates context enrichment before the LLM is called.
+  class StartMneme
+    TYPE = "session.start_mneme"
+
+    attr_reader :session_id, :pending_message_id
+
+    # @param session_id [Integer] session whose drain pipeline should start
+    # @param pending_message_id [Integer] the PendingMessage that triggered the chain
+    def initialize(session_id:, pending_message_id:)
+      @session_id = session_id
+      @pending_message_id = pending_message_id
+    end
+
+    def event_name
+      "#{Bus::NAMESPACE}.#{TYPE}"
+    end
+
+    def to_h
+      {type: TYPE, session_id:, pending_message_id:}
+    end
+  end
+end

--- a/lib/events/start_processing.rb
+++ b/lib/events/start_processing.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Events
+  # Emitted when an active PendingMessage lands on an idle session and does
+  # not require the Mneme/Melete enrichment pipeline (tool calls, tool
+  # responses, sub-agent replies), or when Melete finishes the enrichment
+  # chain. The drain loop subscribes and begins processing the mailbox.
+  #
+  # Final stage of the +start_mneme → start_melete → start_processing+
+  # chain.
+  class StartProcessing
+    TYPE = "session.start_processing"
+
+    attr_reader :session_id, :pending_message_id
+
+    # @param session_id [Integer] session whose drain loop should start
+    # @param pending_message_id [Integer, nil] the PendingMessage that triggered the chain, if any
+    def initialize(session_id:, pending_message_id: nil)
+      @session_id = session_id
+      @pending_message_id = pending_message_id
+    end
+
+    def event_name
+      "#{Bus::NAMESPACE}.#{TYPE}"
+    end
+
+    def to_h
+      {type: TYPE, session_id:, pending_message_id:}
+    end
+  end
+end

--- a/spec/lib/events/start_mneme_spec.rb
+++ b/spec/lib/events/start_mneme_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::StartMneme do
+  subject(:event) { described_class.new(session_id: 7, pending_message_id: 42) }
+
+  it "exposes its type constant" do
+    expect(described_class::TYPE).to eq("session.start_mneme")
+  end
+
+  it "stores session_id" do
+    expect(event.session_id).to eq(7)
+  end
+
+  it "stores pending_message_id" do
+    expect(event.pending_message_id).to eq(42)
+  end
+
+  it "namespaces the event_name for the bus" do
+    expect(event.event_name).to eq("anima.session.start_mneme")
+  end
+
+  describe "#to_h" do
+    it "serialises type, session_id, and pending_message_id" do
+      expect(event.to_h).to eq(
+        type: "session.start_mneme",
+        session_id: 7,
+        pending_message_id: 42
+      )
+    end
+  end
+
+  it "requires pending_message_id (Mneme always has a triggering message)" do
+    expect { described_class.new(session_id: 7) }.to raise_error(ArgumentError)
+  end
+end

--- a/spec/lib/events/start_processing_spec.rb
+++ b/spec/lib/events/start_processing_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::StartProcessing do
+  subject(:event) { described_class.new(session_id: 7, pending_message_id: 42) }
+
+  it "exposes its type constant" do
+    expect(described_class::TYPE).to eq("session.start_processing")
+  end
+
+  it "stores session_id" do
+    expect(event.session_id).to eq(7)
+  end
+
+  it "stores pending_message_id" do
+    expect(event.pending_message_id).to eq(42)
+  end
+
+  it "namespaces the event_name for the bus" do
+    expect(event.event_name).to eq("anima.session.start_processing")
+  end
+
+  it "defaults pending_message_id to nil (emitted at end of Melete enrichment chain)" do
+    event = described_class.new(session_id: 7)
+    expect(event.pending_message_id).to be_nil
+  end
+
+  describe "#to_h" do
+    it "serialises type, session_id, and pending_message_id" do
+      expect(event.to_h).to eq(
+        type: "session.start_processing",
+        session_id: 7,
+        pending_message_id: 42
+      )
+    end
+
+    it "carries a nil pending_message_id when omitted" do
+      hash = described_class.new(session_id: 7).to_h
+      expect(hash).to eq(
+        type: "session.start_processing",
+        session_id: 7,
+        pending_message_id: nil
+      )
+    end
+  end
+end

--- a/spec/models/pending_message_spec.rb
+++ b/spec/models/pending_message_spec.rb
@@ -84,4 +84,123 @@ RSpec.describe PendingMessage, type: :model do
       expect { session.destroy! }.to change(PendingMessage, :count).by(-1)
     end
   end
+
+  describe "kind enum" do
+    it "defaults to active" do
+      pm = session.pending_messages.create!(content: "hi")
+      expect(pm).to be_active
+      expect(pm).not_to be_background
+    end
+
+    it "accepts background" do
+      pm = session.pending_messages.create!(content: "memory", kind: :background)
+      expect(pm).to be_background
+    end
+
+    it "exposes scopes" do
+      active_pm = session.pending_messages.create!(content: "active msg")
+      background_pm = session.pending_messages.create!(content: "background msg", kind: :background)
+
+      expect(PendingMessage.active).to include(active_pm)
+      expect(PendingMessage.active).not_to include(background_pm)
+      expect(PendingMessage.background).to include(background_pm)
+    end
+  end
+
+  describe "message_type validation" do
+    it "allows nil (legacy callers that predate the drain pipeline)" do
+      pm = PendingMessage.new(session: session, content: "hi", source_type: "user")
+      expect(pm).to be_valid
+    end
+
+    PendingMessage::MESSAGE_TYPES.each do |mt|
+      it "accepts #{mt}" do
+        pm = PendingMessage.new(session: session, content: "hi", source_type: "user", message_type: mt)
+        expect(pm).to be_valid
+      end
+    end
+
+    it "rejects unknown values" do
+      pm = PendingMessage.new(session: session, content: "hi", source_type: "user", message_type: "bogus")
+      expect(pm).not_to be_valid
+      expect(pm.errors[:message_type]).to be_present
+    end
+  end
+
+  describe "#route_to_event_bus (after_create_commit)" do
+    before do
+      allow(Events::Bus).to receive(:emit).and_call_original
+    end
+
+    context "with an active message on an idle session" do
+      {"user_message" => Events::StartMneme, "think" => Events::StartMneme}.each do |mt, event_class|
+        it "emits #{event_class.name.split("::").last} for #{mt}" do
+          pm = session.pending_messages.create!(content: "hello", message_type: mt)
+
+          expect(Events::Bus).to have_received(:emit).with(
+            an_instance_of(event_class).and(have_attributes(session_id: session.id, pending_message_id: pm.id))
+          )
+        end
+      end
+
+      {
+        "tool_call" => Events::StartProcessing,
+        "tool_response" => Events::StartProcessing,
+        "subagent" => Events::StartProcessing
+      }.each do |mt, event_class|
+        it "emits #{event_class.name.split("::").last} for #{mt}" do
+          pm = session.pending_messages.create!(
+            content: "result",
+            source_type: "subagent",
+            source_name: "sleuth",
+            message_type: mt
+          )
+
+          expect(Events::Bus).to have_received(:emit).with(
+            an_instance_of(event_class).and(have_attributes(session_id: session.id, pending_message_id: pm.id))
+          )
+        end
+      end
+    end
+
+    context "with a background message" do
+      ["from_mneme", "from_melete"].each do |mt|
+        it "does not emit a start event for #{mt}" do
+          session.pending_messages.create!(
+            content: "memory",
+            source_type: "recall",
+            source_name: "42",
+            message_type: mt,
+            kind: :background
+          )
+
+          expect(Events::Bus).not_to have_received(:emit).with(
+            an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))
+          )
+        end
+      end
+    end
+
+    context "with an active message landing while the session is not idle" do
+      it "does not emit — the running drain loop will pick it up" do
+        session.start_processing!
+
+        session.pending_messages.create!(content: "late arrival", message_type: "user_message")
+
+        expect(Events::Bus).not_to have_received(:emit).with(
+          an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))
+        )
+      end
+    end
+
+    context "with a legacy caller (message_type nil)" do
+      it "does not emit — the pipeline only activates for explicit message types" do
+        session.pending_messages.create!(content: "legacy")
+
+        expect(Events::Bus).not_to have_received(:emit).with(
+          an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))
+        )
+      end
+    end
+  end
 end

--- a/spec/models/pending_message_spec.rb
+++ b/spec/models/pending_message_spec.rb
@@ -107,6 +107,12 @@ RSpec.describe PendingMessage, type: :model do
     end
   end
 
+  describe "MESSAGE_TYPE_ROUTES" do
+    it "only routes values that are also in MESSAGE_TYPES" do
+      expect(PendingMessage::MESSAGE_TYPE_ROUTES.keys).to all(be_in(PendingMessage::MESSAGE_TYPES))
+    end
+  end
+
   describe "message_type validation" do
     it "allows nil (legacy callers that predate the drain pipeline)" do
       pm = PendingMessage.new(session: session, content: "hi", source_type: "user")
@@ -181,11 +187,42 @@ RSpec.describe PendingMessage, type: :model do
       end
     end
 
+    context "with an active message whose message_type has no route" do
+      # from_mneme / from_melete are background-only classifications in the
+      # routing table (MESSAGE_TYPE_ROUTES has no entry). Even if a caller
+      # mistakenly creates them as active, the pipeline stays quiet.
+      ["from_mneme", "from_melete"].each do |mt|
+        it "does not emit for #{mt}" do
+          session.pending_messages.create!(
+            content: "memory",
+            source_type: "recall",
+            source_name: "42",
+            message_type: mt
+          )
+
+          expect(Events::Bus).not_to have_received(:emit).with(
+            an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))
+          )
+        end
+      end
+    end
+
     context "with an active message landing while the session is not idle" do
-      it "does not emit — the running drain loop will pick it up" do
+      it "does not emit while awaiting — the drain loop will pick it up" do
         session.start_processing!
 
         session.pending_messages.create!(content: "late arrival", message_type: "user_message")
+
+        expect(Events::Bus).not_to have_received(:emit).with(
+          an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))
+        )
+      end
+
+      it "does not emit while executing — the drain loop will pick it up" do
+        session.start_processing!
+        session.tool_received!
+
+        session.pending_messages.create!(content: "mid-tool", message_type: "tool_response")
 
         expect(Events::Bus).not_to have_received(:emit).with(
           an_instance_of(Events::StartMneme).or(an_instance_of(Events::StartProcessing))


### PR DESCRIPTION
Closes #439. Part of epic #427.

## Summary

- Add `kind` enum (`background` / `active`, default `active`) and `message_type` string column to `pending_messages`.
- New `Events::StartMneme` / `Events::StartProcessing` event classes — both carry `session_id` + `pending_message_id`.
- `PendingMessage#route_to_event_bus` (after_create_commit) routes active messages on idle sessions through the pipeline:
  - `user_message` / `think` → `:start_mneme` (enrichment pipeline Mneme → Melete → Processing)
  - `tool_call` / `tool_response` / `subagent` → `:start_processing` (direct drain)
  - `background` kind or `from_mneme` / `from_melete` → no event (context-enrichment only)
- Legacy callers (`source_type: user|subagent|skill|workflow|recall|goal` with `message_type` unset) remain a pure no-op until #441/#442/#443 migrate them. `kind` defaults to `active`, but without `message_type` the routing callback bails — no behavioural change.
- Active message landing while session is not idle emits nothing; the running drain loop picks it up (per brainstorm).

## Scope boundaries

- No subscribers for `:start_mneme` / `:start_processing` yet — those live in #440 (drain loop) and #442 (Mneme).
- `source_type` column stays as-is. It's orthogonal (origin of the pending message) — `message_type` is the LLM-role discriminator used by routing. Collapsing them is a separate refactor once #440/#441/#442/#443 migrate callers.

## Test plan

- [x] `bundle exec rspec spec/models/pending_message_spec.rb` — 37 examples (enum defaults, scopes, validation inclusion + nil, routing per message_type, background no-op, non-idle queue-silently, nil message_type no-op).
- [x] Full suite: 2630 examples, 0 failures.
- [x] `bundle exec standardrb` clean.
- [x] `bundle exec reek app/models/pending_message.rb lib/events/start_mneme.rb lib/events/start_processing.rb` — 0 warnings.

## Epic context

`thoughts/shared/notes/2026-04-03/qa-brainstorm-event-loop-mailbox.md` — lines 164–206 (kind decision), 391–447 (routing table + event chain).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new DB columns and an `after_create_commit` event-routing hook that can change when session processing is kicked off for newly enqueued pending messages. While guarded by `kind`, `message_type`, and `session.idle?`, misclassified messages or state-machine callback timing changes could affect pipeline triggering.
> 
> **Overview**
> Introduces `PendingMessage` classification for the event-driven drain pipeline by adding `kind` (`active`/`background`) and `message_type`, plus validation and a new `#route_to_event_bus` `after_create_commit` hook.
> 
> Active pending messages created on *idle* sessions now emit start events via `Events::Bus`: `user_message`/`think` route to the new `Events::StartMneme`, while tool/subagent traffic routes to the new `Events::StartProcessing`; background messages and legacy records with `message_type: nil` are no-ops.
> 
> Updates the session AASM callback from `after_all_transitions` to `after_all_events` for emitting `Events::SessionStateChanged`, and adds migration/structure updates and specs covering the new events, enum behavior, validation, and routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8fe29a6da89cbea646f659d5342f0d8929386f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->