### PR TITLE
#466 refactor: ShellSession on tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Two more subsystems are designed but not yet implemented: **Thymos** (a hormonal
 
 Anima is a Rails app distributed as a gem, following Unix philosophy: immutable program separate from mutable data.
 
+**Requirements:** Ruby 3.4+, `tmux` (used as the persistent shell backend for the bash tool), `gh` (GitHub CLI, for issue/PR tools).
+
 ```bash
 gem install anima-core       # Install the Rails app as a gem
 anima install                # Create ~/.anima/, set up databases, start brain as systemd service

--- a/lib/anima/settings.rb
+++ b/lib/anima/settings.rb
@@ -194,16 +194,6 @@ module Anima
       # @return [String] absolute path
       def soul_path = get("paths", "soul")
 
-      # ─── Environment ──────────────────────────────────────────────
-
-      # Filenames to scan for in the working directory.
-      # @return [Array<String>]
-      def project_files_whitelist = get("environment", "project_files")
-
-      # Maximum directory depth for project file scanning.
-      # @return [Integer]
-      def project_files_max_depth = get("environment", "project_files_max_depth")
-
       # ─── GitHub ─────────────────────────────────────────────────────
 
       # Repository for feature requests (+owner/repo+ format).

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -34,7 +34,6 @@ class ShellSession
   PANE_WIDTH = 200
   PANE_HEIGHT = 50
   HISTORY_LIMIT = 5_000
-  IDLE_POLL_INTERVAL = 0.1
 
   # Env vars that disable interactive pagers and credential prompts in
   # the shell. Without these, tools like +gh+, +git+, +man+, +journalctl+
@@ -218,29 +217,27 @@ class ShellSession
     line = "#{exports}; tmux wait-for -S init-#{uuid}"
     system("tmux", "send-keys", "-t", @target, line, "Enter", out: File::NULL, err: File::NULL)
     pid = Process.spawn("tmux", "wait-for", "init-#{uuid}", out: File::NULL, err: File::NULL)
-    deadline = monotonic_now + 5
-    loop do
-      _, status = Process.wait2(pid, Process::WNOHANG)
-      break if status
-      if monotonic_now > deadline
-        begin
-          Process.kill("TERM", pid)
-        rescue
-          Errno::ESRCH
-        end
-        begin
-          Process.wait(pid)
-        rescue
-          Errno::ECHILD
-        end
-        raise "tmux session #{@target} init timed out"
-      end
-      sleep IDLE_POLL_INTERVAL
+    waiter = Process.detach(pid)
+    return if waiter.join(5)
+
+    begin
+      Process.kill("TERM", pid)
+    rescue
+      Errno::ESRCH
     end
+    waiter.join
+    raise "tmux session #{@target} init timed out"
   end
 
-  # Blocks on +tmux wait-for+, polling for interrupt and timeout. On
-  # cancel we send +C-c+ to abort the running command, then kill the
+  # Blocks until the +tmux wait-for+ child exits (= the bash command in
+  # the pane finished and ran +tmux wait-for -S+), the deadline expires,
+  # or the user requests an interrupt.
+  #
+  # No polling: {Process.detach} returns a Thread that waits on the
+  # child, and {Thread#join} blocks until either the thread finishes or
+  # the timeout fires — returning immediately when the child exits.
+  #
+  # On cancel we send +C-c+ to abort the running command, then kill the
   # wait-for child directly — interactive bash discards the rest of the
   # input line on SIGINT, so the trailing +tmux wait-for -S+ never fires
   # and we can't rely on natural signaling.
@@ -248,41 +245,34 @@ class ShellSession
   # @return [Symbol] +:done+, +:interrupted+, or +:timeout+
   def wait_for_completion(uuid, timeout, interrupt_check)
     pid = Process.spawn("tmux", "wait-for", "done-#{uuid}", out: File::NULL, err: File::NULL)
+    waiter = Process.detach(pid)
     deadline = monotonic_now + timeout
-    poll_interval = interrupt_check ? Anima::Settings.interrupt_check_interval : IDLE_POLL_INTERVAL
+    interrupt_interval = interrupt_check ? Anima::Settings.interrupt_check_interval : timeout
 
     loop do
-      _, status = Process.wait2(pid, Process::WNOHANG)
-      return :done if status
+      remaining = deadline - monotonic_now
+      return cancel_command(pid, waiter, :timeout) if remaining <= 0
 
-      if interrupt_check&.call
-        cancel_command(pid)
-        return :interrupted
-      end
+      # Block until child exits, the next interrupt-check tick, or the deadline.
+      slice = [remaining, interrupt_interval].min
+      return :done if waiter.join(slice)
 
-      if monotonic_now > deadline
-        cancel_command(pid)
-        return :timeout
-      end
-
-      sleep poll_interval
+      return cancel_command(pid, waiter, :interrupted) if interrupt_check&.call
     end
   end
 
-  # Sends Ctrl+C to abort the running command, then reaps the
-  # wait-for child. Idempotent against already-dead processes.
-  def cancel_command(wait_for_pid)
+  # Sends Ctrl+C to abort the running command, kills the wait-for
+  # child, and waits for the detach thread to reap it. Returns +state+
+  # so call sites can inline +return cancel_command(...)+.
+  def cancel_command(pid, waiter, state)
     send_ctrl_c
     begin
-      Process.kill("TERM", wait_for_pid)
-    rescue Errno::ESRCH
-      # Already exited — wait-for unblocked between our last poll and now
+      Process.kill("TERM", pid)
+    rescue
+      Errno::ESRCH
     end
-    begin
-      Process.wait(wait_for_pid)
-    rescue Errno::ECHILD
-      # Already reaped
-    end
+    waiter.join
+    state
   end
 
   def send_ctrl_c

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -66,6 +66,20 @@ class ShellSession
   # server-side, so Ruby must pass the literal string.
   PANE_CWD_FORMAT = '#{pane_current_path}' # rubocop:disable Lint/InterpolationCheck
 
+  # Grace period before escalating SIGTERM → SIGKILL when reaping a
+  # wedged +tmux wait-for+ child. tmux clients normally exit on TERM
+  # within milliseconds; 5 seconds is generous enough that a healthy
+  # one always makes it, while an unkillable one never hangs the shell.
+  WAITER_KILL_GRACE = 5
+
+  # Serializes the cold-start path of {.for_session} / {#initialize} —
+  # +alive?+ → +new-session+ → +inject_shell_env+. Without it, two
+  # threads racing on the same +session_id+ both see +alive?+ false,
+  # both run +new-session+ (the second silently fails), and both run
+  # +inject_shell_env+, double-exporting and corrupting the pane.
+  # Held only during cold start; warm-path callers don't contend.
+  INIT_MUTEX = Mutex.new
+
   # @return [Integer, String] identifier of the {Session} this shell belongs to
   attr_reader :session_id
 
@@ -124,7 +138,7 @@ class ShellSession
   def initialize(session_id:, initial_cwd: nil)
     @session_id = session_id
     @target = "#{TMUX_SESSION_PREFIX}#{session_id}"
-    ensure_session(initial_cwd)
+    INIT_MUTEX.synchronize { ensure_session(initial_cwd) }
   end
 
   # Execute a command in the persistent shell.
@@ -164,12 +178,17 @@ class ShellSession
     state = wait_for_completion(uuid, timeout, interrupt_check)
     output = capture_output
 
+    return {error: "tmux capture-pane failed (session may have died)"} if output.nil?
+
     case state
     when :done then {output: output}
     when :interrupted then {output: output, interrupted: true}
     when :timeout then {error: "Command timed out after #{timeout} seconds.\n\n#{output}"}
     end
-  rescue => error # rubocop:disable Lint/RescueException -- LLM must always get a result hash, never a stack trace
+  rescue => error
+    # Catch-all isolates the LLM tool-call boundary: a stray exception
+    # from tmux internals must surface as a result hash rather than tear
+    # down the conversation pipeline.
     {error: "#{error.class}: #{error.message}"}
   end
 
@@ -226,14 +245,9 @@ class ShellSession
     system("tmux", "send-keys", "-t", @target, line, "Enter", out: File::NULL, err: File::NULL)
     pid = Process.spawn("tmux", "wait-for", "init-#{uuid}", out: File::NULL, err: File::NULL)
     waiter = Process.detach(pid)
-    return if waiter.join(5)
+    return if waiter.join(WAITER_KILL_GRACE)
 
-    begin
-      Process.kill("TERM", pid)
-    rescue Errno::ESRCH
-      # Already exited between waiter.join's deadline and our kill — fine.
-    end
-    waiter.join
+    reap_waiter(pid, waiter)
     raise "tmux session #{@target} init timed out"
   end
 
@@ -269,18 +283,33 @@ class ShellSession
     end
   end
 
-  # Sends Ctrl+C to abort the running command, kills the wait-for
-  # child, and waits for the detach thread to reap it. Returns +state+
-  # so call sites can inline +return cancel_command(...)+.
+  # Sends Ctrl+C to abort the running command and reaps the wait-for
+  # child. Returns +state+ so call sites can inline
+  # +return cancel_command(...)+.
   def cancel_command(pid, waiter, state)
     send_ctrl_c
+    reap_waiter(pid, waiter)
+    state
+  end
+
+  # Reaps a +tmux wait-for+ child after a cancel decision (Ctrl+C or
+  # init timeout). Sends SIGTERM, waits up to {WAITER_KILL_GRACE}
+  # seconds, escalates to SIGKILL if the client is wedged. Guarantees
+  # the caller never blocks indefinitely on a stuck tmux client.
+  def reap_waiter(pid, waiter)
     begin
       Process.kill("TERM", pid)
     rescue Errno::ESRCH
-      # wait-for already exited (raced with our kill) — fine.
+      # Already exited (raced with our kill) — fine.
+    end
+    return if waiter.join(WAITER_KILL_GRACE)
+
+    begin
+      Process.kill("KILL", pid)
+    rescue Errno::ESRCH
+      # Exited between TERM and KILL — fine.
     end
     waiter.join
-    state
   end
 
   def send_ctrl_c
@@ -304,9 +333,15 @@ class ShellSession
   # trailing prompt — nothing leaked from the previous pane state.
   # The +-J+ flag joins terminal-wrapped lines so a long single-line
   # output comes back whole.
+  # @return [String] rendered terminal text on success
+  # @return [nil] when +capture-pane+ exits non-zero (e.g. the session
+  #   died between {#wait_for_completion} and the capture). Caller
+  #   surfaces this as an error to the LLM rather than letting an empty
+  #   string be mistaken for a silent command success.
   def capture_output
-    raw, _ = Open3.capture2("tmux", "capture-pane", "-pJ", "-t", @target, "-S", "-", err: File::NULL)
-    output = truncate(raw.dup.force_encoding("UTF-8").scrub)
+    raw, status = Open3.capture2("tmux", "capture-pane", "-pJ", "-t", @target, "-S", "-", err: File::NULL)
+    return nil unless status.success?
+    output = truncate(raw.force_encoding("UTF-8").scrub)
     output.strip.empty? ? EMPTY_OUTPUT_PLACEHOLDER : output
   end
 

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -295,7 +295,7 @@ class ShellSession
   #    and bash redrawing its prompt — the pane is all whitespace.
   # Either way the LLM gets a coherent message, and the downstream
   # +Message#content+ validation doesn't reject the empty result.
-  EMPTY_OUTPUT_PLACEHOLDER = "(command produced no output)"
+  EMPTY_OUTPUT_PLACEHOLDER = "OK"
 
   # Captures the pane scrollback + visible content. Because we ran
   # +tmux clear-history+ before sending and the shell +clear+ wiped both

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -31,8 +31,16 @@ class ShellSession
   # (current and future) match on to leave unrelated tmux sessions alone.
   TMUX_SESSION_PREFIX = "anima-shell-"
 
+  # Pane geometry — 200×50 is wide enough for most tool output without
+  # forcing wraps that would inflate captures, and tall enough that the
+  # agent sees normal command runs without scrollback in the visible area.
   PANE_WIDTH = 200
   PANE_HEIGHT = 50
+
+  # Scrollback cap. tmux retains the last N lines of output per pane,
+  # discarding older ones automatically — this is what bounds memory and
+  # closes the OOM bug from the old PTY+FIFO design. Each line costs
+  # roughly 1–2KB inside tmux, so 5000 lines ≈ 5–10MB resident per pane.
   HISTORY_LIMIT = 5_000
 
   # Env vars that disable interactive pagers and credential prompts in
@@ -222,8 +230,8 @@ class ShellSession
 
     begin
       Process.kill("TERM", pid)
-    rescue
-      Errno::ESRCH
+    rescue Errno::ESRCH
+      # Already exited between waiter.join's deadline and our kill — fine.
     end
     waiter.join
     raise "tmux session #{@target} init timed out"
@@ -268,8 +276,8 @@ class ShellSession
     send_ctrl_c
     begin
       Process.kill("TERM", pid)
-    rescue
-      Errno::ESRCH
+    rescue Errno::ESRCH
+      # wait-for already exited (raced with our kill) — fine.
     end
     waiter.join
     state
@@ -291,10 +299,15 @@ class ShellSession
     truncate(raw.dup.force_encoding("UTF-8").scrub)
   end
 
+  # Truncates +output+ to {Anima::Settings.max_output_bytes}. The
+  # truncation notice itself counts against the cap, so the returned
+  # string is always +<= max_output_bytes+ — a contract callers can rely
+  # on for context-window budgeting.
   def truncate(output)
     max = Anima::Settings.max_output_bytes
     return output if output.bytesize <= max
-    output.byteslice(0, max).scrub + "\n\n[Truncated: output exceeded #{max} bytes]"
+    notice = "\n\n[Truncated: output exceeded #{max} bytes]"
+    output.byteslice(0, max - notice.bytesize).scrub + notice
   end
 
   def monotonic_now

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -1,775 +1,313 @@
 # frozen_string_literal: true
 
-require "io/console"
-require "monitor"
 require "open3"
-require "pathname"
-require "pty"
 require "securerandom"
 require "shellwords"
-require "uri"
 
-# Immutable snapshot of the shell's environment for change detection.
-# Compared between commands to produce natural-language summaries of what
-# changed — the agent discovers its environment through Bash tool responses.
+# Persistent shell session backed by a tmux session. Commands share
+# working directory, environment, and shell history within a conversation.
+# Multiple tools share the same session via {.for_session}.
 #
-# @!attribute [r] pwd
-#   @return [String, nil] current working directory
-# @!attribute [r] branch
-#   @return [String, nil] current git branch name
-# @!attribute [r] repo
-#   @return [String, nil] "owner/repo" extracted from git origin remote
-# @!attribute [r] project_files
-#   @return [Array<String>] sorted relative paths to project instruction files
-EnvironmentSnapshot = Data.define(:pwd, :branch, :repo, :project_files) do
-  # Sentinel for "never detected" — diffs against this produce a full snapshot.
-  def self.blank = new(pwd: nil, branch: nil, repo: nil, project_files: [])
-end
-
-# Persistent shell session backed by a PTY with FIFO-based stderr separation.
-# Commands share working directory, environment variables, and shell history
-# within a conversation. Multiple tools share the same session.
+# tmux is the source of truth — the {ShellSession} object is a disposable
+# handle. The tmux session survives Anima crashes; teardown happens only
+# through {.release} or {#finalize} (e.g. when the owning {Session} record
+# is deleted).
 #
-# Auto-recovers from timeouts and crashes: if the shell dies, the next command
-# transparently respawns a fresh shell and restores the working directory.
+# Sub-agents inherit cwd from their parent's tmux session at the moment
+# the child shell is created. The lookup is dynamic — the parent's
+# *current* cwd is captured, not a snapshot from spawn time.
 #
-# After each successful command, detects environment changes (CWD, git branch,
-# project files) and includes a natural-language summary in the result hash.
-# This replaces the old EnvironmentProbe system-prompt injection, keeping the
-# system prompt static for prompt caching.
-#
-# Uses IO.select-based deadlines instead of Timeout.timeout for all PTY reads.
-# Timeout.timeout is unsafe with PTY I/O — it uses Thread.raise which can
-# corrupt mutex state, leave resources inconsistent, and cause exceptions
-# to fire outside handler blocks when nested.
+# tmux is a hard runtime dependency. {#initialize} raises a clear error if
+# tmux is missing.
 #
 # @example
-#   session = ShellSession.new(session_id: 42)
-#   session.run("cd /tmp")
-#   session.run("pwd")
-#   # => {stdout: "/tmp", stderr: "", exit_code: 0}
-#   session.finalize
+#   shell = ShellSession.for_session(session)
+#   shell.run("cd /tmp")
+#   shell.run("pwd")
+#   # => {output: "/tmp"}
 class ShellSession
-  # @return [Integer, String] identifier of the {Session} (or spec fixture)
-  #   this shell belongs to
+  # Prefix for every tmux session Anima owns. The full session name is
+  # +anima-shell-{session_id}+; this prefix is what cleanup sweeps
+  # (current and future) match on to leave unrelated tmux sessions alone.
+  TMUX_SESSION_PREFIX = "anima-shell-"
+
+  PANE_WIDTH = 200
+  PANE_HEIGHT = 50
+  HISTORY_LIMIT = 5_000
+  IDLE_POLL_INTERVAL = 0.1
+
+  # Env vars that disable interactive pagers and credential prompts in
+  # the shell. Without these, tools like +gh+, +git+, +man+, +journalctl+
+  # spawn +less+ and block the pane waiting for keypresses — our
+  # +wait-for -S+ never fires, the run hangs to timeout. Set once at
+  # session creation via +new-session -e+ so they propagate to every
+  # command.
+  SHELL_ENV = {
+    "PAGER" => "cat",
+    "GIT_PAGER" => "cat",
+    "MANPAGER" => "cat",
+    "LESS" => "-eFRX",
+    "SYSTEMD_PAGER" => "",
+    "AWS_PAGER" => "",
+    "PSQL_PAGER" => "cat",
+    "BAT_PAGER" => "cat",
+    "GIT_TERMINAL_PROMPT" => "0"
+  }.freeze
+
+  # tmux format-string for the pane's current working directory.
+  # Single-quoted intentionally — tmux performs the +#{...}+ substitution
+  # server-side, so Ruby must pass the literal string.
+  PANE_CWD_FORMAT = '#{pane_current_path}' # rubocop:disable Lint/InterpolationCheck
+
+  # @return [Integer, String] identifier of the {Session} this shell belongs to
   attr_reader :session_id
 
-  # @return [String, nil] current working directory of the shell process
-  attr_reader :pwd
-
-  # Returns the live shell bound to +session+, spawning one the first time
-  # a conversation reaches for bash and reusing it for every subsequent
-  # call. The expensive steps (login shell profile load, PTY + FIFO setup,
-  # +cd+ into +session.initial_cwd+) happen once per conversation, not
-  # once per tool call — so the user's PATH, aliases, and any env vars the
-  # agent sets along the way survive between commands within that session.
-  #
-  # Dead cached shells (after a crash or explicit finalize) are replaced
-  # transparently; {#run} would respawn on its own anyway, but we also
-  # reset +initial_cwd+ on a fresh spawn so the new shell lands where the
-  # conversation started.
+  # Returns the shell bound to +session+. Sub-agents inherit cwd from
+  # their parent's tmux session via {.cwd_via_tmux}, falling back to
+  # +session.initial_cwd+ for root sessions or when the parent's tmux
+  # session is gone.
   #
   # @param session [Session] owning conversation
   # @return [ShellSession]
   def self.for_session(session)
-    id = session.id
-
-    existing, shell = @sessions_mutex.synchronize do
-      cached = @sessions_by_id[id]
-      next [cached, nil] if cached&.alive?
-
-      release(id) if cached
-      [nil, new(session_id: id)]
-    end
-    return existing if existing
-
-    cwd = session.initial_cwd
-    shell.run("cd #{Shellwords.shellescape(cwd)}") if cwd.present? && File.directory?(cwd)
-    shell
+    cwd = parent_cwd_for(session) || session.initial_cwd
+    new(session_id: session.id, initial_cwd: cwd)
   end
 
-  # @param session_id [Integer, String] unique identifier for logging/diagnostics
-  def initialize(session_id:)
+  # Kills the tmux session for +session_id+. Idempotent — silently
+  # succeeds when no such session exists.
+  #
+  # @param session_id [Integer, String]
+  # @return [void]
+  def self.release(session_id)
+    target = "#{TMUX_SESSION_PREFIX}#{session_id}"
+    system("tmux", "kill-session", "-t", target, out: File::NULL, err: File::NULL)
+    nil
+  end
+
+  # Reads the working directory of +session_id+'s tmux pane directly
+  # from the tmux server. Works even when the pane is mid-command — the
+  # +pane_current_path+ format variable is a server-side property
+  # (kernel +/proc/{pid}/cwd+ readlink), not shell-mediated.
+  #
+  # @param session_id [Integer, String]
+  # @return [String, nil] absolute path, or nil when the session is gone
+  def self.cwd_via_tmux(session_id)
+    target = "#{TMUX_SESSION_PREFIX}#{session_id}"
+    output, status = Open3.capture2(
+      "tmux", "display-message", "-p", "-t", target, PANE_CWD_FORMAT,
+      err: File::NULL
+    )
+    return nil unless status.success?
+    cwd = output.strip
+    cwd.empty? ? nil : cwd
+  end
+
+  # @return [String, nil] parent's current working directory, or nil for
+  #   root sessions and when the parent's tmux session is gone
+  def self.parent_cwd_for(session)
+    return nil unless session.parent_session_id
+    cwd_via_tmux(session.parent_session_id)
+  end
+  private_class_method :parent_cwd_for
+
+  # @param session_id [Integer, String]
+  # @param initial_cwd [String, nil] starting working directory
+  # @raise [RuntimeError] if tmux is missing or the session can't be created
+  def initialize(session_id:, initial_cwd: nil)
     @session_id = session_id
-    @mutex = Mutex.new
-    @fifo_path = File.join(Dir.tmpdir, "anima-stderr-#{Process.pid}-#{SecureRandom.hex(8)}")
-    @alive = false
-    @finalized = false
-    @pwd = nil
-    @env_snapshot = nil
-    @read_buffer = +""
-    self.class.cleanup_orphans
-    begin
-      start
-    rescue
-      # Reap the half-spawned PTY, FIFO, and stderr thread before bailing —
-      # otherwise a failed init_shell leaks a live process with no handle on it.
-      teardown
-      raise
-    end
-    self.class.register(self)
+    @target = "#{TMUX_SESSION_PREFIX}#{session_id}"
+    ensure_session(initial_cwd)
   end
 
-  # Execute a command in the persistent shell. Respawns the shell
-  # automatically if the previous session died (timeout, crash, etc.).
+  # Execute a command in the persistent shell.
+  #
+  # Capture sequence:
+  # 1. +tmux clear-history+ wipes off-screen scrollback.
+  # 2. +send-keys "clear; <cmd>; tmux wait-for -S done-<uuid>"+ — bash
+  #    receives the line: shell +clear+ erases the visible pane (and
+  #    scrollback via the +\e[3J+ sequence on modern terminfo), +<cmd>+
+  #    runs, then +wait-for -S+ signals the synchronization channel.
+  # 3. We block on +tmux wait-for done-<uuid>+ in a child process and
+  #    poll for interrupt/timeout. On either we send +C-c+ to the pane
+  #    and kill the wait-for child — interactive bash discards the
+  #    rest of the input line on SIGINT, so the trailing +wait-for -S+
+  #    never fires and we can't rely on natural signaling.
+  # 4. +capture-pane -pJ -S -+ pulls scrollback + visible pane, which
+  #    (after +clear+ wiped both) is exactly the new command's output
+  #    and trailing prompt.
   #
   # @param command [String] bash command to execute
-  # @param timeout [Integer, nil] per-call timeout in seconds; overrides
-  #   Settings.command_timeout when provided
+  # @param timeout [Integer, nil] per-call timeout in seconds; defaults to
+  #   {Anima::Settings.command_timeout}
   # @param interrupt_check [Proc, nil] callable returning truthy when the
-  #   user has requested an interrupt. Polled every
-  #   {Anima::Settings.interrupt_check_interval} seconds during command execution.
-  # @return [Hash] with :stdout, :stderr, :exit_code keys on success
-  # @return [Hash] with :interrupted, :stdout, :stderr keys on user interrupt
-  # @return [Hash] with :error key on failure
+  #   user has requested an interrupt
+  # @return [Hash{Symbol => Object}] +:output+ on success;
+  #   +:output+ + +:interrupted+ on user cancel; +:error+ on failure
   def run(command, timeout: nil, interrupt_check: nil)
-    @mutex.synchronize do
-      return {error: "Shell session is not running"} if @finalized
-      restart unless @alive
-      execute_in_pty(command, timeout: timeout, interrupt_check: interrupt_check)
+    return {error: "Shell session is not running"} unless alive?
+
+    uuid = SecureRandom.hex(8)
+    timeout ||= Anima::Settings.command_timeout
+
+    system("tmux", "clear-history", "-t", @target, out: File::NULL, err: File::NULL)
+    line = "clear; #{command}; tmux wait-for -S done-#{uuid}"
+    system("tmux", "send-keys", "-t", @target, line, "Enter", out: File::NULL, err: File::NULL)
+
+    state = wait_for_completion(uuid, timeout, interrupt_check)
+    output = capture_output
+
+    case state
+    when :done then {output: output}
+    when :interrupted then {output: output, interrupted: true}
+    when :timeout then {error: "Command timed out after #{timeout} seconds.\n\n#{output}"}
     end
   rescue => error # rubocop:disable Lint/RescueException -- LLM must always get a result hash, never a stack trace
     {error: "#{error.class}: #{error.message}"}
   end
 
-  # Clean up PTY, FIFO, and child process. Permanent — the session
-  # will not auto-respawn after this call.
-  def finalize
-    @mutex.synchronize do
-      @finalized = true
-      teardown
-    end
-    self.class.unregister(self)
-  end
-
-  # @return [Boolean] whether the shell process is still running
+  # @return [Boolean] whether the underlying tmux session exists
   def alive?
-    @mutex.synchronize { @alive }
+    !!system("tmux", "has-session", "-t", @target, out: File::NULL, err: File::NULL)
   end
 
-  # --- Class-level session tracking for at_exit cleanup ---
+  # Kills the underlying tmux session. Idempotent.
+  def finalize
+    self.class.release(@session_id)
+  end
 
-  # One live ShellSession per Session id. Conversations rent a shell from
-  # this map via {.for_session}; the map is the single source of truth for
-  # "which shells exist in this process". It has two readers: {.for_session}
-  # (cache lookup) and {.cleanup_all} (at_exit sweep).
+  # Reads the shell's current working directory directly from the tmux
+  # server. Works even mid-command — the lookup is server-side, not
+  # shell-mediated.
   #
-  # {Monitor} (not {Mutex}) because {.for_session} holds the lock across
-  # +new+, whose {#initialize} re-enters the same lock via {.register}. A
-  # plain mutex would deadlock.
-  @sessions_by_id = {}
-  @sessions_mutex = Monitor.new
-
-  class << self
-    # @api private
-    def register(session)
-      @sessions_mutex.synchronize { @sessions_by_id[session.session_id] = session }
-    end
-
-    # @api private
-    def unregister(session)
-      @sessions_mutex.synchronize do
-        @sessions_by_id.delete(session.session_id) if @sessions_by_id[session.session_id].equal?(session)
-      end
-    end
-
-    # Finalize the shell bound to +session_id+, if any. Called when a
-    # conversation is deliberately retired; idempotent if nothing is cached.
-    #
-    # @param session_id [Integer, String]
-    # @return [void]
-    def release(session_id)
-      shell = @sessions_mutex.synchronize { @sessions_by_id.delete(session_id) }
-      shell&.finalize
-    end
-
-    # Finalize all live sessions. Called automatically via at_exit.
-    def cleanup_all
-      @sessions_mutex.synchronize do
-        @sessions_by_id.each_value { |session| session.send(:teardown) }
-        @sessions_by_id.clear
-      end
-    end
-
-    # Resolves the shell to spawn. Falls back to /bin/bash when +$SHELL+ is
-    # unset or empty (e.g. cron, systemd, minimal containers).
-    #
-    # @return [String] absolute path to the login shell
-    def login_shell
-      ENV["SHELL"].presence || "/bin/bash"
-    end
-
-    # Remove stale FIFO files left by crashed processes.
-    # FIFO naming format: anima-stderr-{pid}-{hex}
-    def cleanup_orphans
-      Dir.glob(File.join(Dir.tmpdir, "anima-stderr-*")).each do |path|
-        match = File.basename(path).match(/\Aanima-stderr-(\d+)-/)
-        next unless match
-
-        pid = match[1].to_i
-        next if pid <= 0
-
-        begin
-          Process.kill(0, pid)
-        rescue Errno::ESRCH
-          begin
-            File.delete(path)
-          rescue SystemCallError
-            # Best-effort cleanup
-          end
-        rescue Errno::EPERM
-          # Process exists but we can't signal it — leave it
-        end
-      end
-    end
+  # @return [String, nil]
+  def pwd
+    self.class.cwd_via_tmux(@session_id)
   end
-
-  at_exit { ShellSession.cleanup_all }
 
   private
 
-  def start
-    create_fifo
-    spawn_shell
-    start_stderr_reader
-    init_shell
-    update_pwd
-    seed_env_snapshot
-    @alive = true
-  end
+  def ensure_session(cwd)
+    return if alive?
 
-  # Shuts down the current shell and spawns a fresh one, restoring the
-  # previous working directory. Called automatically when @alive is false.
-  def restart
-    saved_pwd = @pwd
-    teardown
-    @fifo_path = File.join(Dir.tmpdir, "anima-stderr-#{Process.pid}-#{SecureRandom.hex(8)}")
-    start
-    restore_working_directory(saved_pwd)
-  end
-
-  # Restores the shell's working directory after a respawn.
-  # Skips silently if the directory no longer exists.
-  #
-  # @param saved_pwd [String, nil] directory path to restore
-  # @return [void]
-  def restore_working_directory(saved_pwd)
-    return unless saved_pwd && File.directory?(saved_pwd)
-    execute_in_pty("cd #{Shellwords.shellescape(saved_pwd)}")
-  end
-
-  def create_fifo
-    File.mkfifo(@fifo_path, 0o600)
-  rescue Errno::EEXIST
-    # FIFO already exists — reuse it
-  end
-
-  # Env vars that prevent interactive pagers and credential prompts from
-  # hanging the PTY. We need a PTY (not pipes) for pwd tracking via /proc
-  # and signal handling, but this makes programs think they're on a terminal
-  # and launch pagers. No single switch disables all pagers — each tool has
-  # its own env var — so we set a comprehensive list plus LESS flags as a
-  # safety net for direct `less` invocations.
-  SHELL_ENV = {
-    "TERM" => "dumb",
-    "PAGER" => "cat",                   # Default pager for most Unix tools
-    "LESS" => "-eFRX",                  # Safety net: make less auto-exit at EOF, no screen clear
-    "GIT_PAGER" => "cat",              # Git checks this before PAGER
-    "MANPAGER" => "cat",               # man pages
-    "SYSTEMD_PAGER" => "",             # journalctl, systemctl (empty = disable)
-    "BAT_PAGER" => "cat",             # bat (cat alternative)
-    "AWS_PAGER" => "",                 # AWS CLI v2 (empty = disable)
-    "PSQL_PAGER" => "cat",            # PostgreSQL psql
-    "GIT_TERMINAL_PROMPT" => "0"       # Fail immediately instead of prompting for credentials
-  }.freeze
-
-  # Boots the user's login shell just long enough to source their profile
-  # (/etc/profile, ~/.zprofile, ~/.bash_profile, ~/.zshenv — whichever
-  # applies), then +exec+s a bare +bash+ that handles our command stream.
-  #
-  # Sourcing profile is what makes the agent see the same PATH, tool
-  # locations, and env vars the user has in their own terminal. Handing off
-  # to a bare +bash+ afterwards avoids the mess that comes with attaching a
-  # real interactive shell to a PTY — prompts, line editors, syntax
-  # highlighting, bracketed paste, and title-setting escapes would all
-  # corrupt our marker-based output parsing.
-  #
-  # {SHELL_ENV} still merges on top to keep pagers and credential prompts
-  # from hanging the PTY.
-  def spawn_shell
-    @pty_stdout, @pty_stdin, @pid = PTY.spawn(SHELL_ENV, self.class.login_shell, "-l", "-c", BARE_SHELL_EXEC)
-    # Disable terminal echo via termios before the shell can echo our commands.
-    # This is instant (kernel-level), unlike stty -echo which races with input.
-    @pty_stdin.echo = false
-  end
-
-  # Payload handed to the login shell via +-c+. Replaces the login shell's
-  # process with a bare bash so the user's profile env carries forward, but
-  # the interactive shell machinery (ZLE, prompts, syntax highlighting) does
-  # not. Must be bash specifically — the command stream relies on bash-safe
-  # POSIX syntax, and the +--norc --noprofile+ flags are bash-specific.
-  BARE_SHELL_EXEC = "exec bash --norc --noprofile"
-
-  def start_stderr_reader
-    @stderr_mutex = Mutex.new
-    @stderr_buffer = []
-    @stderr_bytes = 0
-    @stderr_truncated = false
-    @max_output_bytes = Anima::Settings.max_output_bytes
-    @stderr_thread = Thread.new do
-      max_bytes = @max_output_bytes
-      File.open(@fifo_path, "r") do |fifo|
-        while (line = fifo.gets)
-          cleaned = line.chomp.delete("\r")
-          @stderr_mutex.synchronize do
-            if @stderr_bytes < max_bytes
-              @stderr_buffer << cleaned
-              @stderr_bytes += cleaned.bytesize
-            else
-              @stderr_truncated = true
-            end
-          end
-        end
-      end
-    rescue Errno::ENOENT, IOError
-      # FIFO was cleaned up or closed
-    end
-  end
-
-  # With echo already off (set in spawn_shell), only command output appears.
-  # The initial bash prompt merges with the marker output on one gets line.
-  def init_shell
-    marker = "__ANIMA_INIT_#{SecureRandom.hex(8)}__"
-    @pty_stdin.puts "PS1=''"
-    @pty_stdin.puts "exec 2>#{@fifo_path}"
-    @pty_stdin.puts "echo '#{marker}'"
-    unless consume_until(marker, deadline: monotonic_now + 10)
-      raise IOError, "Shell initialization timed out"
-    end
-  end
-
-  def execute_in_pty(command, timeout: nil, interrupt_check: nil)
-    clear_stderr
-    marker = "__ANIMA_#{SecureRandom.hex(8)}__"
-    timeout ||= Anima::Settings.command_timeout
-    deadline = monotonic_now + timeout
-
-    @pty_stdin.puts "#{command}; __anima_ec=$?; echo; echo '#{marker}' $__anima_ec"
-
-    stdout, exit_code = read_until_marker(marker, deadline: deadline, interrupt_check: interrupt_check)
-
-    if exit_code == :interrupted
-      recover_shell
-      update_pwd
-      stderr = drain_stderr
-      return {
-        interrupted: true,
-        stdout: truncate(stdout),
-        stderr: truncate(stderr)
-      }
+    unless system("tmux", "-V", out: File::NULL, err: File::NULL)
+      raise "tmux is not installed. Install it with your package manager (e.g. `apt install tmux`)."
     end
 
-    if exit_code.nil?
-      recover_shell
-      stderr = drain_stderr
-      parts = ["Command timed out after #{timeout} seconds."]
-      parts << "Partial stdout:\n#{truncate(stdout)}" unless stdout.empty?
-      parts << "stderr:\n#{truncate(stderr)}" unless stderr.empty?
-      return {error: parts.join("\n\n")}
-    end
+    args = ["tmux", "new-session", "-d", "-s", @target, "-x", PANE_WIDTH.to_s, "-y", PANE_HEIGHT.to_s]
+    args.push("-c", cwd) if cwd && File.directory?(cwd)
+    system(*args, out: File::NULL, err: File::NULL)
 
-    env_summary = update_environment
-    stderr = drain_stderr
+    raise "tmux session #{@target} could not be created" unless alive?
 
-    result = {
-      stdout: truncate(stdout),
-      stderr: truncate(stderr),
-      exit_code: exit_code
-    }
-    result[:env_summary] = env_summary if env_summary
-    result
-  rescue Errno::EIO, IOError
-    @alive = false
-    {error: "Shell session terminated unexpectedly"}
-  rescue => error # rubocop:disable Lint/RescueException -- LLM must always get a result hash, never a stack trace
-    {error: "#{error.class}: #{error.message}"}
+    system(
+      "tmux", "set-option", "-t", @target, "history-limit", HISTORY_LIMIT.to_s,
+      out: File::NULL, err: File::NULL
+    )
+
+    inject_shell_env
   end
 
-  # Reads lines from the PTY until the marker appears.
-  #
-  # @param marker [String] unique marker to detect command completion
-  # @param deadline [Float] monotonic clock deadline
-  # @param interrupt_check [Proc, nil] callable returning truthy on user interrupt
-  # @return [Array(String, Integer)] stdout and exit code on success
-  # @return [Array(String, Symbol)] partial stdout and +:interrupted+ on user interrupt
-  # @return [Array(String, nil)] partial stdout and nil exit code on timeout
-  def read_until_marker(marker, deadline:, interrupt_check: nil)
-    lines = []
-    exit_code = nil
-    check_interval = interrupt_check ? [Anima::Settings.interrupt_check_interval, 0.5].max : nil
-
+  # Sends +export+ statements to the pane after the user's login shell
+  # has sourced its rcfiles, so our pager-disabling env beats any
+  # +export PAGER=less+ in +~/.zshrc+ etc. Blocks via +wait-for+ so
+  # subsequent {#run} calls see the new env.
+  def inject_shell_env
+    uuid = SecureRandom.hex(8)
+    exports = SHELL_ENV.map { |k, v| "export #{k}=#{v.empty? ? "''" : v.shellescape}" }.join("; ")
+    line = "#{exports}; tmux wait-for -S init-#{uuid}"
+    system("tmux", "send-keys", "-t", @target, line, "Enter", out: File::NULL, err: File::NULL)
+    pid = Process.spawn("tmux", "wait-for", "init-#{uuid}", out: File::NULL, err: File::NULL)
+    deadline = monotonic_now + 5
     loop do
-      line = gets_with_deadline(deadline, interrupt_check: interrupt_check, check_interval: check_interval)
-
-      if line == :interrupted
-        exit_code = :interrupted
-        break
-      end
-
-      break if line.nil?
-
-      line = line.chomp.delete("\r")
-
-      if line.include?(marker)
-        exit_code = line.split.last.to_i
-        break
-      end
-
-      lines << line
-    end
-
-    # Strip trailing empty line added by our separator echo
-    lines.pop if lines.last == ""
-
-    [lines.join("\n"), exit_code]
-  end
-
-  # Reads and discards PTY output until the marker appears or deadline expires.
-  #
-  # @param marker [String] unique marker to wait for
-  # @param deadline [Float] monotonic clock deadline
-  # @return [Boolean] true if marker was found, false if deadline expired
-  # @raise [Errno::EIO] when the PTY child process has exited
-  # @raise [IOError] when the PTY file descriptor is closed
-  def consume_until(marker, deadline:)
-    loop do
-      line = gets_with_deadline(deadline)
-      return false if line.nil?
-      return true if line.chomp.delete("\r").include?(marker)
-    end
-  end
-
-  # Reads a single line from the PTY, respecting a deadline.
-  # Caller must hold @mutex — @read_buffer is not independently synchronized.
-  #
-  # Uses IO.select for safe, non-interruptive timeout handling instead of
-  # Timeout.timeout (which uses Thread.raise that can corrupt mutex state
-  # and leave resources inconsistent).
-  #
-  # When +interrupt_check+ is provided, IO.select uses a shorter timeout
-  # (capped at {Anima::Settings.interrupt_check_interval}) and polls the
-  # callback between iterations. Returns +:interrupted+ when the callback
-  # fires, allowing the caller to send Ctrl+C and return partial output.
-  #
-  # @param deadline [Float] monotonic clock deadline
-  # @param interrupt_check [Proc, nil] callable returning truthy on user interrupt
-  # @param check_interval [Float, nil] resolved interrupt check interval (seconds);
-  #   pre-computed by the caller to avoid re-reading Settings on every line
-  # @return [String] line including trailing newline
-  # @return [:interrupted] when user interrupt detected
-  # @return [nil] if deadline expired
-  # @raise [Errno::EIO] when the PTY child process exits (Linux)
-  # @raise [IOError] when the PTY file descriptor is closed
-  def gets_with_deadline(deadline, interrupt_check: nil, check_interval: nil)
-    loop do
-      if (idx = @read_buffer.index("\n"))
-        return @read_buffer.slice!(0..idx)
-      end
-
-      remaining = deadline - monotonic_now
-      return nil if remaining <= 0
-
-      select_timeout = check_interval ? [remaining, check_interval].min : remaining
-
-      ready = IO.select([@pty_stdout], nil, nil, select_timeout)
-
-      if ready
+      _, status = Process.wait2(pid, Process::WNOHANG)
+      break if status
+      if monotonic_now > deadline
         begin
-          @read_buffer << @pty_stdout.read_nonblock(4096)
-        rescue IO::WaitReadable
-          # Spurious wakeup from IO.select — retry
+          Process.kill("TERM", pid)
+        rescue
+          Errno::ESRCH
         end
+        begin
+          Process.wait(pid)
+        rescue
+          Errno::ECHILD
+        end
+        raise "tmux session #{@target} init timed out"
+      end
+      sleep IDLE_POLL_INTERVAL
+    end
+  end
+
+  # Blocks on +tmux wait-for+, polling for interrupt and timeout. On
+  # cancel we send +C-c+ to abort the running command, then kill the
+  # wait-for child directly — interactive bash discards the rest of the
+  # input line on SIGINT, so the trailing +tmux wait-for -S+ never fires
+  # and we can't rely on natural signaling.
+  #
+  # @return [Symbol] +:done+, +:interrupted+, or +:timeout+
+  def wait_for_completion(uuid, timeout, interrupt_check)
+    pid = Process.spawn("tmux", "wait-for", "done-#{uuid}", out: File::NULL, err: File::NULL)
+    deadline = monotonic_now + timeout
+    poll_interval = interrupt_check ? Anima::Settings.interrupt_check_interval : IDLE_POLL_INTERVAL
+
+    loop do
+      _, status = Process.wait2(pid, Process::WNOHANG)
+      return :done if status
+
+      if interrupt_check&.call
+        cancel_command(pid)
+        return :interrupted
       end
 
-      return :interrupted if interrupt_check&.call
+      if monotonic_now > deadline
+        cancel_command(pid)
+        return :timeout
+      end
+
+      sleep poll_interval
     end
   end
 
-  # Sends Ctrl+C and drains leftover output after a timeout or user interrupt.
-  # If recovery fails, marks the session as dead (will be respawned on next run).
-  #
-  # @return [void]
-  # @raise [Errno::EIO] when the PTY child process has exited
-  # @raise [IOError] when the PTY file descriptor is closed
-  def recover_shell
-    @pty_stdin.write("\x03")
-    sleep 0.1
-    marker = "__ANIMA_RECOVER_#{SecureRandom.hex(8)}__"
-    @pty_stdin.puts "echo '#{marker}'"
-    recovered = consume_until(marker, deadline: monotonic_now + 3)
-    @alive = false unless recovered
-  rescue Errno::EIO, IOError
-    @alive = false
-  end
-
-  def clear_stderr
-    @stderr_mutex.synchronize do
-      @stderr_buffer.clear
-      @stderr_bytes = 0
-      @stderr_truncated = false
+  # Sends Ctrl+C to abort the running command, then reaps the
+  # wait-for child. Idempotent against already-dead processes.
+  def cancel_command(wait_for_pid)
+    send_ctrl_c
+    begin
+      Process.kill("TERM", wait_for_pid)
+    rescue Errno::ESRCH
+      # Already exited — wait-for unblocked between our last poll and now
+    end
+    begin
+      Process.wait(wait_for_pid)
+    rescue Errno::ECHILD
+      # Already reaped
     end
   end
 
-  def drain_stderr
-    # Allow FIFO reader thread time to flush kernel buffers into @stderr_buffer.
-    # Without this, stderr arriving just before the marker may be missed.
-    sleep 0.01
-    @stderr_mutex.synchronize do
-      result = @stderr_buffer.join("\n")
-      truncated = @stderr_truncated
-      @stderr_buffer.clear
-      @stderr_bytes = 0
-      @stderr_truncated = false
-      truncated ? result + "\n\n[Truncated: output exceeded #{@max_output_bytes} bytes]" : result
-    end
+  def send_ctrl_c
+    system("tmux", "send-keys", "-t", @target, "C-c", out: File::NULL, err: File::NULL)
   end
 
-  # Captures the initial environment snapshot so the first real Bash call
-  # can diff against the actual shell state rather than a blank sentinel
-  # whose nil pwd would always trigger a "location changed" report.
-  #
-  # Sets {#env_snapshot} to a real snapshot of the current pwd, git branch,
-  # repo, and project files. Called within {#start} after {#update_pwd}
-  # and before the session is marked alive.
-  #
-  # @return [void]
-  def seed_env_snapshot
-    @env_snapshot = take_env_snapshot(EnvironmentSnapshot.blank)
-  end
-
-  # Snapshots the shell's environment and returns a natural-language summary
-  # of what changed since the last snapshot. The agent discovers its
-  # environment through these summaries in Bash tool responses.
-  #
-  # Each call only mentions what changed. Returns nil when nothing did.
-  #
-  # @return [String, nil] human-readable summary of environment changes
-  def update_environment
-    update_pwd
-    previous = @env_snapshot || EnvironmentSnapshot.blank
-    @env_snapshot = take_env_snapshot(previous)
-    describe_env_changes(previous, @env_snapshot)
-  end
-
-  # Reads the shell's current working directory via the /proc filesystem.
-  # @note Linux-only. Falls back silently on other platforms or if the
-  #   process has exited.
-  def update_pwd
-    @pwd = File.readlink("/proc/#{@pid}/cwd")
-  rescue Errno::ENOENT, Errno::EACCES
-    # Process exited or no access — @pwd retains its previous value
-  end
-
-  # Captures the current environment as an immutable snapshot.
-  # Re-detects git state on every call (branch can change without cd).
-  # Re-scans project files only when the working directory changed.
-  #
-  # @param previous [EnvironmentSnapshot] the last known snapshot
-  # @return [EnvironmentSnapshot]
-  def take_env_snapshot(previous)
-    branch, repo = detect_git
-    files = (@pwd != previous.pwd) ? scan_project_files : previous.project_files
-
-    EnvironmentSnapshot.new(pwd: @pwd, branch: branch, repo: repo, project_files: files)
-  end
-
-  # Detects git branch and repo name for the current working directory.
-  #
-  # @return [Array(String, String)] branch and repo name
-  # @return [Array(nil, nil)] when not inside a git repository
-  def detect_git
-    return [nil, nil] unless @pwd
-
-    _, status = Open3.capture2("git", "-C", @pwd, "rev-parse", "--is-inside-work-tree", err: File::NULL)
-    return [nil, nil] unless status.success?
-
-    branch = detect_git_branch
-    repo = detect_git_repo
-    [branch, repo]
-  rescue Errno::ENOENT
-    [nil, nil]
-  end
-
-  # @return [String, nil] current branch name
-  def detect_git_branch
-    output, = Open3.capture2("git", "-C", @pwd, "rev-parse", "--abbrev-ref", "HEAD", err: File::NULL)
-    output.strip.presence
-  end
-
-  # @return [String, nil] "owner/repo" extracted from the origin remote
-  def detect_git_repo
-    output, = Open3.capture2("git", "-C", @pwd, "remote", "get-url", "origin", err: File::NULL)
-    remote = output.strip
-    return unless remote.present?
-
-    extract_repo_name(remote)
-  end
-
-  # Scans for well-known project files in the current working directory.
-  #
-  # @return [Array<String>] sorted relative paths
-  def scan_project_files
-    return [] unless @pwd
-
-    base = Pathname.new(@pwd)
-    whitelist = Anima::Settings.project_files_whitelist
-    max_depth = Anima::Settings.project_files_max_depth
-
-    patterns = whitelist.product((0..max_depth).to_a).map do |filename, depth|
-      File.join(@pwd, Array.new(depth, "*"), filename)
-    end
-
-    patterns.flat_map { |pattern| Dir.glob(pattern) }
-      .map { |path| Pathname.new(path).relative_path_from(base).to_s }
-      .sort
-      .uniq
-  end
-
-  # Extracts owner/repo from a Git remote URL (SSH or HTTPS).
-  #
-  # @param remote_url [String] SSH or HTTPS remote URL
-  # @return [String] "owner/repo" path
-  def extract_repo_name(remote_url)
-    path = if remote_url.match?(%r{\A\w+://})
-      URI.parse(remote_url).path
-    else
-      remote_url.split(":").last
-    end
-    path.delete_prefix("/").delete_suffix(".git")
-  rescue URI::InvalidURIError
-    remote_url
-  end
-
-  # ─── Environment change description ──────────────────────────────
-
-  # Builds a natural-language summary describing what changed between two
-  # environment snapshots. Returns nil when nothing changed.
-  #
-  # @param old_snap [EnvironmentSnapshot]
-  # @param new_snap [EnvironmentSnapshot]
-  # @return [String, nil]
-  def describe_env_changes(old_snap, new_snap)
-    parts = []
-    parts << describe_location_change(old_snap, new_snap)
-    parts << describe_project_files(old_snap, new_snap)
-    parts.compact!
-    parts.empty? ? nil : parts.join("\n")
-  end
-
-  # @return [String, nil] location/branch change line
-  def describe_location_change(old_snap, new_snap)
-    if new_snap.pwd != old_snap.pwd
-      format_full_location(new_snap)
-    elsif new_snap.branch != old_snap.branch && new_snap.branch
-      "Branch changed to #{new_snap.branch}."
-    end
-  end
-
-  # @return [String, nil] project files line
-  def describe_project_files(old_snap, new_snap)
-    return unless new_snap.project_files.any?
-    return unless new_snap.pwd != old_snap.pwd || new_snap.project_files != old_snap.project_files
-
-    "Project has instructions in #{new_snap.project_files.join(", ")}."
-  end
-
-  # Formats the full location line for display in tool responses.
-  #
-  # @param snap [EnvironmentSnapshot]
-  # @return [String]
-  def format_full_location(snap)
-    parts = ["You are now in #{snap.pwd}"]
-    if snap.repo && snap.branch
-      parts << ", git repo #{snap.repo} on branch #{snap.branch}"
-    elsif snap.branch
-      parts << " on branch #{snap.branch}"
-    end
-    parts.join + "."
+  # Captures the pane scrollback + visible content. Because we ran
+  # +tmux clear-history+ before sending and the shell +clear+ wiped both
+  # visible pane and scrollback (via the +\e[3J+ sequence on modern
+  # terminfo), what we capture is exactly the new command's output and
+  # trailing prompt — nothing leaked from the previous pane state.
+  # The +-J+ flag joins terminal-wrapped lines so a long single-line
+  # output comes back whole.
+  def capture_output
+    raw, _ = Open3.capture2("tmux", "capture-pane", "-pJ", "-t", @target, "-S", "-", err: File::NULL)
+    truncate(raw.dup.force_encoding("UTF-8").scrub)
   end
 
   def truncate(output)
-    max_bytes = @max_output_bytes
-    output = output.dup.force_encoding("UTF-8").scrub
-
-    return output if output.bytesize <= max_bytes
-
-    output.byteslice(0, max_bytes)
-      .scrub +
-      "\n\n[Truncated: output exceeded #{max_bytes} bytes]"
+    max = Anima::Settings.max_output_bytes
+    return output if output.bytesize <= max
+    output.byteslice(0, max).scrub + "\n\n[Truncated: output exceeded #{max} bytes]"
   end
 
   def monotonic_now
     Process.clock_gettime(Process::CLOCK_MONOTONIC)
-  end
-
-  # Unconditionally cleans up all shell resources (PTY, FIFO, child process).
-  # Does NOT short-circuit when @alive is already false — this ensures leaked
-  # processes are reaped even after failed recovery marked the session dead.
-  #
-  # @return [void]
-  def teardown
-    @alive = false
-    @read_buffer = +""
-
-    if @pid
-      begin
-        pgid = Process.getpgid(@pid)
-        Process.kill("TERM", -pgid)
-      rescue Errno::ESRCH, Errno::EPERM
-        # Process group already gone
-      end
-    end
-
-    begin
-      @pty_stdin&.close
-    rescue IOError
-      # Already closed
-    end
-
-    begin
-      @pty_stdout&.close
-    rescue IOError
-      # Already closed
-    end
-
-    begin
-      @stderr_thread&.join(1)
-      @stderr_thread&.kill
-    rescue ThreadError
-      # Thread already dead
-    end
-
-    File.delete(@fifo_path) if @fifo_path && File.exist?(@fifo_path)
-
-    if @pid
-      begin
-        # Non-blocking reap with SIGKILL fallback if process doesn't exit in time
-        deadline = monotonic_now + 2
-        loop do
-          _, status = Process.wait2(@pid, Process::WNOHANG)
-          break if status
-          if monotonic_now > deadline
-            Process.kill("KILL", @pid)
-            Process.wait(@pid)
-            break
-          end
-          sleep 0.05
-        end
-      rescue Errno::ECHILD, Errno::ESRCH
-        # Already reaped
-      end
-
-      @pid = nil
-    end
   end
 end

--- a/lib/shell_session.rb
+++ b/lib/shell_session.rb
@@ -287,6 +287,16 @@ class ShellSession
     system("tmux", "send-keys", "-t", @target, "C-c", out: File::NULL, err: File::NULL)
   end
 
+  # Placeholder substituted when a command produces no visible output.
+  # Two cases collapse to the same message:
+  # 1. The command genuinely had nothing to say (+true+, +cd /+,
+  #    +find ... 2>/dev/null+ with no matches).
+  # 2. We captured in the brief race window between +wait-for -S+ firing
+  #    and bash redrawing its prompt — the pane is all whitespace.
+  # Either way the LLM gets a coherent message, and the downstream
+  # +Message#content+ validation doesn't reject the empty result.
+  EMPTY_OUTPUT_PLACEHOLDER = "(command produced no output)"
+
   # Captures the pane scrollback + visible content. Because we ran
   # +tmux clear-history+ before sending and the shell +clear+ wiped both
   # visible pane and scrollback (via the +\e[3J+ sequence on modern
@@ -296,7 +306,8 @@ class ShellSession
   # output comes back whole.
   def capture_output
     raw, _ = Open3.capture2("tmux", "capture-pane", "-pJ", "-t", @target, "-S", "-", err: File::NULL)
-    truncate(raw.dup.force_encoding("UTF-8").scrub)
+    output = truncate(raw.dup.force_encoding("UTF-8").scrub)
+    output.strip.empty? ? EMPTY_OUTPUT_PLACEHOLDER : output
   end
 
   # Truncates +output+ to {Anima::Settings.max_output_bytes}. The

--- a/lib/tools/bash.rb
+++ b/lib/tools/bash.rb
@@ -7,9 +7,12 @@ module Tools
   # would see it — including the prompt, which doubles as live cwd/branch
   # telemetry for the agent.
   #
-  # Supports two modes:
-  # - Single command via +command+ (string)
-  # - Batch via +commands+ (array) with +mode+ controlling error handling
+  # Two input shapes:
+  # - +command+ (string) — one command, one result.
+  # - +commands+ (array) — runs each command in order in the same shell;
+  #   all run regardless of failures (the agent reads merged output and
+  #   decides what to do). Use shell chaining (+&&+) inside a single
+  #   command if you need fail-fast.
   #
   # @see ShellSession#run
   class Bash < Base

--- a/lib/tools/bash.rb
+++ b/lib/tools/bash.rb
@@ -3,11 +3,12 @@
 module Tools
   # Executes bash commands in a persistent {ShellSession}. Commands share
   # working directory, environment variables, and shell history within a
-  # conversation. Output is truncated and timeouts are enforced by the
-  # underlying session.
+  # conversation. Output is the rendered terminal text exactly as a human
+  # would see it — including the prompt, which doubles as live cwd/branch
+  # telemetry for the agent.
   #
   # Supports two modes:
-  # - Single command via +command+ (string) — backward compatible
+  # - Single command via +command+ (string)
   # - Batch via +commands+ (array) with +mode+ controlling error handling
   #
   # @see ShellSession#run
@@ -26,12 +27,7 @@ module Tools
           commands: {
             type: "array",
             items: {type: "string"},
-            description: "Each command gets its own timeout and result."
-          },
-          mode: {
-            type: "string",
-            enum: ["sequential", "parallel"],
-            description: "sequential (default) stops on first failure."
+            description: "Each command gets its own timeout and result. All commands run regardless of failures — use a single command with shell chaining if you need fail-fast."
           }
         }
       }
@@ -47,7 +43,7 @@ module Tools
     # @param input [Hash<String, Object>] string-keyed hash from the Anthropic API.
     #   Supports optional "timeout" key (seconds) to override the global
     #   command_timeout setting for long-running operations.
-    # @return [String] formatted output with stdout, stderr, and exit code
+    # @return [String] rendered terminal output
     # @return [Hash] with :error key on failure
     def execute(input)
       timeout = input["timeout"]
@@ -57,7 +53,7 @@ module Tools
       if has_command && has_commands
         {error: "Provide either 'command' or 'commands', not both"}
       elsif has_commands
-        execute_batch(input["commands"], mode: input.fetch("mode", "sequential"), timeout: timeout)
+        execute_batch(input["commands"], timeout: timeout)
       elsif has_command
         execute_single(input["command"], timeout: timeout)
       else
@@ -77,40 +73,31 @@ module Tools
       return format_interrupted(result) if result[:interrupted]
       return result if result.key?(:error)
 
-      output = format_result(result[:stdout], result[:stderr], result[:exit_code])
-      append_env_summary(output, result[:env_summary])
+      result[:output]
     end
 
-    # Executes an array of commands, returning a combined result string.
-    # Checks for user interrupt between commands and during each command
-    # via the {ShellSession} interrupt_check callback.
+    # Executes an array of commands sequentially through the shared
+    # shell. Continues past errors — the LLM reads the merged output
+    # and decides what to do. The only short-circuit is a user interrupt,
+    # which skips the remaining commands.
     #
     # @param commands [Array<String>] commands to execute
-    # @param mode [String] "sequential" (stop on first failure) or "parallel" (run all)
     # @param timeout [Integer, nil] per-command timeout override
     # @return [String] combined results with per-command headers
     # @return [Hash] with :error key if commands array is invalid
-    def execute_batch(commands, mode:, timeout: nil)
+    def execute_batch(commands, timeout: nil)
       return {error: "Commands array cannot be empty"} unless commands.is_a?(Array) && commands.any?
 
       checker = interrupt_checker
       total = commands.size
       results = []
-      failed = false
       interrupted = false
-
-      last_env_summary = nil
 
       commands.each_with_index do |command, index|
         position = "[#{index + 1}/#{total}]"
 
         if interrupted
           results << "#{position} $ #{command}\n(skipped — interrupted by user)"
-          next
-        end
-
-        if failed && mode == "sequential"
-          results << "#{position} $ #{command}\n(skipped)"
           next
         end
 
@@ -127,47 +114,23 @@ module Tools
           interrupted = true
         elsif result.key?(:error)
           results << "#{position} $ #{command}\n#{result[:error]}"
-          failed = true
         else
-          exit_code = result[:exit_code]
-          output = format_result(result[:stdout], result[:stderr], exit_code)
-          results << "#{position} $ #{command}\n#{output}"
-          last_env_summary = result[:env_summary]
-          failed = true if exit_code != 0
+          results << "#{position} $ #{command}\n#{result[:output]}"
         end
       end
 
-      append_env_summary(results.join("\n\n"), last_env_summary)
-    end
-
-    # Appends environment summary to tool output when present.
-    #
-    # @param output [String] formatted tool response
-    # @param env_summary [String, nil] natural-language environment change summary
-    # @return [String] output with env summary appended
-    def append_env_summary(output, env_summary)
-      env_summary ? "#{output}\n\n#{env_summary}" : output
-    end
-
-    def format_result(stdout, stderr, exit_code)
-      parts = []
-      parts << "stdout:\n#{stdout}" unless stdout.empty?
-      parts << "stderr:\n#{stderr}" unless stderr.empty?
-      parts << "exit_code: #{exit_code}"
-      parts.join("\n\n")
+      results.join("\n\n")
     end
 
     # Formats the result of an interrupted command for the LLM.
     # Includes partial output captured before the interrupt.
     #
-    # @param result [Hash] ShellSession result with :stdout, :stderr keys
+    # @param result [Hash] ShellSession result with :output key
     # @return [String] formatted message for the LLM
     def format_interrupted(result)
-      stdout = result[:stdout].to_s
-      stderr = result[:stderr].to_s
+      output = result[:output].to_s
       parts = [LLM::Client::INTERRUPT_MESSAGE]
-      parts << "Partial stdout:\n#{stdout}" unless stdout.empty?
-      parts << "stderr:\n#{stderr}" unless stderr.empty?
+      parts << "Partial output:\n#{output}" unless output.empty?
       parts.join("\n\n")
     end
 

--- a/lib/tools/spawn_specialist.rb
+++ b/lib/tools/spawn_specialist.rb
@@ -102,7 +102,8 @@ module Tools
         parent_session_id: @session.id,
         prompt: build_prompt(definition),
         granted_tools: definition.tools,
-        spawn_tool_use_id: @tool_use_id
+        spawn_tool_use_id: @tool_use_id,
+        initial_cwd: ShellSession.cwd_via_tmux(@session.id) || @session.initial_cwd
       )
       create_goal_with_pinned_task(child, task)
       assign_nickname_via_melete(child)

--- a/lib/tools/spawn_specialist.rb
+++ b/lib/tools/spawn_specialist.rb
@@ -58,14 +58,12 @@ module Tools
     private_class_method :name_property
 
     # @param session [Session] the parent session spawning the specialist
-    # @param shell_session [ShellSession] the parent's persistent shell (for CWD inheritance)
     # @param agent_registry [Agents::Registry, nil] injectable for testing
     # @param tool_use_id [String, nil] the invoking +spawn_specialist+ tool_call's
     #   pairing id, captured so the spawn pair can later be located by the
     #   HUD visibility sweep in {Mneme::Runner}
-    def initialize(session:, shell_session:, agent_registry: nil, tool_use_id: nil, **)
+    def initialize(session:, agent_registry: nil, tool_use_id: nil, **)
       @session = session
-      @shell_session = shell_session
       @agent_registry = agent_registry || Agents::Registry.instance
       @tool_use_id = tool_use_id
     end
@@ -104,7 +102,6 @@ module Tools
         parent_session_id: @session.id,
         prompt: build_prompt(definition),
         granted_tools: definition.tools,
-        initial_cwd: @shell_session.pwd,
         spawn_tool_use_id: @tool_use_id
       )
       create_goal_with_pinned_task(child, task)

--- a/lib/tools/spawn_subagent.rb
+++ b/lib/tools/spawn_subagent.rb
@@ -44,13 +44,11 @@ module Tools
     end
 
     # @param session [Session] the parent session spawning the sub-agent
-    # @param shell_session [ShellSession] the parent's persistent shell (for CWD inheritance)
     # @param tool_use_id [String, nil] the invoking +spawn_subagent+ tool_call's
     #   pairing id, captured so the spawn pair can later be located by the
     #   HUD visibility sweep in {Mneme::Runner}
-    def initialize(session:, shell_session:, tool_use_id: nil, **)
+    def initialize(session:, tool_use_id: nil, **)
       @session = session
-      @shell_session = shell_session
       @tool_use_id = tool_use_id
     end
 
@@ -89,7 +87,6 @@ module Tools
         parent_session_id: @session.id,
         prompt: GENERIC_PROMPT,
         granted_tools: granted_tools,
-        initial_cwd: @shell_session.pwd,
         spawn_tool_use_id: @tool_use_id
       )
       create_goal_with_pinned_task(child, task)

--- a/lib/tools/spawn_subagent.rb
+++ b/lib/tools/spawn_subagent.rb
@@ -87,7 +87,8 @@ module Tools
         parent_session_id: @session.id,
         prompt: GENERIC_PROMPT,
         granted_tools: granted_tools,
-        spawn_tool_use_id: @tool_use_id
+        spawn_tool_use_id: @tool_use_id,
+        initial_cwd: ShellSession.cwd_via_tmux(@session.id) || @session.initial_cwd
       )
       create_goal_with_pinned_task(child, task)
       assign_nickname_via_melete(child)

--- a/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
+++ b/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
@@ -8,8 +8,8 @@ http_interactions:
       string: '{"model":"claude-opus-4-6","messages":[{"role":"user","content":[{"type":"text","text":"Hey,
         how are you doing today?","cache_control":{"type":"ephemeral"}}]}],"max_tokens":8192,"tools":[{"name":"bash","description":"Execute
         shell commands. Working directory and environment persist between calls.","input_schema":{"type":"object","properties":{"command":{"type":"string"},"commands":{"type":"array","items":{"type":"string"},"description":"Each
-        command gets its own timeout and result."},"mode":{"type":"string","enum":["sequential","parallel"],"description":"sequential
-        (default) stops on first failure."},"timeout":{"type":"integer","description":"Seconds
+        command gets its own timeout and result. All commands run regardless of failures
+        — use a single command with shell chaining if you need fail-fast."},"timeout":{"type":"integer","description":"Seconds
         (default: 180)."}}}},{"name":"read_file","description":"Read file. Relative
         paths resolve against working directory.","input_schema":{"type":"object","properties":{"path":{"type":"string"},"offset":{"type":"integer","description":"1-indexed
         line number (default: 1)."},"limit":{"type":"integer","description":"Max lines
@@ -51,12 +51,12 @@ http_interactions:
         memory, holds what has slipped past your immediate attention. When something
         from earlier matters again she surfaces it as `from_mneme`.\n\nSub-agents
         you spawn arrive the same way, named after whoever sent them — `from_sleuth`,
-        `from_scout`, and so on.\n\n**How delivery works:** Results from sisters and sub-agents appear
-        automatically as tool responses in your conversation — you don''t fetch
-        them. There is no tool to call, no way to poll, and no status to check.
-        When a sub-agent finishes, its output shows up on its own. If you''re waiting
-        on multiple agents, just wait — they''ll arrive. Do other work in the
-        meantime if you can.","cache_control":{"type":"ephemeral"}}]}'
+        `from_scout`, and so on.\n\n**How delivery works:** Results from sisters and
+        sub-agents appear automatically as tool responses in your conversation — you
+        don''t fetch them. There is no tool to call, no way to poll, and no status
+        to check. When a sub-agent finishes, its output shows up on its own. If you''re
+        waiting on multiple agents, just wait — they''ll arrive. Do other work in
+        the meantime if you can.","cache_control":{"type":"ephemeral"}}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"

--- a/spec/lib/anima/settings_spec.rb
+++ b/spec/lib/anima/settings_spec.rb
@@ -105,9 +105,6 @@ RSpec.describe Anima::Settings do
         [melete]
         max_tokens = 128
         message_window = 20
-        [environment]
-        project_files = ["CLAUDE.md", "README.md"]
-        project_files_max_depth = 3
       TOML
       config_file.flush
     end

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -14,11 +14,6 @@ RSpec.describe ShellSession do
       expect(result).not_to have_key(:error)
     end
 
-    it "returns empty output for silent commands" do
-      result = shell.run("true")
-      expect(result[:output].strip).to eq("")
-    end
-
     it "captures stderr in the merged terminal stream" do
       result = shell.run("echo error >&2")
       expect(result[:output]).to include("error")

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -8,65 +8,55 @@ RSpec.describe ShellSession do
   after { shell.finalize }
 
   describe "#run" do
-    it "executes a command and returns stdout" do
+    it "returns the rendered command output" do
       result = shell.run("echo hello")
-      expect(result[:stdout]).to eq("hello")
-      expect(result[:exit_code]).to eq(0)
+      expect(result[:output]).to include("hello")
+      expect(result).not_to have_key(:error)
     end
 
-    it "returns empty stdout for commands with no output" do
+    it "returns empty output for silent commands" do
       result = shell.run("true")
-      expect(result[:stdout]).to eq("")
-      expect(result[:exit_code]).to eq(0)
+      expect(result[:output].strip).to eq("")
     end
 
-    it "captures stderr separately" do
+    it "captures stderr in the merged terminal stream" do
       result = shell.run("echo error >&2")
-      expect(result[:stderr]).to include("error")
-      expect(result[:stdout]).to eq("")
+      expect(result[:output]).to include("error")
     end
 
-    it "captures both stdout and stderr" do
+    it "captures both stdout and stderr together" do
       result = shell.run("echo out && echo err >&2")
-      expect(result[:stdout]).to eq("out")
-      expect(result[:stderr]).to include("err")
+      expect(result[:output]).to include("out")
+      expect(result[:output]).to include("err")
     end
 
-    it "returns non-zero exit code for failing commands" do
-      result = shell.run("(exit 42)")
-      expect(result[:exit_code]).to eq(42)
-    end
-
-    it "reports error when exit kills the shell" do
-      result = shell.run("exit 1")
-      expect(result[:error]).to include("terminated unexpectedly")
+    it "surfaces error text from failing commands without surfacing exit codes" do
+      result = shell.run("ls /nonexistent-path-#{SecureRandom.hex(4)}")
+      expect(result[:output]).to match(/no such file|cannot access/i)
     end
 
     it "preserves working directory between calls" do
       shell.run("cd /tmp")
       result = shell.run("pwd")
-      expect(result[:stdout]).to eq("/tmp")
+      expect(result[:output]).to include("/tmp")
     end
 
     it "preserves environment variables between calls" do
       shell.run("export MY_SHELL_TEST_VAR=persistent")
       result = shell.run("echo $MY_SHELL_TEST_VAR")
-      expect(result[:stdout]).to eq("persistent")
+      expect(result[:output]).to include("persistent")
     end
 
     it "handles multi-line output" do
-      result = shell.run("echo line1 && echo line2 && echo line3")
-      expect(result[:stdout]).to eq("line1\nline2\nline3")
+      result = shell.run("printf 'line1\\nline2\\nline3\\n'")
+      expect(result[:output]).to include("line1")
+      expect(result[:output]).to include("line2")
+      expect(result[:output]).to include("line3")
     end
 
-    it "truncates stdout exceeding max_output_bytes" do
+    it "truncates output exceeding max_output_bytes" do
       result = shell.run("head -c #{Anima::Settings.max_output_bytes + 1000} /dev/zero | tr '\\0' 'x'")
-      expect(result[:stdout]).to include("[Truncated:")
-    end
-
-    it "truncates stderr exceeding max_output_bytes" do
-      result = shell.run("seq 1 100000 >&2")
-      expect(result[:stderr]).to include("[Truncated:")
+      expect(result[:output]).to include("[Truncated:")
     end
 
     it "returns error when shell is finalized" do
@@ -76,64 +66,47 @@ RSpec.describe ShellSession do
     end
 
     context "timeout" do
-      it "returns error for long-running commands" do
-        allow(Anima::Settings).to receive(:command_timeout).and_return(1)
-        timed_shell = described_class.new(session_id: "timeout-#{SecureRandom.hex(4)}")
-        result = timed_shell.run("sleep 30")
+      it "returns error and partial output when the deadline expires" do
+        result = shell.run("echo before_timeout && sleep 30", timeout: 1)
         expect(result[:error]).to include("timed out")
-        timed_shell.finalize
+        expect(result[:error]).to include("before_timeout")
       end
 
-      it "includes partial output in timeout error" do
-        allow(Anima::Settings).to receive(:command_timeout).and_return(2)
-        timed_shell = described_class.new(session_id: "partial-#{SecureRandom.hex(4)}")
-        result = timed_shell.run("echo 'before hang' && sleep 30")
-        expect(result[:error]).to include("timed out")
-        expect(result[:error]).to include("before hang")
-        timed_shell.finalize
-      end
-
-      it "recovers after a command timeout" do
-        allow(Anima::Settings).to receive(:command_timeout).and_return(1)
-        timed_shell = described_class.new(session_id: "recover-#{SecureRandom.hex(4)}")
-        timed_shell.run("sleep 30")
-
-        allow(Anima::Settings).to receive(:command_timeout).and_call_original
-        result = timed_shell.run("echo recovered")
-        expect(result[:stdout]).to eq("recovered")
-        timed_shell.finalize
+      it "recovers cleanly so subsequent commands work" do
+        shell.run("sleep 30", timeout: 1)
+        result = shell.run("echo recovered")
+        expect(result[:output]).to include("recovered")
       end
     end
 
     context "interrupt_check" do
-      it "returns interrupted result when callback fires" do
-        # Fires on the second poll, giving the command one cycle to start
+      it "returns :interrupted when the callback fires" do
         check_count = 0
         checker = -> { (check_count += 1) > 1 }
 
-        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
+        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.3)
         result = shell.run("sleep 30", interrupt_check: checker)
         expect(result[:interrupted]).to be true
       end
 
-      it "includes partial stdout captured before interrupt" do
+      it "includes partial output captured before the interrupt" do
         check_count = 0
         checker = -> { (check_count += 1) > 2 }
 
         allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.3)
         result = shell.run("echo before_interrupt && sleep 30", interrupt_check: checker)
         expect(result[:interrupted]).to be true
-        expect(result[:stdout]).to include("before_interrupt")
+        expect(result[:output]).to include("before_interrupt")
       end
 
-      it "recovers the shell after interrupt" do
+      it "lets the shell continue after an interrupt" do
         checker = -> { true }
 
-        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
+        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.3)
         shell.run("sleep 30", interrupt_check: checker)
 
         result = shell.run("echo recovered")
-        expect(result[:stdout]).to eq("recovered")
+        expect(result[:output]).to include("recovered")
       end
 
       it "preserves working directory after interrupt" do
@@ -141,215 +114,44 @@ RSpec.describe ShellSession do
         expect(shell.pwd).to eq("/tmp")
 
         checker = -> { true }
-        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
+        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.3)
         shell.run("sleep 30", interrupt_check: checker)
 
         expect(shell.pwd).to eq("/tmp")
       end
 
-      it "does not check interrupt when no callback provided" do
+      it "does not flag :interrupted when no callback is provided" do
         result = shell.run("echo fast")
-        expect(result[:stdout]).to eq("fast")
+        expect(result[:output]).to include("fast")
         expect(result[:interrupted]).to be_nil
       end
     end
 
-    context "auto-respawn" do
-      it "respawns after the shell process exits" do
-        result = shell.run("exit 1")
-        expect(result[:error]).to include("terminated unexpectedly")
-
-        result = shell.run("echo respawned")
-        expect(result[:stdout]).to eq("respawned")
-      end
-
-      it "preserves working directory after respawn" do
-        shell.run("cd /tmp")
-        expect(shell.pwd).to eq("/tmp")
-
-        shell.run("exit 1")
-
-        result = shell.run("pwd")
-        expect(result[:stdout]).to eq("/tmp")
-      end
-
-      it "does not respawn after finalize" do
-        shell.finalize
-        result = shell.run("echo hello")
-        expect(result[:error]).to include("not running")
-      end
-    end
-
     context "encoding" do
-      it "returns UTF-8 encoded stdout even when PTY emits binary" do
+      it "returns UTF-8 encoded output even when commands emit binary" do
         result = shell.run("printf '\\xc0\\xff valid ascii'")
-        expect(result[:stdout].encoding).to eq(Encoding::UTF_8)
-        expect(result[:stdout]).to be_valid_encoding
-      end
-
-      it "returns UTF-8 encoded stdout for normal output" do
-        result = shell.run("echo hello")
-        expect(result[:stdout].encoding).to eq(Encoding::UTF_8)
-        expect(result[:stdout]).to be_valid_encoding
-      end
-    end
-
-    context "pager prevention" do
-      it "disables pagers via PAGER and tool-specific env vars" do
-        result = shell.run("echo $PAGER")
-        expect(result[:stdout]).to eq("cat")
-
-        result = shell.run("echo $GIT_PAGER")
-        expect(result[:stdout]).to eq("cat")
-      end
-
-      it "configures less to auto-exit as safety net" do
-        result = shell.run("echo $LESS")
-        expect(result[:stdout]).to eq("-eFRX")
-      end
-
-      it "disables git credential prompts" do
-        result = shell.run("echo $GIT_TERMINAL_PROMPT")
-        expect(result[:stdout]).to eq("0")
+        expect(result[:output].encoding).to eq(Encoding::UTF_8)
+        expect(result[:output]).to be_valid_encoding
       end
     end
   end
 
   describe "#pwd" do
-    it "tracks the current working directory" do
+    it "tracks the current working directory via tmux" do
       shell.run("cd /tmp")
       expect(shell.pwd).to eq("/tmp")
     end
 
-    it "updates after each command" do
+    it "updates after each cd" do
       shell.run("cd /tmp")
       expect(shell.pwd).to eq("/tmp")
       shell.run("cd /")
       expect(shell.pwd).to eq("/")
     end
-  end
 
-  describe ".login_shell" do
-    # before/after instead of around: the outer `after { shell.finalize }`
-    # lazily spawns the subject, and an around-block's restoration runs too
-    # late to prevent it from reading a stubbed $SHELL pointing at a path
-    # that may not exist on CI (e.g. /bin/zsh).
-    before { @saved_shell = ENV["SHELL"] }
-    after { ENV["SHELL"] = @saved_shell }
-
-    it "returns $SHELL when it is set" do
-      ENV["SHELL"] = "/bin/zsh"
-      expect(described_class.login_shell).to eq("/bin/zsh")
-    end
-
-    it "falls back to /bin/bash when $SHELL is unset" do
-      ENV.delete("SHELL")
-      expect(described_class.login_shell).to eq("/bin/bash")
-    end
-
-    it "falls back to /bin/bash when $SHELL is empty" do
-      ENV["SHELL"] = ""
-      expect(described_class.login_shell).to eq("/bin/bash")
-    end
-  end
-
-  describe "shell selection" do
-    it "sources the user's login profile then hands off to a bare bash" do
-      allow(PTY).to receive(:spawn).and_call_original
-
-      described_class.new(session_id: "spawn-#{SecureRandom.hex(4)}").finalize
-
-      expect(PTY).to have_received(:spawn).with(
-        described_class.const_get(:SHELL_ENV),
-        described_class.login_shell,
-        "-l", "-c", described_class.const_get(:BARE_SHELL_EXEC)
-      ).at_least(:once)
-    end
-  end
-
-  describe "environment tracking" do
-    describe "seed_env_snapshot" do
-      it "sets @env_snapshot to real startup state on initialization" do
-        # seed_env_snapshot runs inside start(), called by initialize
-        snapshot = shell.send(:instance_variable_get, :@env_snapshot)
-        expect(snapshot).to be_a(EnvironmentSnapshot)
-        expect(snapshot.pwd).to eq(shell.pwd)
-        expect(snapshot.pwd).not_to be_nil
-      end
-
-      it "is idempotent — calling twice preserves the same state" do
-        snap_before = shell.send(:instance_variable_get, :@env_snapshot)
-        shell.send(:seed_env_snapshot)
-        snap_after = shell.send(:instance_variable_get, :@env_snapshot)
-        expect(snap_after.pwd).to eq(snap_before.pwd)
-        expect(snap_after.branch).to eq(snap_before.branch)
-        expect(snap_after.repo).to eq(snap_before.repo)
-      end
-
-      it "captures nil branch and repo outside a git repo" do
-        Dir.mktmpdir do |tmpdir|
-          non_git_shell = described_class.new(session_id: "non-git-test")
-          non_git_shell.run("cd #{Shellwords.shellescape(tmpdir)}")
-          # Re-seed after cd to capture non-git state
-          non_git_shell.send(:seed_env_snapshot)
-          snapshot = non_git_shell.send(:instance_variable_get, :@env_snapshot)
-          expect(snapshot.branch).to be_nil
-          expect(snapshot.repo).to be_nil
-        ensure
-          non_git_shell&.finalize
-        end
-      end
-    end
-
-    describe "env_summary in tool responses" do
-      it "returns nil when first command does not change environment" do
-        # pwd matches the seeded snapshot — no footer expected
-        result = shell.run("echo hello")
-        expect(result[:env_summary]).to be_nil
-      end
-
-      it "reports location when directory changes" do
-        result = shell.run("cd /tmp")
-        expect(result[:env_summary]).to include("You are now in /tmp")
-      end
-
-      it "returns nil on subsequent command when environment is unchanged" do
-        shell.run("cd /tmp") # changes env — footer emitted (discarded here)
-        result = shell.run("echo hello")
-        expect(result[:env_summary]).to be_nil
-      end
-
-      it "reports branch change without directory change" do
-        Dir.mktmpdir do |tmpdir|
-          shell.run("cd #{Shellwords.shellescape(tmpdir)}")
-          shell.run("git init && git config user.name Test && git config user.email test@test.com && git commit --allow-empty -m init")
-          branch = "test-branch-#{SecureRandom.hex(4)}"
-          result = shell.run("git checkout -b #{branch}")
-          expect(result[:env_summary]).to include("Branch changed to #{branch}.")
-        end
-      end
-
-      it "reports project files on first visit to a directory" do
-        Dir.mktmpdir do |tmpdir|
-          File.write(File.join(tmpdir, "CLAUDE.md"), "# Test")
-          result = shell.run("cd #{Shellwords.shellescape(tmpdir)}")
-          expect(result[:env_summary]).to include("Project has instructions in CLAUDE.md")
-        end
-      end
-
-      it "returns nil on error" do
-        result = shell.run("exit 1")
-        expect(result).to have_key(:error)
-        expect(result).not_to have_key(:env_summary)
-      end
-
-      it "returns nil on interrupt" do
-        checker = -> { true }
-        allow(Anima::Settings).to receive(:interrupt_check_interval).and_return(0.5)
-        result = shell.run("sleep 30", interrupt_check: checker)
-        expect(result[:interrupted]).to be true
-        expect(result).not_to have_key(:env_summary)
-      end
+    it "returns nil after finalize" do
+      shell.finalize
+      expect(shell.pwd).to be_nil
     end
   end
 
@@ -365,147 +167,107 @@ RSpec.describe ShellSession do
   end
 
   describe "#finalize" do
-    it "cleans up the FIFO file" do
-      fifo_path = shell.instance_variable_get(:@fifo_path)
-      expect(File.exist?(fifo_path)).to be true
+    it "kills the underlying tmux session" do
+      session_id = shell.session_id
       shell.finalize
-      expect(File.exist?(fifo_path)).to be false
+      expect(system("tmux", "has-session", "-t", "anima-shell-#{session_id}", out: File::NULL, err: File::NULL)).to be false
     end
 
     it "is idempotent" do
       shell.finalize
       expect { shell.finalize }.not_to raise_error
     end
-
-    it "terminates the child process" do
-      pid = shell.instance_variable_get(:@pid)
-      shell.finalize
-      expect { Process.kill(0, pid) }.to raise_error(Errno::ESRCH)
-    end
-
-    it "cleans up even when session is already dead" do
-      pid = shell.instance_variable_get(:@pid)
-      fifo_path = shell.instance_variable_get(:@fifo_path)
-
-      # Simulate failed recovery that leaves @alive = false
-      shell.run("exit 1")
-      expect(shell.alive?).to be false
-
-      shell.finalize
-      expect(File.exist?(fifo_path)).to be false
-      expect { Process.kill(0, pid) }.to raise_error(Errno::ESRCH)
-    end
   end
 
   describe ".for_session" do
-    let(:session) { instance_double("Session", id: "test-session-#{SecureRandom.hex(4)}", initial_cwd: "/tmp") }
+    let(:session) { instance_double("Session", id: "test-session-#{SecureRandom.hex(4)}", initial_cwd: "/tmp", parent_session_id: nil) }
 
     after { described_class.release(session.id) }
 
-    it "spawns a shell and cd's into initial_cwd on first call" do
+    it "spawns a shell with initial_cwd for root sessions" do
       shell = described_class.for_session(session)
       expect(shell.pwd).to eq("/tmp")
     end
 
-    it "returns the same shell across repeated calls (persistence)" do
-      shell1 = described_class.for_session(session)
-      shell1.run("cd /")
-      shell2 = described_class.for_session(session)
-
-      expect(shell2).to equal(shell1)
-      expect(shell2.pwd).to eq("/")
-    end
-
-    it "preserves exported env vars between for_session calls" do
-      described_class.for_session(session).run("export MY_PERSIST_VAR=42")
-      result = described_class.for_session(session).run("echo $MY_PERSIST_VAR")
-
-      expect(result[:stdout]).to eq("42")
-    end
-
-    it "replaces a dead cached shell with a fresh one on the next lookup" do
-      shell1 = described_class.for_session(session)
-      shell1.finalize
-
-      shell2 = described_class.for_session(session)
-
-      expect(shell2).not_to equal(shell1)
-      expect(shell2.alive?).to be true
-    end
-
     it "isolates shells across different sessions" do
-      other = instance_double("Session", id: "other-#{SecureRandom.hex(4)}", initial_cwd: "/tmp")
+      other = instance_double("Session", id: "other-#{SecureRandom.hex(4)}", initial_cwd: "/tmp", parent_session_id: nil)
 
       a = described_class.for_session(session)
       b = described_class.for_session(other)
 
       a.run("cd /")
       expect(b.pwd).to eq("/tmp")
-      expect(a).not_to equal(b)
+      expect(a.pwd).to eq("/")
     ensure
       described_class.release(other.id)
     end
 
-    it "hands the same shell to concurrent callers racing on one session" do
-      threads = Array.new(4) { Thread.new { described_class.for_session(session) } }
-      shells = threads.map(&:value)
+    context "with a parent session" do
+      let(:parent_id) { "parent-#{SecureRandom.hex(4)}" }
+      let(:parent_session) { instance_double("Session", id: parent_id, initial_cwd: "/tmp", parent_session_id: nil) }
+      let(:child_session) { instance_double("Session", id: "child-#{SecureRandom.hex(4)}", initial_cwd: "/", parent_session_id: parent_id) }
 
-      expect(shells.uniq.size).to eq(1)
-      expect(shells.first).to be_alive
+      after { described_class.release(parent_id) }
+
+      it "inherits the parent's current cwd via tmux, ignoring child.initial_cwd" do
+        parent_shell = described_class.for_session(parent_session)
+        parent_shell.run("cd /var")
+
+        child_shell = described_class.for_session(child_session)
+        expect(child_shell.pwd).to eq("/var")
+      ensure
+        described_class.release(child_session.id)
+      end
+
+      it "falls back to child.initial_cwd when the parent tmux session is gone" do
+        described_class.release(parent_id) # no parent shell exists
+
+        child_shell = described_class.for_session(child_session)
+        expect(child_shell.pwd).to eq("/")
+      ensure
+        described_class.release(child_session.id)
+      end
     end
   end
 
   describe ".release" do
-    let(:session) { instance_double("Session", id: "release-test-#{SecureRandom.hex(4)}", initial_cwd: nil) }
+    let(:session_id) { "release-test-#{SecureRandom.hex(4)}" }
 
-    it "finalizes the cached shell and evicts the cache entry" do
-      shell = described_class.for_session(session)
+    it "kills the tmux session" do
+      described_class.new(session_id: session_id)
+      described_class.release(session_id)
 
-      described_class.release(session.id)
-
-      expect(shell.alive?).to be false
-      expect(described_class.for_session(session)).not_to equal(shell)
-    ensure
-      described_class.release(session.id)
+      expect(system("tmux", "has-session", "-t", "anima-shell-#{session_id}", out: File::NULL, err: File::NULL)).to be false
     end
 
-    it "is a no-op when no shell is cached" do
+    it "is a no-op when no session exists" do
       expect { described_class.release("never-seen-#{SecureRandom.hex(4)}") }.not_to raise_error
     end
 
     it "is safe to call twice on the same session" do
-      described_class.for_session(session)
+      described_class.new(session_id: session_id)
 
       expect {
-        described_class.release(session.id)
-        described_class.release(session.id)
+        described_class.release(session_id)
+        described_class.release(session_id)
       }.not_to raise_error
     end
   end
 
-  describe ".cleanup_orphans" do
-    it "removes FIFO files for dead processes" do
-      stale_path = File.join(Dir.tmpdir, "anima-stderr-99999999-deadbeef01234567")
-      system("mkfifo", stale_path)
-      expect(File.exist?(stale_path)).to be true
+  describe ".cwd_via_tmux" do
+    let(:session_id) { "cwd-test-#{SecureRandom.hex(4)}" }
 
-      described_class.cleanup_orphans
+    after { described_class.release(session_id) }
 
-      expect(File.exist?(stale_path)).to be false
+    it "reads the pane's working directory directly from the tmux server" do
+      shell = described_class.new(session_id: session_id, initial_cwd: "/tmp")
+      expect(described_class.cwd_via_tmux(session_id)).to eq("/tmp")
+      shell.run("cd /var")
+      expect(described_class.cwd_via_tmux(session_id)).to eq("/var")
     end
 
-    it "leaves FIFO files for live processes" do
-      live_path = File.join(Dir.tmpdir, "anima-stderr-#{Process.pid}-deadbeef01234567")
-      system("mkfifo", live_path)
-
-      described_class.cleanup_orphans
-
-      expect(File.exist?(live_path)).to be true
-      begin
-        File.delete(live_path)
-      rescue SystemCallError
-        # Best-effort cleanup
-      end
+    it "returns nil for a non-existent session" do
+      expect(described_class.cwd_via_tmux("never-seen-#{SecureRandom.hex(4)}")).to be_nil
     end
   end
 end

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -148,6 +148,24 @@ RSpec.describe ShellSession do
         expect(result[:output]).to be_valid_encoding
       end
     end
+
+    context "when capture-pane fails" do
+      # Simulates the tmux session dying between `wait-for -S` firing and
+      # the `capture-pane` call. Without an explicit error, the empty
+      # capture would collapse to the EMPTY_OUTPUT_PLACEHOLDER and the LLM
+      # would see "OK" — indistinguishable from a silent command success.
+      it "returns an error so silent session death isn't reported as success" do
+        failed_status = instance_double(Process::Status, success?: false)
+        allow(Open3).to receive(:capture2).and_call_original
+        expect(Open3).to receive(:capture2)
+          .with("tmux", "capture-pane", "-pJ", "-t", anything, "-S", "-", err: File::NULL)
+          .and_return(["", failed_status])
+
+        result = shell.run("echo hello")
+
+        expect(result[:error]).to include("capture-pane failed")
+      end
+    end
   end
 
   describe "#pwd" do

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe ShellSession do
       expect(result[:output]).to include("error")
     end
 
+    it "substitutes a placeholder when a command produces no output" do
+      # `tmux wait-for -S` releases us before bash can redraw its prompt,
+      # so commands with no output occasionally yield an all-whitespace
+      # pane. Downstream Message#content validation would reject that.
+      result = shell.run("true")
+      expect(result[:output]).not_to be_empty
+      expect(result[:output].strip).not_to be_empty
+    end
+
     it "captures both stdout and stderr together" do
       result = shell.run("echo out && echo err >&2")
       expect(result[:output]).to include("out")

--- a/spec/lib/shell_session_spec.rb
+++ b/spec/lib/shell_session_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe ShellSession do
       expect(result[:output]).to include("persistent")
     end
 
+    it "injects pager-disabling env vars after the user's rcfiles run" do
+      # The pager block matters most for tools like `gh`, `git`, `man` that
+      # otherwise spawn `less` and stall the pane. Verifying the export
+      # took effect — beating any `export PAGER=less` from ~/.zshrc.
+      result = shell.run("echo PAGER=$PAGER GIT_PAGER=$GIT_PAGER LESS=$LESS")
+      expect(result[:output]).to include("PAGER=cat")
+      expect(result[:output]).to include("GIT_PAGER=cat")
+      expect(result[:output]).to include("LESS=-eFRX")
+    end
+
     it "handles multi-line output" do
       result = shell.run("printf 'line1\\nline2\\nline3\\n'")
       expect(result[:output]).to include("line1")

--- a/spec/lib/tools/bash_spec.rb
+++ b/spec/lib/tools/bash_spec.rb
@@ -17,68 +17,37 @@ RSpec.describe Tools::Bash do
       expect(schema).to include(name: "bash", description: a_kind_of(String))
       expect(schema[:input_schema][:properties]).to include(
         command: include(type: "string"),
-        commands: include(type: "array", items: {type: "string"}),
-        mode: include(type: "string", enum: contain_exactly("sequential", "parallel"))
+        commands: include(type: "array", items: {type: "string"})
       )
     end
   end
 
   describe "#execute" do
     context "with single command" do
-      it "returns stdout and exit code" do
+      it "returns the rendered output" do
         result = tool.execute("command" => "echo hello")
-        expect(result).to include("stdout:\nhello")
-        expect(result).to include("exit_code: 0")
+        expect(result).to include("hello")
       end
 
-      it "captures stderr" do
+      it "includes stderr in the merged stream" do
         result = tool.execute("command" => "echo oops >&2")
-        expect(result).to include("stderr:")
         expect(result).to include("oops")
-      end
-
-      it "captures both stdout and stderr" do
-        result = tool.execute("command" => "echo out && echo err >&2")
-        expect(result).to include("stdout:\nout")
-        expect(result).to include("err")
-      end
-
-      it "returns non-zero exit code" do
-        result = tool.execute("command" => "(exit 42)")
-        expect(result).to include("exit_code: 42")
-      end
-
-      it "returns only exit code for silent commands (after env warmup)" do
-        tool.execute("command" => "true")
-        result = tool.execute("command" => "true")
-        expect(result).to eq("exit_code: 0")
       end
 
       it "preserves working directory between calls" do
         tool.execute("command" => "cd /tmp")
         result = tool.execute("command" => "pwd")
-        expect(result).to include("stdout:\n/tmp")
-      end
-
-      it "appends environment summary when directory changes" do
-        result = tool.execute("command" => "cd /tmp")
-        expect(result).to include("You are now in /tmp")
-      end
-
-      it "omits environment summary when nothing changes" do
-        tool.execute("command" => "cd /tmp")
-        result = tool.execute("command" => "echo hello")
-        expect(result).not_to include("You are now in")
+        expect(result).to include("/tmp")
       end
 
       it "preserves environment variables between calls" do
         tool.execute("command" => "export MY_PERSIST_VAR=kept")
         result = tool.execute("command" => "echo $MY_PERSIST_VAR")
-        expect(result).to include("stdout:\nkept")
+        expect(result).to include("kept")
       end
 
-      it "passes timeout parameter to shell session" do
-        expect(shell_session).to receive(:run).with("echo hi", timeout: 300, interrupt_check: an_instance_of(Proc)).and_return(stdout: "hi\n", stderr: "", exit_code: 0)
+      it "passes timeout parameter to the shell session" do
+        expect(shell_session).to receive(:run).with("echo hi", timeout: 300, interrupt_check: an_instance_of(Proc)).and_return(output: "hi")
         tool.execute("command" => "echo hi", "timeout" => 300)
       end
 
@@ -88,7 +57,7 @@ RSpec.describe Tools::Bash do
         expect(result[:error]).to include("blank")
       end
 
-      it "delegates errors from shell session" do
+      it "delegates errors from the shell session" do
         shell_session.finalize
         result = tool.execute("command" => "echo hello")
         expect(result).to be_a(Hash)
@@ -96,81 +65,34 @@ RSpec.describe Tools::Bash do
       end
     end
 
-    context "with batch commands in sequential mode" do
-      it "runs all commands and returns combined results" do
+    context "with batch commands" do
+      it "runs all commands and returns combined results with per-command headers" do
         result = tool.execute("commands" => ["echo first", "echo second", "echo third"])
         expect(result).to include("[1/3] $ echo first")
         expect(result).to include("[2/3] $ echo second")
         expect(result).to include("[3/3] $ echo third")
-        expect(result).to include("stdout:\nfirst")
-        expect(result).to include("stdout:\nsecond")
-        expect(result).to include("stdout:\nthird")
+        expect(result).to include("first")
+        expect(result).to include("second")
+        expect(result).to include("third")
       end
 
-      it "defaults to sequential mode" do
-        result = tool.execute("commands" => ["(exit 1)", "echo should-not-run"])
-        expect(result).to include("[1/2] $ (exit 1)")
-        expect(result).to include("exit_code: 1")
-        expect(result).to include("[2/2] $ echo should-not-run\n(skipped)")
-        expect(result).not_to include("should-not-run\nexit_code")
-      end
-
-      it "stops on first non-zero exit code" do
-        result = tool.execute("commands" => ["echo ok", "(exit 2)", "echo never"], "mode" => "sequential")
-        expect(result).to include("[1/3] $ echo ok")
-        expect(result).to include("stdout:\nok")
-        expect(result).to include("[2/3] $ (exit 2)")
-        expect(result).to include("exit_code: 2")
-        expect(result).to include("[3/3] $ echo never\n(skipped)")
-      end
-
-      it "stops on shell session errors" do
+      it "continues past shell session errors — agent reads merged output" do
         allow(shell_session).to receive(:run).with(anything, hash_including(:timeout, :interrupt_check)).and_return(
-          {stdout: "ok\n", stderr: "", exit_code: 0},
+          {output: "ok"},
           {error: "Command timed out after 30s"},
-          {stdout: "unreachable\n", stderr: "", exit_code: 0}
+          {output: "still running"}
         )
-        result = tool.execute("commands" => ["echo ok", "sleep 999", "echo unreachable"])
+        result = tool.execute("commands" => ["echo ok", "sleep 999", "echo still running"])
         expect(result).to include("[1/3] $ echo ok")
         expect(result).to include("[2/3] $ sleep 999")
         expect(result).to include("Command timed out")
-        expect(result).to include("[3/3] $ echo unreachable\n(skipped)")
+        expect(result).to include("[3/3] $ echo still running")
+        expect(result).to include("still running")
       end
 
       it "preserves working directory across batch commands" do
         result = tool.execute("commands" => ["cd /tmp", "pwd"])
-        expect(result).to include("stdout:\n/tmp")
-      end
-
-      it "appends environment summary only once at the end" do
-        result = tool.execute("commands" => ["cd /tmp", "cd /var"])
-        # env_summary appears once at the end, not per-command
-        expect(result).to include("You are now in /var")
-        expect(result.scan("You are now in").length).to eq(1)
-      end
-    end
-
-    context "with batch commands in parallel mode" do
-      it "runs all commands regardless of failures" do
-        result = tool.execute("commands" => ["echo first", "(exit 1)", "echo third"], "mode" => "parallel")
-        expect(result).to include("[1/3] $ echo first")
-        expect(result).to include("stdout:\nfirst")
-        expect(result).to include("[2/3] $ (exit 1)")
-        expect(result).to include("exit_code: 1")
-        expect(result).to include("[3/3] $ echo third")
-        expect(result).to include("stdout:\nthird")
-      end
-
-      it "continues past shell session errors" do
-        allow(shell_session).to receive(:run).with(anything, hash_including(:timeout, :interrupt_check)).and_return(
-          {error: "Command timed out after 30s"},
-          {stdout: "still running\n", stderr: "", exit_code: 0}
-        )
-        result = tool.execute("commands" => ["sleep 999", "echo still running"], "mode" => "parallel")
-        expect(result).to include("[1/2] $ sleep 999")
-        expect(result).to include("Command timed out")
-        expect(result).to include("[2/2] $ echo still running")
-        expect(result).to include("stdout:\nstill running")
+        expect(result).to include("/tmp")
       end
     end
 
@@ -195,8 +117,8 @@ RSpec.describe Tools::Bash do
       end
 
       it "passes timeout to each command in batch" do
-        expect(shell_session).to receive(:run).with("echo a", timeout: 60, interrupt_check: an_instance_of(Proc)).and_return(stdout: "a\n", stderr: "", exit_code: 0)
-        expect(shell_session).to receive(:run).with("echo b", timeout: 60, interrupt_check: an_instance_of(Proc)).and_return(stdout: "b\n", stderr: "", exit_code: 0)
+        expect(shell_session).to receive(:run).with("echo a", timeout: 60, interrupt_check: an_instance_of(Proc)).and_return(output: "a")
+        expect(shell_session).to receive(:run).with("echo b", timeout: 60, interrupt_check: an_instance_of(Proc)).and_return(output: "b")
         tool.execute("commands" => ["echo a", "echo b"], "timeout" => 60)
       end
     end
@@ -204,28 +126,28 @@ RSpec.describe Tools::Bash do
     context "when interrupted by user" do
       it "returns interrupted message for single command" do
         allow(shell_session).to receive(:run).and_return(
-          {interrupted: true, stdout: "", stderr: ""}
+          {interrupted: true, output: ""}
         )
 
         result = tool.execute("command" => "sleep 30")
         expect(result).to include(LLM::Client::INTERRUPT_MESSAGE)
       end
 
-      it "includes partial stdout in interrupted result" do
+      it "includes partial output in interrupted result" do
         allow(shell_session).to receive(:run).and_return(
-          {interrupted: true, stdout: "partial output", stderr: ""}
+          {interrupted: true, output: "partial output"}
         )
         result = tool.execute("command" => "long-command")
-        expect(result).to include("Your human wants your attention")
-        expect(result).to include("Partial stdout:\npartial output")
+        expect(result).to include(LLM::Client::INTERRUPT_MESSAGE)
+        expect(result).to include("Partial output:\npartial output")
       end
 
       it "skips remaining batch commands after interrupt" do
         allow(shell_session).to receive(:run).with("echo first", hash_including(:interrupt_check)).and_return(
-          {stdout: "first\n", stderr: "", exit_code: 0}
+          {output: "first"}
         )
         allow(shell_session).to receive(:run).with("sleep 999", hash_including(:interrupt_check)).and_return(
-          {interrupted: true, stdout: "", stderr: ""}
+          {interrupted: true, output: ""}
         )
         expect(shell_session).not_to receive(:run).with("echo third", anything)
 
@@ -234,15 +156,6 @@ RSpec.describe Tools::Bash do
         expect(result).to include("[2/3] $ sleep 999")
         expect(result).to include(LLM::Client::INTERRUPT_MESSAGE)
         expect(result).to include("[3/3] $ echo third\n(skipped — interrupted by user)")
-      end
-
-      it "includes stderr in interrupted result" do
-        allow(shell_session).to receive(:run).and_return(
-          {interrupted: true, stdout: "", stderr: "warning: something"}
-        )
-        result = tool.execute("command" => "failing-command")
-        expect(result).to include(LLM::Client::INTERRUPT_MESSAGE)
-        expect(result).to include("stderr:\nwarning: something")
       end
     end
 

--- a/spec/lib/tools/spawn_specialist_spec.rb
+++ b/spec/lib/tools/spawn_specialist_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe Tools::SpawnSpecialist do
   let!(:parent_session) { Session.create! }
-  let(:shell_session) { instance_double(ShellSession, pwd: "/home/user/project") }
   let(:tmp_dir) { Dir.mktmpdir }
   let(:agent_registry) do
     registry = Agents::Registry.new
@@ -12,7 +11,7 @@ RSpec.describe Tools::SpawnSpecialist do
     registry
   end
 
-  subject(:tool) { described_class.new(session: parent_session, shell_session: shell_session, agent_registry: agent_registry) }
+  subject(:tool) { described_class.new(session: parent_session, agent_registry: agent_registry) }
 
   before do
     # Stub Melete to simulate nickname assignment
@@ -159,13 +158,6 @@ RSpec.describe Tools::SpawnSpecialist do
 
       child = Session.last
       expect(child.parent_session).to eq(parent_session)
-    end
-
-    it "inherits the parent shell's working directory" do
-      tool.execute(input)
-
-      child = Session.last
-      expect(child.initial_cwd).to eq("/home/user/project")
     end
 
     it "creates a Goal on the child session with the task as description" do

--- a/spec/lib/tools/spawn_specialist_spec.rb
+++ b/spec/lib/tools/spawn_specialist_spec.rb
@@ -107,6 +107,30 @@ RSpec.describe Tools::SpawnSpecialist do
       expect(child.granted_tools).to eq(%w[read_file bash])
     end
 
+    context "initial_cwd inheritance" do
+      # The child's running shell looks up parent cwd via tmux dynamically,
+      # but +initial_cwd+ is the persisted fallback used when the parent's
+      # tmux session is gone (e.g. across an Anima restart). Snapshotting
+      # parent's current cwd at spawn time keeps that fallback useful
+      # rather than letting it default to nil → process cwd.
+      it "snapshots parent's current tmux cwd as the child's initial_cwd" do
+        allow(ShellSession).to receive(:cwd_via_tmux).with(parent_session.id).and_return("/tmp/work")
+
+        tool.execute(input)
+
+        expect(Session.last.initial_cwd).to eq("/tmp/work")
+      end
+
+      it "falls back to parent's initial_cwd when parent's tmux session is gone" do
+        parent_session.update!(initial_cwd: "/home/agent")
+        allow(ShellSession).to receive(:cwd_via_tmux).with(parent_session.id).and_return(nil)
+
+        tool.execute(input)
+
+        expect(Session.last.initial_cwd).to eq("/home/agent")
+      end
+    end
+
     it "prepends identity context to the specialist prompt" do
       tool.execute(input)
 

--- a/spec/lib/tools/spawn_subagent_spec.rb
+++ b/spec/lib/tools/spawn_subagent_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe Tools::SpawnSubagent do
       expect(child.parent_session).to eq(parent_session)
     end
 
+    context "initial_cwd inheritance" do
+      # The child's running shell looks up parent cwd via tmux dynamically,
+      # but +initial_cwd+ is the persisted fallback used when the parent's
+      # tmux session is gone (e.g. across an Anima restart). Snapshotting
+      # parent's current cwd at spawn time keeps that fallback useful
+      # rather than letting it default to nil → process cwd.
+      it "snapshots parent's current tmux cwd as the child's initial_cwd" do
+        allow(ShellSession).to receive(:cwd_via_tmux).with(parent_session.id).and_return("/tmp/work")
+
+        tool.execute(input)
+
+        expect(Session.last.initial_cwd).to eq("/tmp/work")
+      end
+
+      it "falls back to parent's initial_cwd when parent's tmux session is gone" do
+        parent_session.update!(initial_cwd: "/home/agent")
+        allow(ShellSession).to receive(:cwd_via_tmux).with(parent_session.id).and_return(nil)
+
+        tool.execute(input)
+
+        expect(Session.last.initial_cwd).to eq("/home/agent")
+      end
+    end
+
     it "captures the invoking tool_call's id on the child as spawn_tool_use_id" do
       tool = described_class.new(
         session: parent_session,

--- a/spec/lib/tools/spawn_subagent_spec.rb
+++ b/spec/lib/tools/spawn_subagent_spec.rb
@@ -4,9 +4,8 @@ require "rails_helper"
 
 RSpec.describe Tools::SpawnSubagent do
   let!(:parent_session) { Session.create! }
-  let(:shell_session) { instance_double(ShellSession, pwd: "/home/user/project") }
 
-  subject(:tool) { described_class.new(session: parent_session, shell_session: shell_session) }
+  subject(:tool) { described_class.new(session: parent_session) }
 
   before do
     # Stub Melete to simulate nickname assignment
@@ -99,20 +98,12 @@ RSpec.describe Tools::SpawnSubagent do
     it "captures the invoking tool_call's id on the child as spawn_tool_use_id" do
       tool = described_class.new(
         session: parent_session,
-        shell_session: shell_session,
         tool_use_id: "toolu_spawn_abc"
       )
 
       tool.execute(input)
 
       expect(Session.last.spawn_tool_use_id).to eq("toolu_spawn_abc")
-    end
-
-    it "inherits the parent shell's working directory" do
-      tool.execute(input)
-
-      child = Session.last
-      expect(child.initial_cwd).to eq("/home/user/project")
     end
 
     it "sets the child session's prompt with identity context" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,7 +53,6 @@ RSpec.configure do |config|
       "paths" => {"soul" => Rails.root.join("spec/fixtures/soul.md").to_s},
       "session" => {"default_view_mode" => "basic"},
       "melete" => {"max_tokens" => 4096, "blocking_on_user_message" => true, "blocking_on_agent_message" => false, "message_window" => 20},
-      "environment" => {"project_files" => ["CLAUDE.md", "AGENTS.md", "README.md", "CONTRIBUTING.md"], "project_files_max_depth" => 3},
       "mneme" => {"max_tokens" => 2048, "viewport_fraction" => 0.33, "l1_budget_fraction" => 0.15, "l2_budget_fraction" => 0.05, "l2_snapshot_threshold" => 5, "pinned_budget_fraction" => 0.05},
       "recall" => {"max_results" => 5, "budget_fraction" => 0.05, "max_snippet_tokens" => 512, "recency_decay" => 0.3}
     )

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -102,16 +102,6 @@ max_tool_response_chars = 6_000
 # ~24000 chars ≈ ~8000 tokens.
 max_subagent_response_chars = 24_000
 
-# ─── Environment ──────────────────────────────────────────────
-
-[environment]
-
-# Files to scan for in the working directory (at root and up to project_files_max_depth subdirectories deep).
-project_files = ["CLAUDE.md", "AGENTS.md", "README.md", "CONTRIBUTING.md"]
-
-# Maximum directory depth for project file scanning.
-project_files_max_depth = 3
-
 # ─── GitHub ─────────────────────────────────────────────────────
 
 [github]


### PR DESCRIPTION
Closes #466.

## Summary

Replaces the ~400-LOC PTY+FIFO `ShellSession` with a ~120-LOC tmux wrapper. Closes the OOM bug (`@read_buffer` unbounded accumulation in the old PTY code) by capping scrollback at the tmux server level — `history-limit 5000` lines bounds memory at the kernel rather than in Ruby.

The interface for callers (`for_session`, `release`, `#run`, `#pwd`, `#alive?`, `#finalize`) is preserved. `Tools::Bash` now returns the rendered terminal text (what a human would see) instead of separate stdout/stderr/exit_code/env_summary fields, matching the issue's "human-shaped text processor" framing.

## What's gone

- PTY + FIFO + stderr reader thread + sentinel-marker parsing
- `@read_buffer` unbounded accumulation (OOM source)
- `recover_shell` SIGTERM/SIGKILL dance
- `EnvironmentSnapshot` + Open3 git/file detection (the shell prompt now serves as live env telemetry for the agent)
- `@sessions_by_id` in-process registry + `Monitor` + `at_exit` cleanup — tmux is the single source of truth, sessions survive Anima crashes
- `Tools::Bash` `mode` parameter (relied on exit codes that are now gone)
- `project_files_whitelist` / `project_files_max_depth` settings
- ~280 LOC of test scaffolding around the above

## What's new

- One tmux session per `Session` (`anima-shell-{session_id}`), torn down only via explicit `release` / `finalize`
- Sub-agents inherit cwd from parent's tmux pane via `display-message` — dynamic lookup at child shell creation, not snapshot-at-spawn
- `tmux wait-for` channel for command completion (with manual kill of the wait-for child after Ctrl+C, since interactive bash discards the rest of its line on SIGINT)
- `clear-history` + shell `clear` (which writes `\e[3J` on modern terminfo) wipes both visible pane and scrollback so each capture contains exactly the new command's output
- `capture-pane -pJ -S -` returns merged terminal text — `-J` joins wrapped lines so long single-line outputs come back whole
- Pager-disabling env vars (`PAGER=cat`, `GIT_PAGER=cat`, `LESS=-eFRX`, etc.) injected via `send-keys export ...` after the shell starts, so they beat any `export PAGER=less` in the user's `~/.zshrc` etc. — without this, `gh`/`git`/`man` open `less` and block the pane forever
- README install section lists `tmux` as a hard runtime requirement

## Test plan

- [x] `bundle exec rspec spec/lib/shell_session_spec.rb` — passes
- [x] `bundle exec rspec spec/lib/tools/bash_spec.rb` — passes
- [x] `bundle exec rspec spec/integration/session_happy_path_smoke_spec.rb` — passes (real tmux + real `gh`)
- [x] `bundle exec rspec spec/lib/tools/spawn_subagent_spec.rb spec/lib/tools/spawn_specialist_spec.rb spec/lib/anima/settings_spec.rb spec/jobs/ spec/lib/providers/anthropic_spec.rb` — all pass
- [x] `bundle exec standardrb` clean
- [ ] Manual smoke (real Anima session) — pending review