### PR TITLE
#463 feat: clarify push-based delivery model in sisters section

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -734,14 +734,14 @@ class Session < ApplicationRecord
     <<~SISTERS.strip
       ## Your Sisters
 
-      You don't work alone. Two muses share the conversation with you, and their work arrives as tool calls prefixed `from_`:
+      You don't work alone. Two muses share the conversation with you, and their work arrives as tool responses prefixed `from_`:
 
       - **Melete**, the muse of practice, prepares the stage before you speak. Her contributions arrive as `from_melete_skill`, `from_melete_workflow`, and `from_melete_goal`.
       - **Mneme**, the muse of memory, holds what has slipped past your immediate attention. When something from earlier matters again she surfaces it as `from_mneme`.
 
       Sub-agents you spawn arrive the same way, named after whoever sent them — `from_sleuth`, `from_scout`, and so on.
 
-      The `from_` prefix is the only signal you need: anything with it is information delivered *to* you, not a tool you called. Those names aren't in your toolkit — trying to invoke one will fail.
+      **How delivery works:** Results from sisters and sub-agents appear automatically as tool responses in your conversation — you don't fetch them. There is no tool to call, no way to poll, and no status to check. When a sub-agent finishes, its output shows up on its own. If you're waiting on multiple agents, just wait — they'll arrive. Do other work in the meantime if you can.
     SISTERS
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -977,7 +977,7 @@ RSpec.describe Session do
       expect(prompt).to include("from_melete_skill")
       expect(prompt).to include("Mneme")
       expect(prompt).to include("from_mneme")
-      expect(prompt).to include("`from_` prefix")
+      expect(prompt).to include("**How delivery works:**")
     end
 
     it "places the sisters block after the soul and before snapshots" do


### PR DESCRIPTION
Closes #463.

## Problem

The "Your Sisters" section in the system prompt told the agent what NOT to do ("those names aren't in your toolkit — trying to invoke one will fail") but not what TO do. Under cognitive load — e.g. waiting on 5 parallel sub-agents during a PR review — this led to repeated polling attempts, hammering `from_<nickname>` as if it were a tool, hitting `Unknown tool` errors with no way to distinguish "still working" from "finished."

The root issue: the original wording said "tool calls" and framed delivery as a constraint. The agent needs a mental model, not a prohibition.

## Solution

Two changes to `Session#assemble_sisters_section`:

1. **"tool responses" instead of "tool calls"** — they're incoming, not outgoing
2. **Replace the negative constraint** with a "How delivery works" paragraph explaining push-based delivery: results arrive automatically, there's nothing to call/poll/check, just wait

## Test plan

- [x] `bundle exec rspec spec/models/session_spec.rb` — 212 examples, 0 failures
- [x] `bundle exec standardrb` — clean

---
🧬 Built by [Ani](https://github.com/hoblin/anima) (anima-core v1.4.0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts system-prompt wording and a matching spec assertion; no runtime logic or data flow changes.
> 
> **Overview**
> Clarifies the `## Your Sisters` system-prompt section to describe sister/sub-agent outputs as incoming *tool responses* and adds an explicit **push-based delivery** explanation (no polling/unknown-tool calls).
> 
> Updates the `Session#assemble_system_prompt` spec to assert the new delivery paragraph (`**How delivery works:**`) instead of the prior `from_`-prefix warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea12dccc4a0a1d4bccb95948225c6aba3a18ea3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->