### PR TITLE
#431 feat: sub-agent HUD syncs with viewport eviction

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -29,6 +29,10 @@ detectors:
       - "Tools::ViewMessages"
       # Event subscribers extract payload fields — inherent to the pattern.
       - "Events::Subscribers::SubagentMessageRouter"
+      # Query-style predicate operates on the argument by design.
+      - "Session#subagent_trace_in_viewport?"
+      # Visibility restore operates on the child session — that's the job.
+      - "PendingMessage#restore_subagent_hud_visibility!"
       # Spawn tools orchestrate child session creation — references are the job.
       - "Tools::SpawnSubagent#spawn_child"
       - "Tools::SpawnSpecialist#spawn_child"

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ The difference from every other system: memory isn't a tool the agent uses. It's
 
 ### TUI HUD & View Modes
 
-The right-side HUD panel shows session state at a glance: session name, goals (with status icons), active skills, workflow, and sub-agents. Toggle with `C-a → h`; when hidden, the input border shows `C-a → h HUD` as a reminder.
+The right-side HUD panel shows session state at a glance: session name, goals (with status icons), active skills, workflow, and sub-agents. Toggle with `C-a → h`; when hidden, the input border shows `C-a → h HUD` as a reminder. The sub-agent list mirrors what Aoide actually carries in her viewport: once Mneme eviction takes the last spawn pair or `from_<nickname>` response out of the sliding window, the entry drops from the HUD; if a later response reintroduces a trace, the entry comes back.
 
 **Braille spinner**: An animated braille character (U+2800-U+28FF) replaces the old "Thinking..." label in both the chat viewport and HUD. Each processing state has a distinct animation pattern — smooth snake rotation for LLM generation, staccato pulse for tool execution, rapid deceleration for interrupting. Sub-agents in the HUD show state-driven icons: `●` (generating, green), `◉` (tool executing, green), `●` (interrupting, red), `◌` (idle, grey).
 

--- a/app/channels/session_channel.rb
+++ b/app/channels/session_channel.rb
@@ -210,7 +210,10 @@ class SessionChannel < ApplicationCable::Channel
       "goals" => session.goals_summary
     }
 
-    children = session.child_sessions.order(:created_at).select(:id, :name, :aasm_state)
+    children = session.child_sessions
+      .where(hud_visible: true)
+      .order(:created_at)
+      .select(:id, :name, :aasm_state)
     if children.any?
       payload["children"] = children.map { |child|
         {"id" => child.id, "name" => child.name, "session_state" => child.aasm_state}

--- a/app/jobs/tool_execution_job.rb
+++ b/app/jobs/tool_execution_job.rb
@@ -31,7 +31,7 @@ class ToolExecutionJob < ApplicationJob
     shell_session = ShellSession.for_session(session)
     registry = Tools::Registry.build(session: session, shell_session: shell_session)
 
-    content, success = execute(registry, tool_name, tool_input)
+    content, success = execute(registry, tool_name, tool_input, tool_use_id)
 
     Events::Bus.emit(Events::ToolExecuted.new(
       session_id: session_id,
@@ -58,8 +58,8 @@ class ToolExecutionJob < ApplicationJob
 
   # Always emits something executable back — a missing +tool_result+
   # permanently corrupts the Anthropic conversation history.
-  def execute(registry, tool_name, tool_input)
-    result = registry.execute(tool_name, tool_input)
+  def execute(registry, tool_name, tool_input, tool_use_id)
+    result = registry.execute(tool_name, tool_input, tool_use_id: tool_use_id)
     result = ::ToolDecorator.call(tool_name, result)
     content = format_result(result)
     content = truncate(content, registry, tool_name)

--- a/app/models/pending_message.rb
+++ b/app/models/pending_message.rb
@@ -315,6 +315,23 @@ class PendingMessage < ApplicationRecord
       timestamp: now,
       token_count: TokenEstimation.estimate_token_count(content)
     )
+
+    restore_subagent_hud_visibility! if subagent?
+  end
+
+  # Flips the delivering sub-agent back to +hud_visible: true+ when the
+  # phantom pair we just persisted reintroduces a trace. A subsequent
+  # eviction that passes every trace will hide the sub-agent again via
+  # {Mneme::Runner#refresh_subagent_visibility}.
+  #
+  # Re-broadcasts the parent's children list on flip so the TUI adds the
+  # HUD entry back without waiting for the next AASM state change.
+  def restore_subagent_hud_visibility!
+    child = session.child_sessions.find_by(name: source_name)
+    return unless child && !child.hud_visible
+
+    child.update_column(:hud_visible, true)
+    child.broadcast_children_update_to_parent
   end
 
   # Builds a phantom tool_use/tool_result message pair.

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -465,7 +465,9 @@ class Session < ApplicationRecord
 
   # Broadcasts child session list to all clients subscribed to the parent
   # session. Called when a child session is created or its AASM state
-  # changes so the HUD sub-agents section updates in real time.
+  # changes so the HUD sub-agents section updates in real time. Evicted
+  # sub-agents (+hud_visible: false+) are filtered out — the panel mirrors
+  # what Aoide currently carries in her viewport.
   #
   # Queries children via FK directly (avoids loading the parent record) and
   # selects only the columns needed for the HUD payload.
@@ -474,7 +476,7 @@ class Session < ApplicationRecord
   def broadcast_children_update_to_parent
     return unless parent_session_id
 
-    children = Session.where(parent_session_id: parent_session_id)
+    children = Session.where(parent_session_id: parent_session_id, hud_visible: true)
       .order(:created_at)
       .select(:id, :name, :aasm_state)
     ActionCable.server.broadcast("session_#{parent_session_id}", {
@@ -484,6 +486,42 @@ class Session < ApplicationRecord
         {"id" => child.id, "name" => child.name, "session_state" => child.aasm_state}
       }
     })
+  end
+
+  # True when at least one of +child+'s traces (the +spawn_subagent+ tool
+  # pair or any +from_{nickname}+ phantom pair) still lives above the
+  # Mneme boundary in this session's viewport. Used by {Mneme::Runner}
+  # after boundary advancement to decide whether a child should drop out
+  # of the HUD panel.
+  #
+  # Returns +false+ when the given session isn't a direct child, when it
+  # has no +spawn_tool_use_id+ (legacy child), or when the boundary has
+  # passed every trace.
+  #
+  # @param child [Session] a sub-agent session to check
+  # @return [Boolean]
+  def subagent_trace_in_viewport?(child)
+    return false unless child.parent_session_id == id
+
+    boundary_id = mneme_boundary_message_id
+    scope = messages
+    scope = scope.where("messages.id >= ?", boundary_id) if boundary_id
+
+    spawn_uid = child.spawn_tool_use_id
+    nickname = child.name
+    conditions = []
+    bindings = {}
+    if spawn_uid
+      conditions << "messages.tool_use_id = :uid"
+      bindings[:uid] = spawn_uid
+    end
+    if nickname
+      conditions << "json_extract(messages.payload, '$.tool_name') = :tool"
+      bindings[:tool] = "from_#{nickname}"
+    end
+    return false if conditions.empty?
+
+    scope.where(conditions.join(" OR "), **bindings).exists?
   end
 
   # AASM guard for the +executing → awaiting+ branch of +start_processing+.

--- a/config/initializers/event_subscribers.rb
+++ b/config/initializers/event_subscribers.rb
@@ -17,6 +17,7 @@
 MESSAGE_LIFECYCLE_FILTER = ->(event) { event[:name].start_with?("anima.message.") }
 MESSAGE_CREATED_FILTER = ->(event) { event[:name] == "anima.message.created" }
 EVICTION_FILTER = ->(event) { event[:name] == "anima.eviction.completed" }
+SUBAGENT_EVICTED_FILTER = ->(event) { event[:name] == "anima.subagent.evicted" }
 ACTIVE_STATE_TRIGGER_FILTER = ->(event) {
   %w[anima.skill.activated anima.workflow.activated anima.eviction.completed].include?(event[:name])
 }
@@ -70,6 +71,10 @@ Rails.application.config.after_initialize do
 
     # Broadcasts eviction cutoff to clients after Mneme advances the boundary.
     Events::Bus.subscribe(Events::Subscribers::EvictionBroadcaster.new, &EVICTION_FILTER)
+
+    # Broadcasts sub-agent HUD removal when eviction takes the last trace
+    # of a sub-agent past the Mneme boundary.
+    Events::Bus.subscribe(Events::Subscribers::SubagentVisibilityBroadcaster.new, &SUBAGENT_EVICTED_FILTER)
 
     # Rebroadcasts active skills/workflow on every event that can change
     # the set: skill activation, workflow activation, or eviction.

--- a/db/migrate/20260420100000_add_hud_visibility_to_sessions.rb
+++ b/db/migrate/20260420100000_add_hud_visibility_to_sessions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Sub-agent sessions track presence in the parent's HUD panel through the
+# +hud_visible+ boolean. Mneme flips it to +false+ when viewport eviction
+# removes every trace of the sub-agent (spawn pair + response pairs). The
+# +spawn_tool_use_id+ column lets the trace query find the spawn pair
+# directly instead of string-matching the +spawn_subagent+ tool_input.
+class AddHudVisibilityToSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sessions, :hud_visible, :boolean, default: true, null: false
+    add_column :sessions, :spawn_tool_use_id, :string
+
+    add_index :sessions, [:parent_session_id, :hud_visible]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -75,7 +75,7 @@ WHEN OLD.message_type IN ('user_message', 'agent_message', 'system_message')
 BEGIN
   DELETE FROM messages_fts WHERE rowid = OLD.id;
 END;
-CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "granted_tools" text, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "name" varchar, "parent_session_id" integer, "prompt" text, "recalled_message_ids" json DEFAULT '[]' NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, CONSTRAINT "fk_rails_045409ac27"
+CREATE TABLE "sessions" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "created_at" datetime(6) NOT NULL, "granted_tools" text, "interrupt_requested" boolean DEFAULT FALSE NOT NULL, "mneme_boundary_message_id" integer, "name" varchar, "parent_session_id" integer, "prompt" text, "recalled_message_ids" json DEFAULT '[]' NOT NULL, "updated_at" datetime(6) NOT NULL, "view_mode" varchar DEFAULT 'basic' NOT NULL, "initial_cwd" varchar, "aasm_state" varchar DEFAULT 'idle' NOT NULL, "hud_visible" boolean DEFAULT TRUE NOT NULL, "spawn_tool_use_id" varchar, CONSTRAINT "fk_rails_045409ac27"
 FOREIGN KEY ("parent_session_id")
   REFERENCES "sessions" ("id")
 );
@@ -88,7 +88,9 @@ FOREIGN KEY ("session_id")
 CREATE INDEX "index_pending_messages_on_session_id" ON "pending_messages" ("session_id");
 CREATE INDEX "index_pending_messages_on_drain_ordering" ON "pending_messages" ("session_id", "message_type", "created_at");
 CREATE INDEX "index_pending_messages_on_session_and_tool_use" ON "pending_messages" ("session_id", "tool_use_id");
+CREATE INDEX "index_sessions_on_parent_session_id_and_hud_visible" ON "sessions" ("parent_session_id", "hud_visible");
 INSERT INTO "schema_migrations" (version) VALUES
+('20260420100000'),
 ('20260419140000'),
 ('20260419130000'),
 ('20260419120000'),

--- a/lib/events/subagent_evicted.rb
+++ b/lib/events/subagent_evicted.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Events
+  # Emitted when {Mneme::Runner} advances the boundary past every remaining
+  # trace of a sub-agent — the spawn pair plus every +from_{nickname}+
+  # phantom pair. Subscribers broadcast the removal so clients drop the
+  # entry from the HUD panel.
+  #
+  # +session_id+ is the parent session (HUD owner), +child_id+ is the
+  # sub-agent session whose traces just aged out.
+  class SubagentEvicted
+    TYPE = "subagent.evicted"
+
+    attr_reader :session_id, :child_id
+
+    # @param session_id [Integer] parent session whose HUD should drop the entry
+    # @param child_id [Integer] sub-agent session whose traces were evicted
+    def initialize(session_id:, child_id:)
+      @session_id = session_id
+      @child_id = child_id
+    end
+
+    def event_name
+      "#{Bus::NAMESPACE}.#{TYPE}"
+    end
+
+    def to_h
+      {type: TYPE, session_id:, child_id:}
+    end
+  end
+end

--- a/lib/events/subscribers/subagent_visibility_broadcaster.rb
+++ b/lib/events/subscribers/subagent_visibility_broadcaster.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Events
+  module Subscribers
+    # Broadcasts sub-agent eviction to the parent session's stream so the
+    # TUI HUD panel removes the entry. Fires in response to
+    # {Events::SubagentEvicted}, which {Mneme::Runner} emits after a
+    # boundary advance leaves a sub-agent with no remaining traces in the
+    # parent viewport.
+    #
+    # @example Registering at boot
+    #   Events::Bus.subscribe(Events::Subscribers::SubagentVisibilityBroadcaster.new) { |event|
+    #     event[:name] == "anima.subagent.evicted"
+    #   }
+    class SubagentVisibilityBroadcaster
+      include Events::Subscriber
+
+      # @param event [Hash] Rails.event notification hash
+      def emit(event)
+        payload = event[:payload]
+        session_id = payload[:session_id]
+        ActionCable.server.broadcast(
+          "session_#{session_id}",
+          {
+            "action" => "subagent_evicted",
+            "session_id" => session_id,
+            "child_id" => payload[:child_id]
+          }
+        )
+      end
+    end
+  end
+end

--- a/lib/mneme/runner.rb
+++ b/lib/mneme/runner.rb
@@ -96,7 +96,25 @@ module Mneme
         session_id: session.id,
         evict_above_id: last_evicted_id
       ))
+      refresh_subagent_visibility
       log.debug("session=#{session.id} — boundary advanced to message #{new_boundary_id}")
+    end
+
+    # Flips visible sub-agents to +hud_visible: false+ once every one of
+    # their viewport traces (spawn pair + +from_{nickname}+ phantom pairs)
+    # has fallen past the Mneme boundary. Emits {Events::SubagentEvicted}
+    # per flip so the broadcaster removes them from the HUD panel on the
+    # parent stream. Flips are logged so the transition is auditable.
+    def refresh_subagent_visibility
+      session_id = session.id
+      session.child_sessions.where(hud_visible: true).each do |child|
+        next if session.subagent_trace_in_viewport?(child)
+
+        child_id = child.id
+        child.update_column(:hud_visible, false)
+        Events::Bus.emit(Events::SubagentEvicted.new(session_id: session_id, child_id: child_id))
+        log.debug("session=#{session_id} — sub-agent #{child_id} evicted from HUD")
+      end
     end
 
     # Renders eviction zone and context as a Mneme transcript using

--- a/lib/tools/registry.rb
+++ b/lib/tools/registry.rb
@@ -106,16 +106,22 @@ module Tools
     end
 
     # Execute a tool by name. Classes are instantiated with the registry's
-    # context; instances are called directly.
+    # context; instances are called directly. The enclosing +tool_use_id+
+    # is merged into the context when provided so tools that need to
+    # reference their own invoking tool_call (e.g. {Tools::SpawnSubagent}
+    # persisting +spawn_tool_use_id+ on the child session) can read it via
+    # a named kwarg in their initializer.
     #
     # @param name [String] registered tool name
     # @param input [Hash] tool input parameters (may include "timeout" for
     #   tools that support per-call timeout overrides)
+    # @param tool_use_id [String, nil] the invoking tool_call's pairing id
     # @return [String, Hash] tool execution result
     # @raise [UnknownToolError] if no tool is registered with the given name
-    def execute(name, input)
+    def execute(name, input, tool_use_id: nil)
       tool = @tools.fetch(name) { raise UnknownToolError, "Unknown tool: #{name}" }
-      instance = tool.is_a?(Class) ? tool.new(**@context) : tool
+      context = tool_use_id ? @context.merge(tool_use_id: tool_use_id) : @context
+      instance = tool.is_a?(Class) ? tool.new(**context) : tool
       instance.execute(input)
     end
 

--- a/lib/tools/spawn_specialist.rb
+++ b/lib/tools/spawn_specialist.rb
@@ -60,10 +60,14 @@ module Tools
     # @param session [Session] the parent session spawning the specialist
     # @param shell_session [ShellSession] the parent's persistent shell (for CWD inheritance)
     # @param agent_registry [Agents::Registry, nil] injectable for testing
-    def initialize(session:, shell_session:, agent_registry: nil, **)
+    # @param tool_use_id [String, nil] the invoking +spawn_specialist+ tool_call's
+    #   pairing id, captured so the spawn pair can later be located by the
+    #   HUD visibility sweep in {Mneme::Runner}
+    def initialize(session:, shell_session:, agent_registry: nil, tool_use_id: nil, **)
       @session = session
       @shell_session = shell_session
       @agent_registry = agent_registry || Agents::Registry.instance
+      @tool_use_id = tool_use_id
     end
 
     # Creates a child session with the specialist's predefined prompt and
@@ -100,7 +104,8 @@ module Tools
         parent_session_id: @session.id,
         prompt: build_prompt(definition),
         granted_tools: definition.tools,
-        initial_cwd: @shell_session.pwd
+        initial_cwd: @shell_session.pwd,
+        spawn_tool_use_id: @tool_use_id
       )
       create_goal_with_pinned_task(child, task)
       assign_nickname_via_melete(child)

--- a/lib/tools/spawn_subagent.rb
+++ b/lib/tools/spawn_subagent.rb
@@ -45,9 +45,13 @@ module Tools
 
     # @param session [Session] the parent session spawning the sub-agent
     # @param shell_session [ShellSession] the parent's persistent shell (for CWD inheritance)
-    def initialize(session:, shell_session:, **)
+    # @param tool_use_id [String, nil] the invoking +spawn_subagent+ tool_call's
+    #   pairing id, captured so the spawn pair can later be located by the
+    #   HUD visibility sweep in {Mneme::Runner}
+    def initialize(session:, shell_session:, tool_use_id: nil, **)
       @session = session
       @shell_session = shell_session
+      @tool_use_id = tool_use_id
     end
 
     # Creates a child session with a clean context (no parent history),
@@ -85,7 +89,8 @@ module Tools
         parent_session_id: @session.id,
         prompt: GENERIC_PROMPT,
         granted_tools: granted_tools,
-        initial_cwd: @shell_session.pwd
+        initial_cwd: @shell_session.pwd,
+        spawn_tool_use_id: @tool_use_id
       )
       create_goal_with_pinned_task(child, task)
       assign_nickname_via_melete(child)

--- a/lib/tui/screens/chat.rb
+++ b/lib/tui/screens/chat.rb
@@ -315,6 +315,8 @@ module TUI
             handle_goals_updated(msg)
           when "children_updated"
             handle_children_updated(msg)
+          when "subagent_evicted"
+            handle_subagent_evicted(msg)
           when "sessions_list"
             @sessions_list = msg["sessions"]
           when "pending_message_created"
@@ -481,6 +483,20 @@ module TUI
         @session_info[:children] = msg["children"] || []
       end
 
+      # Removes a sub-agent from the HUD panel when viewport eviction has
+      # taken its last trace past the Mneme boundary. Only applies to the
+      # current session — the brain emits this only on the parent's stream.
+      #
+      # @param msg [Hash] ActionCable payload with "session_id" and "child_id" keys
+      def handle_subagent_evicted(msg)
+        return unless msg["session_id"] == @session_info[:id]
+
+        child_id = msg["child_id"]
+        return unless child_id
+
+        @session_info[:children] = @session_info[:children]&.reject { |child| child["id"] == child_id }
+      end
+
       # Handles explicit session state transitions from the server.
       # Drives the braille spinner animation. Only processes broadcasts
       # matching the current session.
@@ -503,8 +519,8 @@ module TUI
         child_id = msg["child_id"]
         return unless child_id
 
-        child = @session_info[:children]&.find { |c| c["id"] == child_id }
-        child["session_state"] = msg["state"] if child
+        entry = @session_info[:children]&.find { |child| child["id"] == child_id }
+        entry["session_state"] = msg["state"] if entry
       end
 
       # Updates the session state and synchronizes the spinner.

--- a/spec/channels/session_channel_spec.rb
+++ b/spec/channels/session_channel_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe SessionChannel, type: :channel do
         end
       end
 
+      context "with a mix of visible and evicted sub-agents" do
+        let!(:session) { create(:session, id: session_id) }
+        let!(:visible) { create(:session, parent_session: session, name: "analyzer") }
+
+        before do
+          Session.create!(parent_session: session, name: "retired", hud_visible: false)
+          subscribe(session_id: session_id)
+        end
+
+        it "includes only sub-agents still visible in the HUD" do
+          changed = transmissions.find { |t| t["action"] == "session_changed" }
+
+          ids = changed["children"].map { |c| c["id"] }
+          expect(ids).to contain_exactly(visible.id)
+        end
+      end
+
       context "for a bare session with no skills, workflow, goals, or children" do
         before do
           create(:session, id: session_id)

--- a/spec/jobs/tool_execution_job_spec.rb
+++ b/spec/jobs/tool_execution_job_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe ToolExecutionJob do
       expect(shell_session).not_to have_received(:finalize)
     end
 
+    it "forwards the invoking tool_use_id to the registry" do
+      expect(registry).to receive(:execute)
+        .with("bash", {"command" => "ls"}, tool_use_id: "toolu_77")
+        .and_return("ok")
+
+      described_class.perform_now(session.id, tool_use_id: "toolu_77", tool_name: "bash", tool_input: {"command" => "ls"})
+    end
+
     it "runs the output through ResponseTruncator when a threshold is configured" do
       allow(registry).to receive(:truncation_threshold).and_return(10)
       allow(registry).to receive(:execute).and_return("huge output")

--- a/spec/lib/events/subagent_evicted_spec.rb
+++ b/spec/lib/events/subagent_evicted_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::SubagentEvicted do
+  describe "#to_h" do
+    it "serializes as a flat hash with session_id and child_id" do
+      event = described_class.new(session_id: 7, child_id: 42)
+
+      expect(event.to_h).to eq(type: "subagent.evicted", session_id: 7, child_id: 42)
+    end
+  end
+
+  describe "#event_name" do
+    it "prefixes the type with the Events::Bus namespace" do
+      event = described_class.new(session_id: 1, child_id: 2)
+
+      expect(event.event_name).to eq("anima.subagent.evicted")
+    end
+  end
+end

--- a/spec/lib/events/subscribers/subagent_visibility_broadcaster_spec.rb
+++ b/spec/lib/events/subscribers/subagent_visibility_broadcaster_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Events::Subscribers::SubagentVisibilityBroadcaster do
+  subject(:broadcaster) { described_class.new }
+
+  let(:session) { create(:session) }
+  let(:child) { Session.create!(parent_session: session, prompt: "task") }
+
+  describe "#emit" do
+    it "broadcasts subagent_evicted to the parent session stream" do
+      event = {
+        payload: {
+          type: Events::SubagentEvicted::TYPE,
+          session_id: session.id,
+          child_id: child.id
+        }
+      }
+
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "session_#{session.id}",
+        {"action" => "subagent_evicted", "session_id" => session.id, "child_id" => child.id}
+      )
+
+      broadcaster.emit(event)
+    end
+  end
+end

--- a/spec/lib/mneme/runner_spec.rb
+++ b/spec/lib/mneme/runner_spec.rb
@@ -240,6 +240,80 @@ RSpec.describe Mneme::Runner do
     end
   end
 
+  describe "sub-agent HUD visibility sweep after eviction" do
+    let!(:anchor) { create(:message, :user_message, session:, token_count: 100) }
+    let!(:filler) { create(:message, :user_message, session:, token_count: 100) }
+    let!(:next_anchor) { create(:message, :user_message, session:, token_count: 100) }
+
+    before { session.update_column(:mneme_boundary_message_id, anchor.id) }
+
+    it "flips child.hud_visible to false and emits SubagentEvicted when no traces remain" do
+      child = Session.create!(
+        parent_session: session,
+        prompt: "task",
+        name: "loop-sleuth",
+        spawn_tool_use_id: "toolu_spawn_123"
+      )
+
+      events = []
+      allow(Events::Bus).to receive(:emit).and_wrap_original do |original, event|
+        events << event
+        original.call(event)
+      end
+
+      allow(client).to receive(:chat_with_tools) { "Done" }
+      runner.call
+
+      expect(child.reload.hud_visible).to be false
+      evicted = events.find { |e| e.is_a?(Events::SubagentEvicted) }
+      expect(evicted).to have_attributes(session_id: session.id, child_id: child.id)
+    end
+
+    it "keeps child.hud_visible true when the spawn pair survives the advance" do
+      # anchor/filler/next_anchor make up the eviction zone (boundary is anchor.id).
+      # after_zone is the first conversation message beyond the zone — the new
+      # boundary lands here. The spawn_call sits past that, so the trace still
+      # lives in the viewport after the advance.
+      create(:message, :user_message, session:, token_count: 100)
+      child = Session.create!(
+        parent_session: session,
+        prompt: "task",
+        name: "scout",
+        spawn_tool_use_id: "toolu_spawn_456"
+      )
+      create(:message, :bash_tool_call, session:,
+        tool_use_id: "toolu_spawn_456",
+        payload: {"tool_name" => "spawn_subagent", "tool_use_id" => "toolu_spawn_456"},
+        token_count: 50)
+
+      allow(client).to receive(:chat_with_tools) { "Done" }
+      runner.call
+
+      expect(child.reload.hud_visible).to be true
+    end
+
+    it "does not re-emit SubagentEvicted for sub-agents already hidden" do
+      child = Session.create!(
+        parent_session: session,
+        prompt: "task",
+        name: "loop-sleuth",
+        spawn_tool_use_id: "toolu_spawn_789",
+        hud_visible: false
+      )
+
+      events = []
+      allow(Events::Bus).to receive(:emit).and_wrap_original do |original, event|
+        events << event
+        original.call(event)
+      end
+
+      allow(client).to receive(:chat_with_tools) { "Done" }
+      runner.call
+
+      expect(events).not_to include(an_instance_of(Events::SubagentEvicted).and(have_attributes(child_id: child.id)))
+    end
+  end
+
   describe "integration with real LLM", vcr: {match_requests_on: [:method, :uri]} do
     it "calls save_snapshot with a meaningful summary" do
       first = create(:message, :user_message, session:, token_count: 20,

--- a/spec/lib/tools/registry_spec.rb
+++ b/spec/lib/tools/registry_spec.rb
@@ -142,6 +142,36 @@ RSpec.describe Tools::Registry do
         expect(result).to eq("")
       end
     end
+
+    context "with tool_use_id" do
+      let(:uid_capturing_tool_class) do
+        Class.new(Tools::Base) do
+          def self.tool_name = "uid_capture"
+          def self.description = "Captures the tool_use_id from context"
+          def self.input_schema = {type: "object", properties: {}, required: []}
+
+          def initialize(tool_use_id: nil, **)
+            @tool_use_id = tool_use_id
+          end
+
+          def execute(_input)
+            @tool_use_id.to_s
+          end
+        end
+      end
+
+      it "forwards tool_use_id to the tool's initializer" do
+        registry.register(uid_capturing_tool_class)
+
+        expect(registry.execute("uid_capture", {}, tool_use_id: "toolu_xyz")).to eq("toolu_xyz")
+      end
+
+      it "omits tool_use_id from the context when none is provided" do
+        registry.register(uid_capturing_tool_class)
+
+        expect(registry.execute("uid_capture", {})).to eq("")
+      end
+    end
   end
 
   describe "instance-based tools" do

--- a/spec/lib/tools/spawn_subagent_spec.rb
+++ b/spec/lib/tools/spawn_subagent_spec.rb
@@ -96,6 +96,18 @@ RSpec.describe Tools::SpawnSubagent do
       expect(child.parent_session).to eq(parent_session)
     end
 
+    it "captures the invoking tool_call's id on the child as spawn_tool_use_id" do
+      tool = described_class.new(
+        session: parent_session,
+        shell_session: shell_session,
+        tool_use_id: "toolu_spawn_abc"
+      )
+
+      tool.execute(input)
+
+      expect(Session.last.spawn_tool_use_id).to eq("toolu_spawn_abc")
+    end
+
     it "inherits the parent shell's working directory" do
       tool.execute(input)
 

--- a/spec/models/pending_message_spec.rb
+++ b/spec/models/pending_message_spec.rb
@@ -75,6 +75,38 @@ RSpec.describe PendingMessage do
     end
   end
 
+  describe "#promote_as_phantom_pair! for sub-agent deliveries" do
+    let(:parent) { create(:session) }
+    let!(:child) { Session.create!(parent_session: parent, prompt: "task", name: "loop-sleuth", hud_visible: false) }
+
+    it "restores hud_visible on the child and re-broadcasts the children list" do
+      pm = create(:pending_message, :subagent, session: parent, content: "result", source_name: "loop-sleuth")
+
+      payload = nil
+      allow(ActionCable.server).to receive(:broadcast) do |stream, data|
+        payload = data if stream == "session_#{parent.id}" && data["action"] == "children_updated"
+      end
+
+      pm.send(:promote_as_phantom_pair!)
+
+      expect(child.reload.hud_visible).to be true
+      expect(payload).to be_present
+      expect(payload["children"].map { |c| c["id"] }).to include(child.id)
+    end
+
+    it "leaves an already-visible sub-agent untouched (no broadcast)" do
+      child.update_column(:hud_visible, true)
+      pm = create(:pending_message, :subagent, session: parent, content: "result", source_name: "loop-sleuth")
+
+      expect(ActionCable.server).not_to receive(:broadcast).with(
+        "session_#{parent.id}",
+        a_hash_including("action" => "children_updated")
+      )
+
+      pm.send(:promote_as_phantom_pair!)
+    end
+  end
+
   describe "broadcasts" do
     it "broadcasts pending_message_created on create" do
       expect { create(:pending_message, session: session, content: "waiting") }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -265,6 +265,20 @@ RSpec.describe Session do
       child_a.broadcast_children_update_to_parent
     end
 
+    it "omits sub-agents whose traces have been fully evicted from the HUD" do
+      parent = Session.create!
+      visible = Session.create!(parent_session: parent, prompt: "agent A", name: "analyzer")
+      Session.create!(parent_session: parent, prompt: "agent B", name: "reviewer", hud_visible: false)
+
+      payload = nil
+      allow(ActionCable.server).to receive(:broadcast) { |_, data| payload = data }
+
+      visible.broadcast_children_update_to_parent
+
+      ids = payload["children"].map { |c| c["id"] }
+      expect(ids).to contain_exactly(visible.id)
+    end
+
     it "does nothing for root sessions" do
       root = Session.create!
 
@@ -293,6 +307,60 @@ RSpec.describe Session do
 
       child_data = payload["children"].first
       expect(child_data.keys).to contain_exactly("id", "name", "session_state")
+    end
+  end
+
+  describe "#subagent_trace_in_viewport?" do
+    let(:parent) { Session.create! }
+    let(:child) do
+      Session.create!(parent_session: parent, prompt: "task", name: "sleuth", spawn_tool_use_id: "toolu_spawn_abc")
+    end
+
+    it "returns true when the spawn pair lives above the Mneme boundary" do
+      spawn_call = create(:message, :bash_tool_call, session: parent,
+        tool_use_id: "toolu_spawn_abc",
+        payload: {"tool_name" => "spawn_subagent", "tool_use_id" => "toolu_spawn_abc"})
+      parent.update_column(:mneme_boundary_message_id, spawn_call.id)
+
+      expect(parent.subagent_trace_in_viewport?(child)).to be true
+    end
+
+    it "returns true when any from_<nickname> phantom pair lives above the boundary" do
+      anchor = create(:message, :user_message, session: parent)
+      parent.update_column(:mneme_boundary_message_id, anchor.id)
+      create(:message, :bash_tool_call, session: parent,
+        tool_use_id: "phantom_1",
+        payload: {"tool_name" => "from_sleuth", "tool_use_id" => "phantom_1"})
+
+      expect(parent.subagent_trace_in_viewport?(child)).to be true
+    end
+
+    it "returns false when every trace is below the boundary" do
+      create(:message, :bash_tool_call, session: parent,
+        tool_use_id: "toolu_spawn_abc",
+        payload: {"tool_name" => "spawn_subagent", "tool_use_id" => "toolu_spawn_abc"})
+      create(:message, :bash_tool_call, session: parent,
+        tool_use_id: "phantom_1",
+        payload: {"tool_name" => "from_sleuth", "tool_use_id" => "phantom_1"})
+      anchor = create(:message, :user_message, session: parent)
+      parent.update_column(:mneme_boundary_message_id, anchor.id)
+
+      expect(parent.subagent_trace_in_viewport?(child)).to be false
+    end
+
+    it "returns false when the session is not the child's parent" do
+      stranger = Session.create!
+      create(:message, :bash_tool_call, session: stranger,
+        tool_use_id: "toolu_spawn_abc",
+        payload: {"tool_name" => "spawn_subagent", "tool_use_id" => "toolu_spawn_abc"})
+
+      expect(stranger.subagent_trace_in_viewport?(child)).to be false
+    end
+
+    it "returns false for a legacy child with no spawn_tool_use_id and no name" do
+      nameless = Session.create!(parent_session: parent, prompt: "legacy")
+
+      expect(parent.subagent_trace_in_viewport?(nameless)).to be false
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #431.

Sub-agents now drop out of the TUI HUD panel as soon as Mneme's eviction cycle takes the last trace of them out of the parent viewport — and come back if a later delivery reintroduces a trace. TUI reconnects rehydrate only the sub-agents still visible in the HUD.

### What landed

- **Schema** — `sessions.hud_visible` (boolean, default `true`) and `sessions.spawn_tool_use_id` (nullable string), indexed on `(parent_session_id, hud_visible)`.
- **Trace detection** — `Session#subagent_trace_in_viewport?(child)` checks the parent's messages above `mneme_boundary_message_id` for the spawn pair (`tool_use_id == child.spawn_tool_use_id`) or any `from_<nickname>` phantom pair.
- **Eviction sweep** — `Mneme::Runner#after_call` calls a new `refresh_subagent_visibility` right after advancing the boundary. Children with no remaining trace flip to `hud_visible: false` and emit `Events::SubagentEvicted`.
- **Broadcast** — `Events::Subscribers::SubagentVisibilityBroadcaster` turns `SubagentEvicted` into `{"action" => "subagent_evicted", "child_id" => ...}` on the parent stream. The TUI's `handle_subagent_evicted` removes the entry.
- **Flip back** — `PendingMessage#promote_as_phantom_pair!` restores `hud_visible: true` and re-broadcasts `children_updated` when a sub-agent reply lands after prior eviction.
- **Reconnect** — `SessionChannel#transmit_session_changed` and `Session#broadcast_children_update_to_parent` filter on `hud_visible: true` so the HUD panel stays accurate across TUI restarts.
- **Spawn-pair linkage** — `Tools::Registry#execute` now threads the invoking `tool_use_id` into the tool context; `SpawnSubagent` and `SpawnSpecialist` persist it on the child as `spawn_tool_use_id`. `ToolExecutionJob` forwards it.

### Out of scope

- Pre-existing sub-agents have `spawn_tool_use_id: nil` (DB default). Their visibility is driven purely by `from_<nickname>` phantom pairs — acceptable fallback, no backfill needed.

## Test plan

- [x] `bundle exec rspec` — 2438 examples, 0 failures.
- [x] `bundle exec standardrb` clean.
- [x] `bundle exec reek` no new warnings outside the existing `EvictionBroadcaster`-shaped `UtilityFunction` note.
- [ ] Manual TUI smoke: spawn a sub-agent, wait for eviction to pass the spawn pair + all `from_<nickname>` pairs, confirm HUD entry disappears; send a new message from the sub-agent, confirm HUD entry reappears.
- [ ] Manual TUI reconnect: hide a sub-agent via eviction, quit the TUI, reopen — the HUD panel should render without the evicted sub-agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted visibility state on `sessions` and ties it to Mneme eviction and ActionCable broadcasts, which could cause incorrect HUD state or missed updates if the trace query/broadcast timing is wrong. Changes span DB, eviction runner, tool execution context, and TUI event handling, increasing integration risk.
> 
> **Overview**
> Sub-agent entries in the TUI HUD now **automatically disappear when Mneme eviction removes the sub-agent’s last trace from the parent viewport**, and reappear if a later sub-agent delivery reintroduces a trace.
> 
> This adds `sessions.hud_visible` and `sessions.spawn_tool_use_id`, filters child-session lists (`SessionChannel#transmit_session_changed` and `Session#broadcast_children_update_to_parent`) to only include `hud_visible` children, and adds a Mneme post-eviction sweep (`Mneme::Runner#refresh_subagent_visibility`) that flips visibility off and emits a new `Events::SubagentEvicted` event.
> 
> Tool execution now threads the invoking `tool_use_id` through `ToolExecutionJob` → `Tools::Registry#execute` so `spawn_subagent`/`spawn_specialist` can persist `spawn_tool_use_id` on the child session, and the TUI gains a `subagent_evicted` ActionCable handler to remove the HUD entry immediately; sub-agent phantom-pair promotion restores visibility (and rebroadcasts `children_updated`) when a hidden sub-agent speaks again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83bc907d597813357def2db9689d3bf903e2be21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->