### PR TITLE
#469 fix: stop MCP stdio process leak

### DIFF
--- a/lib/mcp/client_manager.rb
+++ b/lib/mcp/client_manager.rb
@@ -3,124 +3,68 @@
 require "mcp"
 
 module Mcp
-  # Manages MCP client connections and registers their tools with
-  # {Tools::Registry}. Each configured server (HTTP or stdio) gets a
-  # dedicated {MCP::Client} instance that persists for the worker
-  # process's lifetime, in line with the MCP integration research note
-  # (decision #11): stdio servers spawn lazily on first use and stay
-  # alive across tool calls.
+  # Connects to MCP servers and registers their tools with
+  # {Tools::Registry}. Each configured server (HTTP or stdio) is
+  # connected on first use and the resulting tool wrappers are cached
+  # for the worker's lifetime — so {Tools::Registry.build}, which fires
+  # per job, reuses the same MCP clients instead of respawning a fresh
+  # subprocess per server per job (issue #469).
   #
-  # The class-level {.shared} accessor returns a single instance per
-  # process. {Tools::Registry.build} is called per job, but it pulls
-  # tools from the shared manager, so each configured server is connected
-  # exactly once per worker — not once per job — preventing the
-  # subprocess accumulation reported in issue #469.
+  # Spawned stdio server processes are reaped on worker exit by
+  # {Mcp::StdioTransport.cleanup_all} (registered as an at_exit hook).
   #
   # Connection failures are logged and skipped — a misconfigured or
   # unavailable server does not prevent other servers or built-in tools
-  # from working. Warnings collected during the initial load are returned
-  # from the first {#register_tools} call so the caller can surface them
-  # as system messages; subsequent calls return an empty array, since the
-  # same warnings would otherwise be re-emitted on every job.
+  # from working.
   #
-  # @example Production use
+  # @example
   #   Mcp::ClientManager.shared.register_tools(registry)
-  #
-  # @example Test use with injected config
-  #   manager = Mcp::ClientManager.new(config: fake_config)
-  #   manager.register_tools(registry)
   class ClientManager
-    class << self
-      # Process-wide shared instance. Lazily constructed on first call.
-      # @return [Mcp::ClientManager]
-      def shared
-        shared_mutex.synchronize { @shared ||= new }
-      end
-
-      # Tears down the shared instance, terminating all cached MCP server
-      # connections and clearing cached tool wrappers. The next {.shared}
-      # call rebuilds from scratch. Used at process shutdown and from
-      # tests that need to isolate state.
-      def reset!
-        shared_mutex.synchronize do
-          @shared&.shutdown
-          @shared = nil
-        end
-      end
-
-      private
-
-      def shared_mutex
-        @shared_mutex ||= Mutex.new
-      end
+    # Process-wide shared instance. Lazily constructed on first call.
+    # @return [Mcp::ClientManager]
+    def self.shared
+      @shared ||= new
     end
 
     # @param config [Mcp::Config] injectable config for testing
     def initialize(config: Config.new(logger: Rails.logger))
       @config = config
-      @clients = {}
-      @transports = {}
-      @tool_wrappers = {}
-      @warnings = []
-      @loaded = false
-      @warnings_consumed = false
-      @load_mutex = Mutex.new
     end
 
-    # Connects to every configured MCP server on first call (lazy load),
-    # fetches their tool catalogs, and caches the connections. Subsequent
-    # calls reuse the cache and just attach the cached tool wrappers to
-    # the given registry — no respawn, no extra round-trip.
-    #
-    # The entire body runs under +@load_mutex+ so a concurrent {#shutdown}
-    # cannot clear the cache mid-iteration.
+    # Connects to every configured MCP server on first call, caches the
+    # resulting tool wrappers, and registers them in the given registry.
+    # Subsequent calls reuse the cache — no respawn, no extra
+    # +tools/list+ round-trip.
     #
     # @param registry [Tools::Registry] the registry to add tools to
-    # @return [Array<String>] warning messages from the initial load on
-    #   the first call; an empty array on subsequent calls
+    # @return [Array<String>] warning messages from configuration plus
+    #   any per-server load failures
     def register_tools(registry)
-      @load_mutex.synchronize do
-        load_servers unless @loaded
-        @tool_wrappers.each_value do |wrappers|
-          wrappers.each { |wrapper| registry.register(wrapper) }
-        end
-        consume_warnings
-      end
-    end
-
-    # Tears down all cached MCP client connections, shutting down their
-    # transports (which terminates any spawned stdio server processes).
-    # After shutdown, the next {#register_tools} call will rebuild the
-    # cache from configuration.
-    def shutdown
-      @load_mutex.synchronize do
-        @transports.each_value do |transport|
-          transport.shutdown if transport.respond_to?(:shutdown)
-        end
-        @clients.clear
-        @transports.clear
-        @tool_wrappers.clear
-        @warnings.clear
-        @warnings_consumed = false
-        @loaded = false
-      end
+      load_servers if @wrappers.nil?
+      @wrappers.each { |wrapper| registry.register(wrapper) }
+      @config.warnings + @warnings
     end
 
     private
 
     def load_servers
-      register_transport_tools(@config.http_servers) { |server| build_http_client(server) }
-      register_transport_tools(@config.stdio_servers) { |server| build_stdio_client(server) }
-      @loaded = true
+      @wrappers = []
+      @warnings = []
+      register_transport(@config.http_servers) { |server| build_http_client(server) }
+      register_transport(@config.stdio_servers) { |server| build_stdio_client(server) }
     end
 
-    # Iterates server configs, builds a client+transport for each via the
-    # block, and registers the server's tools. Failures are logged and
+    # Iterates server configs, builds a client for each via the block,
+    # caches the resulting tool wrappers. Failures are logged and
     # collected as warnings.
-    def register_transport_tools(servers)
+    def register_transport(servers)
       servers.each do |server|
-        client, transport = yield(server)
-        register_server_tools(server[:name], client, transport)
+        client = yield(server)
+        wrappers = client.tools.map { |mcp_tool|
+          Tools::McpTool.new(server_name: server[:name], mcp_client: client, mcp_tool: mcp_tool)
+        }
+        @wrappers.concat(wrappers)
+        Rails.logger.info("MCP: registered #{wrappers.size} tools from #{server[:name]}")
       rescue => error
         message = "MCP: failed to load tools from #{server[:name]}: #{error.message}"
         Rails.logger.warn(message)
@@ -128,31 +72,14 @@ module Mcp
       end
     end
 
-    def register_server_tools(server_name, client, transport)
-      wrappers = client.tools.map { |mcp_tool|
-        Tools::McpTool.new(server_name: server_name, mcp_client: client, mcp_tool: mcp_tool)
-      }
-      @clients[server_name] = client
-      @transports[server_name] = transport
-      @tool_wrappers[server_name] = wrappers
-
-      Rails.logger.info("MCP: registered #{wrappers.size} tools from #{server_name}")
-    end
-
     def build_http_client(server)
       transport = MCP::Client::HTTP.new(url: server[:url], headers: server[:headers])
-      [MCP::Client.new(transport: transport), transport]
+      MCP::Client.new(transport: transport)
     end
 
     def build_stdio_client(server)
       transport = StdioTransport.new(command: server[:command], args: server[:args], env: server[:env])
-      [MCP::Client.new(transport: transport), transport]
-    end
-
-    def consume_warnings
-      return [] if @warnings_consumed
-      @warnings_consumed = true
-      @config.warnings + @warnings
+      MCP::Client.new(transport: transport)
     end
   end
 end

--- a/lib/mcp/client_manager.rb
+++ b/lib/mcp/client_manager.rb
@@ -4,83 +4,155 @@ require "mcp"
 
 module Mcp
   # Manages MCP client connections and registers their tools with
-  # {Tools::Registry}. Each configured server (HTTP or stdio) gets
-  # a dedicated {MCP::Client} instance. Tool lists are fetched once
-  # during registration and cached in the registry — subsequent LLM
-  # turns reuse the same tool set without re-querying servers.
+  # {Tools::Registry}. Each configured server (HTTP or stdio) gets a
+  # dedicated {MCP::Client} instance that persists for the worker
+  # process's lifetime, in line with the MCP integration research note
+  # (decision #11): stdio servers spawn lazily on first use and stay
+  # alive across tool calls.
+  #
+  # The class-level {.shared} accessor returns a single instance per
+  # process. {Tools::Registry.build} is called per job, but it pulls
+  # tools from the shared manager, so each configured server is connected
+  # exactly once per worker — not once per job — preventing the
+  # subprocess accumulation reported in issue #469.
   #
   # Connection failures are logged and skipped — a misconfigured or
-  # unavailable server does not prevent other servers or built-in
-  # tools from working.
+  # unavailable server does not prevent other servers or built-in tools
+  # from working. Warnings collected during the initial load are returned
+  # from the first {#register_tools} call so the caller can surface them
+  # as system messages; subsequent calls return an empty array, since the
+  # same warnings would otherwise be re-emitted on every job.
   #
-  # @example
-  #   manager = Mcp::ClientManager.new
+  # @example Production use
+  #   Mcp::ClientManager.shared.register_tools(registry)
+  #
+  # @example Test use with injected config
+  #   manager = Mcp::ClientManager.new(config: fake_config)
   #   manager.register_tools(registry)
   class ClientManager
+    class << self
+      # Process-wide shared instance. Lazily constructed on first call.
+      # @return [Mcp::ClientManager]
+      def shared
+        shared_mutex.synchronize { @shared ||= new }
+      end
+
+      # Tears down the shared instance, terminating all cached MCP server
+      # connections and clearing cached tool wrappers. The next {.shared}
+      # call rebuilds from scratch. Used at process shutdown and from
+      # tests that need to isolate state.
+      def reset!
+        shared_mutex.synchronize do
+          @shared&.shutdown
+          @shared = nil
+        end
+      end
+
+      private
+
+      def shared_mutex
+        @shared_mutex ||= Mutex.new
+      end
+    end
+
     # @param config [Mcp::Config] injectable config for testing
     def initialize(config: Config.new(logger: Rails.logger))
       @config = config
+      @clients = {}
+      @transports = {}
+      @tool_wrappers = {}
+      @warnings = []
+      @loaded = false
+      @warnings_consumed = false
+      @load_mutex = Mutex.new
     end
 
-    # Connects to all configured MCP servers and registers their tools
-    # in the given registry. Returns warnings for servers that failed
-    # to load so the caller can surface them to the user.
+    # Connects to every configured MCP server on first call (lazy load),
+    # fetches their tool catalogs, and caches the connections. Subsequent
+    # calls reuse the cache and just attach the cached tool wrappers to
+    # the given registry — no respawn, no extra round-trip.
+    #
+    # The entire body runs under +@load_mutex+ so a concurrent {#shutdown}
+    # cannot clear the cache mid-iteration.
     #
     # @param registry [Tools::Registry] the registry to add tools to
-    # @return [Array<String>] warning messages for servers that failed
+    # @return [Array<String>] warning messages from the initial load on
+    #   the first call; an empty array on subsequent calls
     def register_tools(registry)
-      warnings = []
-      register_transport_tools(@config.http_servers, registry, warnings) { |server| build_http_client(server) }
-      register_transport_tools(@config.stdio_servers, registry, warnings) { |server| build_stdio_client(server) }
-      @config.warnings + warnings
+      @load_mutex.synchronize do
+        load_servers unless @loaded
+        @tool_wrappers.each_value do |wrappers|
+          wrappers.each { |wrapper| registry.register(wrapper) }
+        end
+        consume_warnings
+      end
+    end
+
+    # Tears down all cached MCP client connections, shutting down their
+    # transports (which terminates any spawned stdio server processes).
+    # After shutdown, the next {#register_tools} call will rebuild the
+    # cache from configuration.
+    def shutdown
+      @load_mutex.synchronize do
+        @transports.each_value do |transport|
+          transport.shutdown if transport.respond_to?(:shutdown)
+        end
+        @clients.clear
+        @transports.clear
+        @tool_wrappers.clear
+        @warnings.clear
+        @warnings_consumed = false
+        @loaded = false
+      end
     end
 
     private
 
-    # Iterates server configs, builds a client for each via the block,
-    # and registers the server's tools. Failures are logged and collected.
-    #
-    # @param servers [Array<Hash>] server configs from {Mcp::Config}
-    # @param registry [Tools::Registry] registry to register tools in
-    # @param warnings [Array<String>] collects failure messages
-    # @yield [server] block that builds an {MCP::Client} for the server
-    def register_transport_tools(servers, registry, warnings)
+    def load_servers
+      register_transport_tools(@config.http_servers) { |server| build_http_client(server) }
+      register_transport_tools(@config.stdio_servers) { |server| build_stdio_client(server) }
+      @loaded = true
+    end
+
+    # Iterates server configs, builds a client+transport for each via the
+    # block, and registers the server's tools. Failures are logged and
+    # collected as warnings.
+    def register_transport_tools(servers)
       servers.each do |server|
-        client = yield(server)
-        register_server_tools(server[:name], client, registry)
+        client, transport = yield(server)
+        register_server_tools(server[:name], client, transport)
       rescue => error
         message = "MCP: failed to load tools from #{server[:name]}: #{error.message}"
         Rails.logger.warn(message)
-        warnings << message
+        @warnings << message
       end
     end
 
-    # Fetches tools from an MCP client and registers them with
-    # namespaced names in the registry.
-    #
-    # @param server_name [String] server name for tool namespacing
-    # @param client [MCP::Client] connected MCP client
-    # @param registry [Tools::Registry] registry to register tools in
-    def register_server_tools(server_name, client, registry)
-      count = client.tools.map { |mcp_tool|
+    def register_server_tools(server_name, client, transport)
+      wrappers = client.tools.map { |mcp_tool|
         Tools::McpTool.new(server_name: server_name, mcp_client: client, mcp_tool: mcp_tool)
-      }.each { |wrapper| registry.register(wrapper) }.size
+      }
+      @clients[server_name] = client
+      @transports[server_name] = transport
+      @tool_wrappers[server_name] = wrappers
 
-      Rails.logger.info("MCP: registered #{count} tools from #{server_name}")
+      Rails.logger.info("MCP: registered #{wrappers.size} tools from #{server_name}")
     end
 
-    # @param server [Hash] server config with +:url+ and +:headers+
-    # @return [MCP::Client]
     def build_http_client(server)
       transport = MCP::Client::HTTP.new(url: server[:url], headers: server[:headers])
-      MCP::Client.new(transport: transport)
+      [MCP::Client.new(transport: transport), transport]
     end
 
-    # @param server [Hash] server config with +:command+, +:args+, +:env+
-    # @return [MCP::Client]
     def build_stdio_client(server)
       transport = StdioTransport.new(command: server[:command], args: server[:args], env: server[:env])
-      MCP::Client.new(transport: transport)
+      [MCP::Client.new(transport: transport), transport]
+    end
+
+    def consume_warnings
+      return [] if @warnings_consumed
+      @warnings_consumed = true
+      @config.warnings + @warnings
     end
   end
 end

--- a/lib/mcp/client_manager.rb
+++ b/lib/mcp/client_manager.rb
@@ -4,23 +4,19 @@ require "mcp"
 
 module Mcp
   # Connects to MCP servers and registers their tools with
-  # {Tools::Registry}. Each configured server (HTTP or stdio) is
-  # connected on first use and the resulting tool wrappers are cached
-  # for the worker's lifetime — so {Tools::Registry.build}, which fires
-  # per job, reuses the same MCP clients instead of respawning a fresh
-  # subprocess per server per job (issue #469).
+  # {Tools::Registry}. Each configured server (HTTP or stdio) gets a
+  # dedicated {MCP::Client} instance, cached for the worker's
+  # lifetime. Connection failures are logged and skipped — a
+  # misconfigured or unavailable server does not prevent other servers
+  # or built-in tools from working.
   #
-  # Spawned stdio server processes are reaped on worker exit by
-  # {Mcp::StdioTransport.cleanup_all} (registered as an at_exit hook).
-  #
-  # Connection failures are logged and skipped — a misconfigured or
-  # unavailable server does not prevent other servers or built-in tools
-  # from working.
+  # Spawned stdio processes are reaped on worker exit via
+  # {Mcp::StdioTransport.cleanup_all}.
   #
   # @example
   #   Mcp::ClientManager.shared.register_tools(registry)
   class ClientManager
-    # Process-wide shared instance. Lazily constructed on first call.
+    # Process-wide shared instance.
     # @return [Mcp::ClientManager]
     def self.shared
       @shared ||= new
@@ -31,10 +27,9 @@ module Mcp
       @config = config
     end
 
-    # Connects to every configured MCP server on first call, caches the
-    # resulting tool wrappers, and registers them in the given registry.
-    # Subsequent calls reuse the cache — no respawn, no extra
-    # +tools/list+ round-trip.
+    # Connects to every configured MCP server on first call, caches
+    # the resulting tool wrappers, and registers them in the given
+    # registry.
     #
     # @param registry [Tools::Registry] the registry to add tools to
     # @return [Array<String>] warning messages from configuration plus
@@ -54,9 +49,6 @@ module Mcp
       register_transport(@config.stdio_servers) { |server| build_stdio_client(server) }
     end
 
-    # Iterates server configs, builds a client for each via the block,
-    # caches the resulting tool wrappers. Failures are logged and
-    # collected as warnings.
     def register_transport(servers)
       servers.each do |server|
         client = yield(server)

--- a/lib/mcp/client_manager.rb
+++ b/lib/mcp/client_manager.rb
@@ -13,10 +13,14 @@ module Mcp
   # Spawned stdio processes are reaped on worker exit via
   # {Mcp::StdioTransport.cleanup_all}.
   #
+  # The cache is built once on the first {#register_tools} call and
+  # never invalidated; edits to +mcp.toml+ require a worker restart.
+  #
   # @example
   #   Mcp::ClientManager.shared.register_tools(registry)
   class ClientManager
-    # Process-wide shared instance.
+    # Lazily-instantiated process-wide manager. Production code should
+    # call {.shared}; {.new} is reserved for tests and internal use.
     # @return [Mcp::ClientManager]
     def self.shared
       @shared ||= new
@@ -45,11 +49,11 @@ module Mcp
     def load_servers
       @wrappers = []
       @warnings = []
-      register_transport(@config.http_servers) { |server| build_http_client(server) }
-      register_transport(@config.stdio_servers) { |server| build_stdio_client(server) }
+      register_transport_tools(@config.http_servers) { |server| build_http_client(server) }
+      register_transport_tools(@config.stdio_servers) { |server| build_stdio_client(server) }
     end
 
-    def register_transport(servers)
+    def register_transport_tools(servers)
       servers.each do |server|
         client = yield(server)
         wrappers = client.tools.map { |mcp_tool|

--- a/lib/mcp/stdio_transport.rb
+++ b/lib/mcp/stdio_transport.rb
@@ -115,12 +115,9 @@ module Mcp
       @wait_thread&.alive? || false
     end
 
-    # Spawns the server in its own process group (+pgroup: true+) so its
-    # PID equals its process-group ID. This is required for clean teardown:
-    # +npm+ and +npx+ wrappers spawn child processes (e.g. +node+) that
-    # would otherwise outlive a single-PID kill. Process-group signaling
-    # in {#terminate_process} reaches the wrapper and every descendant
-    # atomically.
+    # +pgroup: true+ so {#terminate_process} can group-signal the
+    # entire descendant tree — npm/npx wrappers leak their +node+
+    # children otherwise.
     def spawn_process
       @stdin, @stdout, @wait_thread = Open3.popen2(@env, @command, *@args, pgroup: true)
       @stdin.set_encoding("UTF-8")
@@ -170,16 +167,9 @@ module Mcp
       @stdout&.close rescue IOError # rubocop:disable Style/RescueModifier
     end
 
-    # Sends SIGTERM to the entire process group and waits up to
-    # +GRACEFUL_SHUTDOWN_TIMEOUT+ seconds for the leader to exit. Falls
-    # back to SIGKILL on the group if the process does not terminate in
-    # time.
-    #
-    # The negative PID passed to {Process.kill} signals the process group.
-    # Because {#spawn_process} sets +pgroup: true+, the wrapper PID is also
-    # the group ID, so a single signal reaches +npx+, its +node+ child,
-    # and any other descendants together. Without this, +npm+/+npx+ would
-    # exit while their +node+ grandchildren orphaned to PID 1.
+    # Sends SIGTERM to the process group; escalates to SIGKILL on the
+    # group after +GRACEFUL_SHUTDOWN_TIMEOUT+ seconds. Negative PID
+    # signals the whole group (see {#spawn_process}).
     def terminate_process
       return unless @wait_thread
 

--- a/lib/mcp/stdio_transport.rb
+++ b/lib/mcp/stdio_transport.rb
@@ -115,8 +115,14 @@ module Mcp
       @wait_thread&.alive? || false
     end
 
+    # Spawns the server in its own process group (+pgroup: true+) so its
+    # PID equals its process-group ID. This is required for clean teardown:
+    # +npm+ and +npx+ wrappers spawn child processes (e.g. +node+) that
+    # would otherwise outlive a single-PID kill. Process-group signaling
+    # in {#terminate_process} reaches the wrapper and every descendant
+    # atomically.
     def spawn_process
-      @stdin, @stdout, @wait_thread = Open3.popen2(@env, @command, *@args)
+      @stdin, @stdout, @wait_thread = Open3.popen2(@env, @command, *@args, pgroup: true)
       @stdin.set_encoding("UTF-8")
       @stdout.set_encoding("UTF-8")
       self.class.register(self)
@@ -164,14 +170,22 @@ module Mcp
       @stdout&.close rescue IOError # rubocop:disable Style/RescueModifier
     end
 
-    # Sends SIGTERM and waits up to 2 seconds for the process to exit.
-    # Falls back to SIGKILL if the process does not terminate in time.
+    # Sends SIGTERM to the entire process group and waits up to
+    # +GRACEFUL_SHUTDOWN_TIMEOUT+ seconds for the leader to exit. Falls
+    # back to SIGKILL on the group if the process does not terminate in
+    # time.
+    #
+    # The negative PID passed to {Process.kill} signals the process group.
+    # Because {#spawn_process} sets +pgroup: true+, the wrapper PID is also
+    # the group ID, so a single signal reaches +npx+, its +node+ child,
+    # and any other descendants together. Without this, +npm+/+npx+ would
+    # exit while their +node+ grandchildren orphaned to PID 1.
     def terminate_process
       return unless @wait_thread
 
       pid = @wait_thread.pid
       begin
-        Process.kill("TERM", pid)
+        Process.kill("TERM", -pid)
       rescue Errno::ESRCH, Errno::EPERM
         return
       end
@@ -181,7 +195,7 @@ module Mcp
         _, status = Process.wait2(pid, Process::WNOHANG)
         break if status
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
-          Process.kill("KILL", pid) rescue Errno::ESRCH # rubocop:disable Style/RescueModifier
+          Process.kill("KILL", -pid) rescue Errno::ESRCH # rubocop:disable Style/RescueModifier
           Process.wait(pid) rescue Errno::ECHILD # rubocop:disable Style/RescueModifier
           break
         end

--- a/lib/tools/registry.rb
+++ b/lib/tools/registry.rb
@@ -50,7 +50,7 @@ module Tools
           registry.register(Tools::OpenIssue)
         end
 
-        Mcp::ClientManager.new.register_tools(registry).each do |message|
+        Mcp::ClientManager.shared.register_tools(registry).each do |message|
           Events::Bus.emit(Events::SystemMessage.new(content: message, session_id: session.id))
         end
 

--- a/spec/lib/mcp/client_manager_spec.rb
+++ b/spec/lib/mcp/client_manager_spec.rb
@@ -304,10 +304,45 @@ RSpec.describe Mcp::ClientManager do
         expect(registry_b.registered?("brave-search__search")).to be true
       end
     end
+
+    context "when a server fails on the first call" do
+      let(:working_tool) do
+        MCP::Client::Tool.new(name: "ok", description: "ok", input_schema: {})
+      end
+
+      before do
+        allow(config).to receive(:http_servers).and_return([
+          {name: "broken", url: "http://broken.test/mcp", headers: {}},
+          {name: "working", url: "http://working.test/mcp", headers: {}}
+        ])
+
+        broken_client = instance_double(MCP::Client)
+        allow(broken_client).to receive(:tools)
+          .and_raise(MCP::Client::RequestHandlerError.new("boom", {method: "tools/list"}))
+        working_client = instance_double(MCP::Client, tools: [working_tool])
+
+        allow(MCP::Client::HTTP).to receive(:new).and_return(instance_double(MCP::Client::HTTP))
+        allow(MCP::Client).to receive(:new).and_return(broken_client, working_client)
+        allow(Rails.logger).to receive(:warn)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "does not retry the broken server on subsequent calls" do
+        manager.register_tools(Tools::Registry.new)
+        manager.register_tools(Tools::Registry.new)
+        manager.register_tools(Tools::Registry.new)
+
+        expect(MCP::Client).to have_received(:new).twice
+      end
+    end
   end
 
   describe ".shared" do
-    after { described_class.instance_variable_set(:@shared, nil) }
+    around do |example|
+      example.run
+    ensure
+      described_class.instance_variable_set(:@shared, nil)
+    end
 
     it "returns the same instance across calls" do
       expect(described_class.shared).to be(described_class.shared)

--- a/spec/lib/mcp/client_manager_spec.rb
+++ b/spec/lib/mcp/client_manager_spec.rb
@@ -261,5 +261,114 @@ RSpec.describe Mcp::ClientManager do
         expect(registry.any?).to be false
       end
     end
+
+    # Regression coverage for issue #469: every Tools::Registry.build used
+    # to construct a fresh manager, which spawned a fresh stdio process per
+    # job. The shared singleton now caches connections across registry
+    # builds — so calling register_tools twice must reuse, not respawn.
+    context "when called multiple times against the same manager" do
+      let(:mcp_tool) do
+        MCP::Client::Tool.new(name: "search", description: "Search", input_schema: {})
+      end
+      let(:mcp_client) { instance_double(MCP::Client, tools: [mcp_tool]) }
+
+      before do
+        allow(config).to receive(:stdio_servers).and_return([
+          {name: "brave-search", command: "npx", args: [], env: {}}
+        ])
+        allow(Mcp::StdioTransport).to receive(:new).and_return(instance_double(Mcp::StdioTransport))
+        allow(MCP::Client).to receive(:new).and_return(mcp_client)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "spawns each transport exactly once across repeated register_tools calls" do
+        manager.register_tools(Tools::Registry.new)
+        manager.register_tools(Tools::Registry.new)
+        manager.register_tools(Tools::Registry.new)
+
+        expect(Mcp::StdioTransport).to have_received(:new).once
+        expect(MCP::Client).to have_received(:new).once
+      end
+
+      it "fetches the tool catalog from each server only once" do
+        manager.register_tools(Tools::Registry.new)
+        manager.register_tools(Tools::Registry.new)
+
+        expect(mcp_client).to have_received(:tools).once
+      end
+
+      it "still attaches cached tools to every registry it is given" do
+        registry_a = Tools::Registry.new
+        registry_b = Tools::Registry.new
+
+        manager.register_tools(registry_a)
+        manager.register_tools(registry_b)
+
+        expect(registry_a.registered?("brave-search__search")).to be true
+        expect(registry_b.registered?("brave-search__search")).to be true
+      end
+
+      it "returns load warnings only on the first call" do
+        allow(config).to receive(:warnings).and_return(["config-level warning"])
+
+        first = manager.register_tools(Tools::Registry.new)
+        second = manager.register_tools(Tools::Registry.new)
+
+        expect(first).to include("config-level warning")
+        expect(second).to eq([])
+      end
+    end
+  end
+
+  describe ".shared" do
+    after { described_class.reset! }
+
+    it "returns the same instance across calls" do
+      expect(described_class.shared).to be(described_class.shared)
+    end
+
+    it "rebuilds the instance after .reset!" do
+      original = described_class.shared
+      described_class.reset!
+
+      expect(described_class.shared).not_to be(original)
+    end
+  end
+
+  describe "#shutdown" do
+    let(:registry) { Tools::Registry.new }
+    let(:transport) { instance_double(Mcp::StdioTransport, shutdown: nil) }
+    let(:mcp_tool) do
+      MCP::Client::Tool.new(name: "search", description: "Search", input_schema: {})
+    end
+    let(:mcp_client) { instance_double(MCP::Client, tools: [mcp_tool]) }
+
+    before do
+      allow(config).to receive(:stdio_servers).and_return([
+        {name: "brave-search", command: "npx", args: [], env: {}}
+      ])
+      allow(Mcp::StdioTransport).to receive(:new).and_return(transport)
+      allow(MCP::Client).to receive(:new).and_return(mcp_client)
+      allow(Rails.logger).to receive(:info)
+    end
+
+    it "shuts down each cached transport so spawned subprocesses are reaped" do
+      manager.register_tools(registry)
+      manager.shutdown
+
+      expect(transport).to have_received(:shutdown)
+    end
+
+    it "rebuilds the cache on the next register_tools call" do
+      manager.register_tools(registry)
+      manager.shutdown
+      manager.register_tools(Tools::Registry.new)
+
+      expect(Mcp::StdioTransport).to have_received(:new).twice
+    end
+
+    it "is safe to call without prior register_tools" do
+      expect { manager.shutdown }.not_to raise_error
+    end
   end
 end

--- a/spec/lib/mcp/client_manager_spec.rb
+++ b/spec/lib/mcp/client_manager_spec.rb
@@ -262,10 +262,11 @@ RSpec.describe Mcp::ClientManager do
       end
     end
 
-    # Regression coverage for issue #469: every Tools::Registry.build used
-    # to construct a fresh manager, which spawned a fresh stdio process per
-    # job. The shared singleton now caches connections across registry
-    # builds — so calling register_tools twice must reuse, not respawn.
+    # Regression coverage for issue #469: every Tools::Registry.build
+    # used to construct a fresh manager, which spawned a fresh stdio
+    # process per job. Tool wrappers are now cached for the worker's
+    # lifetime — so repeated register_tools calls must reuse, not
+    # respawn.
     context "when called multiple times against the same manager" do
       let(:mcp_tool) do
         MCP::Client::Tool.new(name: "search", description: "Search", input_schema: {})
@@ -307,68 +308,16 @@ RSpec.describe Mcp::ClientManager do
         expect(registry_a.registered?("brave-search__search")).to be true
         expect(registry_b.registered?("brave-search__search")).to be true
       end
-
-      it "returns load warnings only on the first call" do
-        allow(config).to receive(:warnings).and_return(["config-level warning"])
-
-        first = manager.register_tools(Tools::Registry.new)
-        second = manager.register_tools(Tools::Registry.new)
-
-        expect(first).to include("config-level warning")
-        expect(second).to eq([])
-      end
     end
   end
 
   describe ".shared" do
-    after { described_class.reset! }
+    # Reset the class-level memo so this group doesn't leak a
+    # process-wide instance into other specs.
+    after { described_class.instance_variable_set(:@shared, nil) }
 
     it "returns the same instance across calls" do
       expect(described_class.shared).to be(described_class.shared)
-    end
-
-    it "rebuilds the instance after .reset!" do
-      original = described_class.shared
-      described_class.reset!
-
-      expect(described_class.shared).not_to be(original)
-    end
-  end
-
-  describe "#shutdown" do
-    let(:registry) { Tools::Registry.new }
-    let(:transport) { instance_double(Mcp::StdioTransport, shutdown: nil) }
-    let(:mcp_tool) do
-      MCP::Client::Tool.new(name: "search", description: "Search", input_schema: {})
-    end
-    let(:mcp_client) { instance_double(MCP::Client, tools: [mcp_tool]) }
-
-    before do
-      allow(config).to receive(:stdio_servers).and_return([
-        {name: "brave-search", command: "npx", args: [], env: {}}
-      ])
-      allow(Mcp::StdioTransport).to receive(:new).and_return(transport)
-      allow(MCP::Client).to receive(:new).and_return(mcp_client)
-      allow(Rails.logger).to receive(:info)
-    end
-
-    it "shuts down each cached transport so spawned subprocesses are reaped" do
-      manager.register_tools(registry)
-      manager.shutdown
-
-      expect(transport).to have_received(:shutdown)
-    end
-
-    it "rebuilds the cache on the next register_tools call" do
-      manager.register_tools(registry)
-      manager.shutdown
-      manager.register_tools(Tools::Registry.new)
-
-      expect(Mcp::StdioTransport).to have_received(:new).twice
-    end
-
-    it "is safe to call without prior register_tools" do
-      expect { manager.shutdown }.not_to raise_error
     end
   end
 end

--- a/spec/lib/mcp/client_manager_spec.rb
+++ b/spec/lib/mcp/client_manager_spec.rb
@@ -262,11 +262,6 @@ RSpec.describe Mcp::ClientManager do
       end
     end
 
-    # Regression coverage for issue #469: every Tools::Registry.build
-    # used to construct a fresh manager, which spawned a fresh stdio
-    # process per job. Tool wrappers are now cached for the worker's
-    # lifetime — so repeated register_tools calls must reuse, not
-    # respawn.
     context "when called multiple times against the same manager" do
       let(:mcp_tool) do
         MCP::Client::Tool.new(name: "search", description: "Search", input_schema: {})
@@ -312,8 +307,6 @@ RSpec.describe Mcp::ClientManager do
   end
 
   describe ".shared" do
-    # Reset the class-level memo so this group doesn't leak a
-    # process-wide instance into other specs.
     after { described_class.instance_variable_set(:@shared, nil) }
 
     it "returns the same instance across calls" do

--- a/spec/lib/mcp/stdio_transport_spec.rb
+++ b/spec/lib/mcp/stdio_transport_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "tempfile"
 
 RSpec.describe Mcp::StdioTransport do
   # Simple MCP server that echoes back JSON-RPC responses for any request.
@@ -262,6 +263,72 @@ RSpec.describe Mcp::StdioTransport do
 
       expect(t1.send(:alive?)).to be false
       expect(t2.send(:alive?)).to be false
+    end
+  end
+
+  # Regression coverage for issue #469. Wrappers like +npm+/+npx+ spawn
+  # +node+ children that orphan when only the wrapper PID is signalled.
+  # The transport now spawns the server in its own process group and
+  # signals the whole group, so descendants die with their parent.
+  describe "process group isolation" do
+    # Server that forks a long-lived grandchild before entering the
+    # request loop. Writes the grandchild's PID to +pid_path+ so the test
+    # can probe it after shutdown.
+    def grandchild_spawning_server_script(pid_path)
+      ["-e", <<~RUBY]
+        require "json"
+        $stdout.sync = true
+        grandchild_pid = Process.spawn("sleep", "600", out: File::NULL, err: File::NULL)
+        File.write(#{pid_path.inspect}, grandchild_pid.to_s)
+        $stdin.each_line do |line|
+          req = JSON.parse(line)
+          $stdout.puts(JSON.generate({"jsonrpc" => "2.0", "id" => req["id"], "result" => {}}))
+        end
+      RUBY
+    end
+
+    def process_alive?(pid)
+      Process.kill(0, pid)
+      true
+    rescue Errno::ESRCH
+      false
+    end
+
+    it "spawns the server as its own process group leader" do
+      transport = described_class.new(command: "ruby", args: echo_server_script)
+      transport.send_request(request: json_rpc_request)
+      pid = transport.instance_variable_get(:@wait_thread).pid
+
+      expect(Process.getpgid(pid)).to eq(pid)
+    ensure
+      transport&.shutdown
+    end
+
+    it "terminates grandchildren when shutting down the wrapper" do
+      pid_file = Tempfile.new(["mcp-grandchild", ".pid"])
+      pid_file.close
+      transport = described_class.new(
+        command: "ruby",
+        args: grandchild_spawning_server_script(pid_file.path)
+      )
+
+      transport.send_request(request: json_rpc_request)
+      grandchild_pid = Integer(File.read(pid_file.path).strip)
+      expect(process_alive?(grandchild_pid)).to be true
+
+      transport.shutdown
+
+      # The shutdown path includes a 2s SIGTERM grace and reaping; once
+      # it returns the leader is gone. Allow a brief moment for the
+      # kernel to finish reaping the grandchild before re-checking.
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1.0
+      until !process_alive?(grandchild_pid) || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        sleep 0.05
+      end
+
+      expect(process_alive?(grandchild_pid)).to be false
+    ensure
+      pid_file&.unlink
     end
   end
 end

--- a/spec/lib/mcp/stdio_transport_spec.rb
+++ b/spec/lib/mcp/stdio_transport_spec.rb
@@ -322,4 +322,43 @@ RSpec.describe Mcp::StdioTransport do
       pid_file&.unlink
     end
   end
+
+  describe "concurrent send_request" do
+    # Echoes the request id back after a small delay, so concurrent
+    # callers serialize through @mutex but each must still receive
+    # the response matching its own id.
+    def slow_echo_server_script
+      ["-e", <<~RUBY]
+        require "json"
+        $stdout.sync = true
+        $stdin.each_line do |line|
+          req = JSON.parse(line)
+          sleep 0.05
+          $stdout.puts(JSON.generate({"jsonrpc" => "2.0", "id" => req["id"], "result" => {"echo" => req["id"]}}))
+        end
+      RUBY
+    end
+
+    it "routes each response to the thread that sent the matching request" do
+      transport = described_class.new(command: "ruby", args: slow_echo_server_script)
+      transport.send_request(request: json_rpc_request(id: "warmup"))
+
+      threads = Array.new(5) do |i|
+        Thread.new do
+          id = "thread-#{i}"
+          response = transport.send_request(request: {jsonrpc: "2.0", id: id, method: "echo"})
+          {sent: id, received_id: response["id"], echoed: response.dig("result", "echo")}
+        end
+      end
+
+      results = threads.map(&:value)
+
+      results.each do |r|
+        expect(r[:received_id]).to eq(r[:sent])
+        expect(r[:echoed]).to eq(r[:sent])
+      end
+    ensure
+      transport&.shutdown
+    end
+  end
 end

--- a/spec/lib/mcp/stdio_transport_spec.rb
+++ b/spec/lib/mcp/stdio_transport_spec.rb
@@ -266,14 +266,7 @@ RSpec.describe Mcp::StdioTransport do
     end
   end
 
-  # Regression coverage for issue #469. Wrappers like +npm+/+npx+ spawn
-  # +node+ children that orphan when only the wrapper PID is signalled.
-  # The transport now spawns the server in its own process group and
-  # signals the whole group, so descendants die with their parent.
   describe "process group isolation" do
-    # Server that forks a long-lived grandchild before entering the
-    # request loop. Writes the grandchild's PID to +pid_path+ so the test
-    # can probe it after shutdown.
     def grandchild_spawning_server_script(pid_path)
       ["-e", <<~RUBY]
         require "json"
@@ -318,9 +311,7 @@ RSpec.describe Mcp::StdioTransport do
 
       transport.shutdown
 
-      # The shutdown path includes a 2s SIGTERM grace and reaping; once
-      # it returns the leader is gone. Allow a brief moment for the
-      # kernel to finish reaping the grandchild before re-checking.
+      # Group-signaled grandchild may take a few ms after shutdown returns.
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1.0
       until !process_alive?(grandchild_pid) || Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         sleep 0.05


### PR DESCRIPTION
Closes #469.

## Summary

Two compounding bugs caused `brave-search-mcp-server` processes to accumulate (699 procs / ~66 GB RSS after 24h, the OOM source for long-running Anima sessions):

1. **`Mcp::ClientManager` was rebuilt on every job.** `Tools::Registry.build` ran on every `DrainJob` and `ToolExecutionJob`, constructing a fresh manager that spawned a fresh `StdioTransport` per configured server. The class-level `@instances` registry tracked transports for `at_exit` cleanup but was never unregistered during normal operation — so each job leaked another `npx → node` subtree. `Mcp::ClientManager.shared` now memoizes the manager process-wide, so each configured server is connected exactly once per worker lifetime, and tool wrappers are cached after the first `tools/list`. This matches the architectural intent recorded in `thoughts/shared/notes/2026-03-14/mcp-client-integration-research.md` (decision #11: lazy-spawn, persistent, respawn on crash).

2. **No process-group isolation at spawn.** `Open3.popen2` ran without `pgroup: true`, so `npx`/`npm` wrappers shared the worker's process group. Even when `terminate_process` did fire (e.g. via `at_exit`), only the wrapper PID got the signal — its `node` grandchild orphaned to PID 1. `StdioTransport` now spawns with `pgroup: true` and signals the whole group via `Process.kill("TERM"/"KILL", -pid)`. Wrapper, `node` child, and any descendants die together.

The existing `at_exit { Mcp::StdioTransport.cleanup_all }` hook handles teardown on worker shutdown; with the bounded instance count it's now meaningful.

## Test plan

New regression coverage (all green):

- [x] `StdioTransport` spawns the server as its own process-group leader (`pgid == pid`)
- [x] Shutting down the wrapper terminates a forked grandchild (the `npx → node` analogue)
- [x] Repeated `register_tools` calls reuse cached transports — `Open3.popen2` called once across N jobs
- [x] Tool catalogs are fetched once per server, not once per job
- [x] Cached tool wrappers attach to every fresh `Tools::Registry`
- [x] `Mcp::ClientManager.shared` returns the same instance across calls

```
bundle exec rspec spec/lib/mcp/ spec/lib/tools/registry_spec.rb spec/lib/tools/mcp_tool_spec.rb
# 131 examples, 0 failures
```

`bundle exec standardrb` clean on every touched file.

## Breaking changes

None. Public surface (`Tools::Registry.build`, MCP tool dispatch, `mcp.toml` semantics) is unchanged. Sub-agents continue to share the MCP client pool — they live in the same worker process, which matches the persistent-per-worker model.