### PR TITLE
#444 refactor: drop AASM interrupt event, cooperative flag stays

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ When content exceeds the panel height, the HUD scrolls. Three input methods:
 | `Escape` or `C-a` | Exit HUD focus mode |
 | Mouse wheel over HUD | Scroll without entering focus mode |
 
-**Escape key interrupt:** Press `Escape` while the agent is working to stop execution mid-tool. Running shell commands receive Ctrl+C and return partial output; pending tool calls are skipped; LLM text generation is discarded. The interrupt cascades to active sub-agents.
+**Escape key interrupt:** Press `Escape` while the agent is working to signal an interrupt. Running shell commands cooperatively abort — they receive Ctrl+C and return partial output tagged `Your human wants your attention`, which the LLM sees on the next round and pivots from. The interrupt cascades to active sub-agents.
 
 Three switchable view modes let you control how much detail the TUI shows. Cycle with `C-a → v`:
 

--- a/app/channels/session_channel.rb
+++ b/app/channels/session_channel.rb
@@ -79,13 +79,13 @@ class SessionChannel < ApplicationCable::Channel
   # Cascades to running sub-agent sessions to avoid burning tokens in
   # child jobs that the parent will discard anyway.
   #
-  # No-op if the session isn't currently processing ({Session#may_interrupt?}
-  # returns false when the AASM state is +:idle+).
+  # No-op on idle sessions — nothing to interrupt, and the flag would
+  # leak into the next round without an AASM transition to clear it.
   #
   # @param _data [Hash] unused
   def interrupt_execution(_data)
     session = Session.find(@current_session_id)
-    return unless session.may_interrupt?
+    return if session.idle?
 
     session.update!(interrupt_requested: true)
     session.child_sessions.processing.update_all(interrupt_requested: true)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -54,10 +54,6 @@ class Session < ApplicationRecord
     event :response_complete do
       transitions from: :awaiting, to: :idle
     end
-
-    event :interrupt do
-      transitions from: [:awaiting, :executing], to: :idle
-    end
   end
 
   attribute :view_mode, :string, default: -> { Anima::Settings.default_view_mode }
@@ -539,7 +535,6 @@ class Session < ApplicationRecord
   # emitted nothing, so without this callback the message would sit
   # forever once the LLM call completed.
   #
-  # The +:executing → :idle+ path (interrupt) is also covered here.
   # The +:executing → :awaiting+ path (tool round close) does not need
   # this callback — the closing tool_response PM is itself the wake.
   #

--- a/spec/integration/session_interrupt_spec.rb
+++ b/spec/integration/session_interrupt_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Integration spec for the session interrupt flow. Verifies that the
+# layered pieces compose into a clean round-trip when a running tool
+# is interrupted:
+#
+#   :executing + outstanding tool_call
+#     -> interrupt_requested = true              (SessionChannel#interrupt_execution)
+#     -> bash cooperatively aborts, emits synthetic tool_response PM
+#     -> PM#promote! persists the tool_response Message
+#     -> start_processing! (:executing -> :awaiting)  closes the round
+#     -> response_complete! (:awaiting -> :idle)      LLM acknowledges
+#     -> clear_interrupt_flag_if_idle resets the flag
+#
+# Individual layers (bash polling, PM promotion, SessionChannel flag
+# setting) have dedicated specs. This one stitches them together so
+# regressions at the seams surface quickly.
+RSpec.describe "Session interrupt flow" do
+  let(:session) { create(:session) }
+  let(:tool_use_id) { "tu_bash_interrupt_1" }
+
+  before do
+    session.start_processing!
+    session.tool_received!
+
+    create(:message, :bash_tool_call,
+      session: session,
+      tool_use_id: tool_use_id,
+      payload: {
+        "tool_name" => "bash",
+        "tool_use_id" => tool_use_id,
+        "tool_input" => {"command" => "sleep 10"}
+      })
+
+    session.update!(interrupt_requested: true)
+  end
+
+  it "drops back to idle and clears the flag once the interrupt round-trip completes" do
+    synthetic_response = create(:pending_message, :tool_response,
+      session: session,
+      tool_use_id: tool_use_id,
+      source_name: "bash",
+      content: LLM::Client::INTERRUPT_MESSAGE,
+      success: false)
+
+    synthetic_response.promote!
+
+    tool_response = session.messages.find_by(message_type: "tool_response", tool_use_id: tool_use_id)
+    expect(tool_response.payload["content"]).to eq(LLM::Client::INTERRUPT_MESSAGE)
+    expect(tool_response.payload["success"]).to be(false)
+
+    expect(session.start_processing!).to be_truthy
+    expect(session).to be_awaiting
+    expect(session.reload.interrupt_requested?).to be(true)
+
+    expect(session.response_complete!).to be_truthy
+    expect(session).to be_idle
+    expect(session.reload.interrupt_requested?).to be(false)
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -53,23 +53,6 @@ RSpec.describe Session do
         expect(session.start_processing!).to be_falsey
         expect(session).to be_executing
       end
-
-      it "transitions from awaiting to idle via interrupt!" do
-        session.start_processing!
-        expect(session).to be_awaiting
-
-        expect(session.interrupt!).to be_truthy
-        expect(session).to be_idle
-      end
-
-      it "transitions from executing to idle via interrupt!" do
-        session.start_processing!
-        session.tool_received!
-        expect(session).to be_executing
-
-        expect(session.interrupt!).to be_truthy
-        expect(session).to be_idle
-      end
     end
 
     describe "guards" do
@@ -87,10 +70,6 @@ RSpec.describe Session do
       it "rejects response_complete from idle" do
         expect(session.response_complete!).to be_falsey
       end
-
-      it "rejects interrupt from idle" do
-        expect(session.interrupt!).to be_falsey
-      end
     end
 
     describe "may_ predicates" do
@@ -99,7 +78,6 @@ RSpec.describe Session do
       it "reports valid transitions from idle" do
         expect(session.may_start_processing?).to be true
         expect(session.may_tool_received?).to be false
-        expect(session.may_interrupt?).to be false
       end
 
       it "reports valid transitions from awaiting" do
@@ -107,7 +85,6 @@ RSpec.describe Session do
         expect(session.may_start_processing?).to be false
         expect(session.may_tool_received?).to be true
         expect(session.may_response_complete?).to be true
-        expect(session.may_interrupt?).to be true
       end
 
       it "reports valid transitions from executing" do
@@ -116,7 +93,6 @@ RSpec.describe Session do
         allow(session).to receive(:tool_round_complete?).and_return(true)
         expect(session.may_start_processing?).to be true
         expect(session.may_response_complete?).to be false
-        expect(session.may_interrupt?).to be true
       end
 
       it "denies start_processing from executing while the round is incomplete" do


### PR DESCRIPTION
## Summary

Finalizes the session interrupt design after the epic #427 / #440 / #450 work landed. The ticket was written before the event-driven drain + AASM cycle existed; several premises no longer hold. Closes #444.

- **Deletes the `interrupt` AASM event.** It was never invoked. Calling it mid-`:executing` would race with in-flight tool_responses; calling it only from `:awaiting` is redundant with the natural round-close flow.
- **Replaces `may_interrupt?` guard in `SessionChannel#interrupt_execution` with `!idle?`.** Keeps the no-op on idle sessions without peeking at AASM state (principle from #438 handoff). Flag set is idempotent otherwise.
- **Adds `spec/integration/session_interrupt_spec.rb`.** End-to-end spec wiring PM promotion, AASM transitions, and the flag-clear callback together: synthetic interrupt tool_response closes the round → `:executing → :awaiting → :idle` → `clear_interrupt_flag_if_idle` resets the flag.
- **Corrects README.** The Escape interrupt section claimed "pending tool calls are skipped" and "LLM text generation is discarded" — neither is true. Only bash cooperatively aborts; other tools run to completion; LLM calls can't be canceled mid-flight (Anthropic API has no cancel endpoint).

## What stays (already shipped in #440 / #450)

- `interrupt_requested` flag on Session (`db/migrate/20260316094817_add_interrupt_requested_to_sessions.rb`)
- Flag setter + UI broadcast: `SessionChannel#interrupt_execution`
- Bash cooperative polling: `lib/tools/bash.rb`, `lib/shell_session.rb`
- `LLM::Client::INTERRUPT_MESSAGE` ("Your human wants your attention")
- `Session#clear_interrupt_flag_if_idle` auto-clear on `:idle`
- TUI entry point: Escape → `CableClient#interrupt`

## Out of scope (explicitly)

- LLM request cancellation mid-`:awaiting`. Accepted limitation.
- Propagating cooperative polling to non-bash tools.
- Cross-job coordination for parallel `ToolExecutionJob` batches — each bash polls independently; parallel abort works without coordination.

## Test plan

- [x] `bundle exec rspec spec/models/session_spec.rb spec/channels/session_channel_spec.rb spec/integration/session_interrupt_spec.rb` — 272 examples, 0 failures
- [x] `bundle exec rspec spec/models/pending_message_spec.rb spec/jobs/drain_job_spec.rb` — 37 examples, 0 failures
- [x] `standardrb --fix` — clean
- [ ] CI green on this branch

Refs #444, part of #427.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes session state-machine behavior around interrupts and relies on the cooperative interrupt flag/round-trip to return to `idle`; mistakes could leave sessions stuck or interrupts leaking into subsequent rounds.
> 
> **Overview**
> **Simplifies session interruption to be purely cooperative.** Removes the unused AASM `interrupt` event and the related `may_interrupt?` expectations/tests, leaving the interrupt flow to complete via the normal `:executing → :awaiting → :idle` round closure.
> 
> **Tightens the interrupt trigger and adds coverage.** `SessionChannel#interrupt_execution` now no-ops only when the session is `idle?` (avoiding stale `interrupt_requested` leaking into the next round), and a new integration spec verifies the end-to-end interrupt round-trip (synthetic tool response promotion, state transitions, and automatic flag clearing).
> 
> **Docs update.** README’s Escape interrupt section is corrected to describe cooperative bash abort behavior and the synthetic `Your human wants your attention` tool result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739eaed48cfc3fdaa03317f2f93192bc6796cca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->