### PR TITLE
#465 feat: add tool prompt_snippet and prompt_guidelines to system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Inside the Brain, three independent LLM processes run in parallel on a shared ev
 
 ### Three Muses
 
-**Aoide — the performer.** The main LLM (Claude Opus 4.6), the muse of voice and performance. Thinks, decides, uses tools, talks to the user. Reads a system prompt assembled fresh every turn (soul + sisters block + snapshots) and a live **viewport** of events from the database — never a static array. Everything the agent outputs is Aoide; her sisters stay silent in her voice.
+**Aoide — the performer.** The main LLM (Claude Opus 4.6), the muse of voice and performance. Thinks, decides, uses tools, talks to the user. Reads a system prompt assembled fresh every turn (soul + sisters block + tool menu + tool guidelines + snapshots) and a live **viewport** of events from the database — never a static array. Everything the agent outputs is Aoide; her sisters stay silent in her voice.
 
 **Melete — the preparer.** A separate LLM process (Claude Haiku 4.5) that runs as Aoide's subconscious between turns. She observes the conversation and handles everything Aoide shouldn't break flow for: activating relevant skills, managing workflows, tracking goals, naming the session. The first microservice on Anima's event bus — the working proof that background subscribers scale. → [Preparation as a Second Brain (Melete)](#preparation-as-a-second-brain-melete)
 
@@ -294,7 +294,7 @@ The TUI is a standalone client with zero Rails dependency. Its settings cover co
 
 ### Three Layers (mirroring biology)
 
-1. **Cortex (Aoide)** — the main LLM, the muse of performance. Thinking, decisions, tool use. Reads the system prompt (soul + sisters + snapshots) and the event viewport. This layer is fully implemented.
+1. **Cortex (Aoide)** — the main LLM, the muse of performance. Thinking, decisions, tool use. Reads the system prompt (soul + sisters + tool menu + tool guidelines + snapshots) and the event viewport. This layer is fully implemented.
 
 2. **Endocrine system (Thymos)** [planned] — a lightweight background process. Reads recent events. Doesn't respond. Just updates hormone levels. Pure stimulus→response, like a biological gland. Melete is the architectural proof that background subscribers work — Thymos plugs into the same event bus.
 
@@ -318,7 +318,7 @@ Events flow through two channels:
 1. **In-process** — Rails Structured Event Reporter (local subscribers like Persister)
 2. **Over the wire** — Action Cable WebSocket (`Event::Broadcasting` callbacks push to connected TUI clients)
 
-Events fire, subscribers react, state updates. The system prompt — soul, sisters block, and snapshots — is assembled fresh for each LLM call. Skills, workflows, and goals flow through the message stream as phantom tool pairs instead, keeping the system prompt stable for prompt caching. The agent's identity (soul.md) is always current, never stale.
+Events fire, subscribers react, state updates. The system prompt — soul, sisters block, tool menu, tool guidelines, and snapshots — is assembled fresh for each LLM call. Skills, workflows, and goals flow through the message stream as phantom tool pairs instead, keeping the system prompt stable for prompt caching. The agent's identity (soul.md) is always current, never stale.
 
 ### Context as Viewport, Not Tape
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -743,17 +743,19 @@ class Session < ApplicationRecord
   #
   # @return [String, nil] available tools section, or nil when empty
   def assemble_available_tools_section
-    menu = resolved_tool_classes.filter_map { |tool| advertise_tool(tool) }
+    menu = resolved_tool_classes.filter_map do |tool|
+      snippet = tool.prompt_snippet
+      "- #{tool.tool_name}: #{snippet}" if snippet
+    end
     return if menu.empty?
 
     "## Available Tools\n\n#{menu.join("\n")}"
   end
 
   # Concatenates each available tool's {Tools::Base.prompt_guidelines}
-  # into a single behavioural-guidance section. Guidelines steer
-  # cross-tool selection (e.g. prefer edit_file over `sed`) and reinforce
-  # non-obvious behaviour the schema cannot convey at every reasoning
-  # token.
+  # into a single behavioral guidance section. Guidelines steer cross-tool
+  # selection (e.g. prefer edit_file over `sed`) and reinforce non-obvious
+  # behaviour the schema cannot convey at every reasoning token.
   #
   # @return [String, nil] tool guidelines section, or nil when empty
   def assemble_tool_guidelines_section
@@ -763,36 +765,15 @@ class Session < ApplicationRecord
     "## Tool Guidelines\n\n#{bullets.join("\n")}"
   end
 
-  # Renders a single tool's menu entry for the available tools section.
-  #
-  # @param tool [Class<Tools::Base>] tool class
-  # @return [String, nil] Markdown bullet, or nil when the tool opts out
-  def advertise_tool(tool)
-    snippet = tool.prompt_snippet
-    "- #{tool.tool_name}: #{snippet}" if snippet
-  end
-
-  # Resolves the active tool classes for this session, applying the same
-  # +granted_tools+ filter and main/sub-agent split as
-  # {Tools::Registry.build}. Used by {#tool_schemas} and the prompt
-  # section assemblers so all three views stay in sync.
+  # Memoizes the active tool classes for this session by delegating to
+  # {Tools::Registry.tool_classes_for} — the shared resolver used by
+  # {.build}, {#tool_schemas}, and the prompt section assemblers so all
+  # views stay in sync. Safe to memoize: +granted_tools+ and +sub_agent?+
+  # are immutable post-creation.
   #
   # @return [Array<Class>] tool classes (no MCP tools — those are dynamic)
   def resolved_tool_classes
-    tools = if granted_tools
-      granted = granted_tools.filter_map { |name| Tools::Registry::STANDARD_TOOLS_BY_NAME[name] }
-      (Tools::Registry::ALWAYS_GRANTED_TOOLS + granted).uniq
-    else
-      Tools::Registry::STANDARD_TOOLS.dup
-    end
-
-    if sub_agent?
-      tools.push(Tools::MarkGoalCompleted)
-    else
-      tools.push(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
-    end
-
-    tools
+    @resolved_tool_classes ||= Tools::Registry.tool_classes_for(self)
   end
 
   # Assembles the task section for sub-agent system prompts.

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -286,14 +286,21 @@ class Session < ApplicationRecord
   end
 
   # Assembles the system prompt: version preamble, soul, sisters block,
-  # and snapshots. Skills, workflows, goals, and environment awareness
-  # flow through the message stream and tool responses, keeping the
-  # system prompt stable for prompt caching.
+  # available tools menu, tool guidelines, and snapshots. Skills,
+  # workflows, goals, and environment awareness flow through the message
+  # stream and tool responses, keeping the system prompt stable for
+  # prompt caching.
   #
   # @return [String] composed system prompt
   def assemble_system_prompt
-    [assemble_version_preamble, assemble_soul_section, assemble_sisters_section, assemble_snapshots_section]
-      .compact.join("\n\n")
+    [
+      assemble_version_preamble,
+      assemble_soul_section,
+      assemble_sisters_section,
+      assemble_available_tools_section,
+      assemble_tool_guidelines_section,
+      assemble_snapshots_section
+    ].compact.join("\n\n")
   end
 
   # Serializes non-evicted goals as a lightweight summary for ActionCable
@@ -623,22 +630,7 @@ class Session < ApplicationRecord
   #
   # @return [Array<Hash>] tool schema hashes matching Anthropic tools API format
   def tool_schemas
-    tools = if granted_tools
-      granted = granted_tools.filter_map { |name| Tools::Registry::STANDARD_TOOLS_BY_NAME[name] }
-      (Tools::Registry::ALWAYS_GRANTED_TOOLS + granted).uniq
-    else
-      Tools::Registry::STANDARD_TOOLS.dup
-    end
-
-    unless sub_agent?
-      tools.push(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
-    end
-
-    if sub_agent?
-      tools.push(Tools::MarkGoalCompleted)
-    end
-
-    tools.map(&:schema)
+    resolved_tool_classes.map(&:schema)
   end
 
   # Builds the system prompt payload for debug mode transmission.
@@ -743,6 +735,64 @@ class Session < ApplicationRecord
 
       **How delivery works:** Results from sisters and sub-agents appear automatically as tool responses in your conversation — you don't fetch them. There is no tool to call, no way to poll, and no status to check. When a sub-agent finishes, its output shows up on its own. If you're waiting on multiple agents, just wait — they'll arrive. Do other work in the meantime if you can.
     SISTERS
+  end
+
+  # Renders a one-line menu of the session's available tools, populated
+  # from each tool's {Tools::Base.prompt_snippet}. Tools without a snippet
+  # are omitted; the section disappears entirely when no tool contributes.
+  #
+  # @return [String, nil] available tools section, or nil when empty
+  def assemble_available_tools_section
+    menu = resolved_tool_classes.filter_map { |tool| advertise_tool(tool) }
+    return if menu.empty?
+
+    "## Available Tools\n\n#{menu.join("\n")}"
+  end
+
+  # Concatenates each available tool's {Tools::Base.prompt_guidelines}
+  # into a single behavioural-guidance section. Guidelines steer
+  # cross-tool selection (e.g. prefer edit_file over `sed`) and reinforce
+  # non-obvious behaviour the schema cannot convey at every reasoning
+  # token.
+  #
+  # @return [String, nil] tool guidelines section, or nil when empty
+  def assemble_tool_guidelines_section
+    bullets = resolved_tool_classes.flat_map(&:prompt_guidelines).map { |line| "- #{line}" }
+    return if bullets.empty?
+
+    "## Tool Guidelines\n\n#{bullets.join("\n")}"
+  end
+
+  # Renders a single tool's menu entry for the available tools section.
+  #
+  # @param tool [Class<Tools::Base>] tool class
+  # @return [String, nil] Markdown bullet, or nil when the tool opts out
+  def advertise_tool(tool)
+    snippet = tool.prompt_snippet
+    "- #{tool.tool_name}: #{snippet}" if snippet
+  end
+
+  # Resolves the active tool classes for this session, applying the same
+  # +granted_tools+ filter and main/sub-agent split as
+  # {Tools::Registry.build}. Used by {#tool_schemas} and the prompt
+  # section assemblers so all three views stay in sync.
+  #
+  # @return [Array<Class>] tool classes (no MCP tools — those are dynamic)
+  def resolved_tool_classes
+    tools = if granted_tools
+      granted = granted_tools.filter_map { |name| Tools::Registry::STANDARD_TOOLS_BY_NAME[name] }
+      (Tools::Registry::ALWAYS_GRANTED_TOOLS + granted).uniq
+    else
+      Tools::Registry::STANDARD_TOOLS.dup
+    end
+
+    if sub_agent?
+      tools.push(Tools::MarkGoalCompleted)
+    else
+      tools.push(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
+    end
+
+    tools
   end
 
   # Assembles the task section for sub-agent system prompts.

--- a/lib/tools/base.rb
+++ b/lib/tools/base.rb
@@ -50,6 +50,22 @@ module Tools
       def truncation_threshold
         Anima::Settings.max_tool_response_chars
       end
+
+      # One-line entry rendered into the system prompt's "## Available Tools"
+      # menu. Tools that return +nil+ are omitted from the menu.
+      #
+      # @return [String, nil] short capability statement, or nil to skip
+      def prompt_snippet
+        nil
+      end
+
+      # Cross-tool behavioral guidelines merged into the system prompt's
+      # "## Tool Guidelines" section. Each entry becomes a Markdown bullet.
+      #
+      # @return [Array<String>] guideline lines, or empty array to skip
+      def prompt_guidelines
+        []
+      end
     end
 
     # Subclasses whose schema depends on runtime context (e.g. session state,

--- a/lib/tools/bash.rb
+++ b/lib/tools/bash.rb
@@ -20,6 +20,14 @@ module Tools
 
     def self.description = "Execute shell commands. Working directory and environment persist between calls."
 
+    def self.prompt_snippet = "Run shell commands."
+
+    def self.prompt_guidelines = [
+      "Working directory persists between bash calls — `cd` once or use absolute paths.",
+      "For targeted text changes, prefer edit_file over `sed`/`awk` — exact-match replacement is safer than pattern matching.",
+      "For reading files, prefer read_file over `cat`."
+    ]
+
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/edit.rb
+++ b/lib/tools/edit.rb
@@ -22,6 +22,10 @@ module Tools
 
     def self.prompt_snippet = "Replace exact text in a file."
 
+    def self.prompt_guidelines = [
+      "Reach for edit_file whenever you'd otherwise pipe a file through `sed`, `awk`, or a heredoc rewrite — exact-text replacement is faster, leaves the rest of the file untouched, and returns a diff."
+    ]
+
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/edit.rb
+++ b/lib/tools/edit.rb
@@ -20,6 +20,8 @@ module Tools
 
     def self.description = "Replace text in a file."
 
+    def self.prompt_snippet = "Replace exact text in a file."
+
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/read.rb
+++ b/lib/tools/read.rb
@@ -21,6 +21,8 @@ module Tools
 
     def self.description = "Read file. Relative paths resolve against working directory."
 
+    def self.prompt_snippet = "Read a file."
+
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/registry.rb
+++ b/lib/tools/registry.rb
@@ -40,21 +40,34 @@ module Tools
       def build(session:, shell_session:)
         registry = new(context: {shell_session: shell_session, session: session})
 
-        granted_standard_tools(session).each { |tool| registry.register(tool) }
-
-        if session.sub_agent?
-          registry.register(Tools::MarkGoalCompleted)
-        else
-          registry.register(Tools::SpawnSubagent)
-          registry.register(Tools::SpawnSpecialist)
-          registry.register(Tools::OpenIssue)
-        end
+        tool_classes_for(session).each { |tool| registry.register(tool) }
 
         Mcp::ClientManager.new.register_tools(registry).each do |message|
           Events::Bus.emit(Events::SystemMessage.new(content: message, session_id: session.id))
         end
 
         registry
+      end
+
+      # Resolves the ordered tool-class list for a session: granted standard
+      # tools (or all of them when +granted_tools+ is nil), plus spawn tools
+      # for main sessions or +mark_goal_completed+ for sub-agents. MCP tools
+      # are excluded — they are dynamic and registered separately by
+      # {.build}. Single source of truth for {.build}, {Session#tool_schemas},
+      # and the system-prompt section assemblers.
+      #
+      # @param session [Session]
+      # @return [Array<Class<Tools::Base>>]
+      def tool_classes_for(session)
+        tools = granted_standard_tools(session).dup
+
+        if session.sub_agent?
+          tools.push(Tools::MarkGoalCompleted)
+        else
+          tools.push(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
+        end
+
+        tools
       end
 
       private

--- a/lib/tools/write.rb
+++ b/lib/tools/write.rb
@@ -19,6 +19,12 @@ module Tools
 
     def self.description = "Write file."
 
+    def self.prompt_snippet = "Create or overwrite a whole file."
+
+    def self.prompt_guidelines = [
+      "write_file replaces the whole file. For targeted changes, use edit_file."
+    ]
+
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/write.rb
+++ b/lib/tools/write.rb
@@ -22,7 +22,7 @@ module Tools
     def self.prompt_snippet = "Create or overwrite a whole file."
 
     def self.prompt_guidelines = [
-      "write_file replaces the whole file. For targeted changes, use edit_file."
+      "Use write_file only for new files or full rewrites — for targeted changes, edit_file leaves the rest of the file untouched."
     ]
 
     def self.input_schema

--- a/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
+++ b/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
@@ -56,7 +56,14 @@ http_interactions:
         don''t fetch them. There is no tool to call, no way to poll, and no status
         to check. When a sub-agent finishes, its output shows up on its own. If you''re
         waiting on multiple agents, just wait — they''ll arrive. Do other work in
-        the meantime if you can.","cache_control":{"type":"ephemeral"}}]}'
+        the meantime if you can.\n\n## Available Tools\n\n- bash: Run shell commands.\n-
+        read_file: Read a file.\n- write_file: Create or overwrite a whole file.\n-
+        edit_file: Replace exact text in a file.\n\n## Tool Guidelines\n\n- Working
+        directory persists between bash calls — `cd` once or use absolute paths.\n-
+        For targeted text changes, prefer edit_file over `sed`/`awk` — exact-match
+        replacement is safer than pattern matching.\n- For reading files, prefer read_file
+        over `cat`.\n- write_file replaces the whole file. For targeted changes, use
+        edit_file.","cache_control":{"type":"ephemeral"}}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"

--- a/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
+++ b/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
@@ -62,8 +62,11 @@ http_interactions:
         directory persists between bash calls — `cd` once or use absolute paths.\n-
         For targeted text changes, prefer edit_file over `sed`/`awk` — exact-match
         replacement is safer than pattern matching.\n- For reading files, prefer read_file
-        over `cat`.\n- write_file replaces the whole file. For targeted changes, use
-        edit_file.","cache_control":{"type":"ephemeral"}}]}'
+        over `cat`.\n- Use write_file only for new files or full rewrites — for targeted
+        changes, edit_file leaves the rest of the file untouched.\n- Reach for edit_file
+        whenever you''d otherwise pipe a file through `sed`, `awk`, or a heredoc rewrite
+        — exact-text replacement is faster, leaves the rest of the file untouched,
+        and returns a diff.","cache_control":{"type":"ephemeral"}}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"

--- a/spec/lib/tools/base_spec.rb
+++ b/spec/lib/tools/base_spec.rb
@@ -68,4 +68,40 @@ RSpec.describe Tools::Base do
       expect { described_class.new.execute({}) }.to raise_error(NotImplementedError)
     end
   end
+
+  describe ".prompt_snippet" do
+    it "defaults to nil so tools opt in to the available-tools menu" do
+      expect(described_class.prompt_snippet).to be_nil
+    end
+
+    context "when overridden by a subclass" do
+      let(:custom_tool) do
+        Class.new(described_class) do
+          def self.prompt_snippet = "Do the thing."
+        end
+      end
+
+      it "uses the subclass value" do
+        expect(custom_tool.prompt_snippet).to eq("Do the thing.")
+      end
+    end
+  end
+
+  describe ".prompt_guidelines" do
+    it "defaults to an empty array so tools contribute nothing by default" do
+      expect(described_class.prompt_guidelines).to eq([])
+    end
+
+    context "when overridden by a subclass" do
+      let(:custom_tool) do
+        Class.new(described_class) do
+          def self.prompt_guidelines = ["Prefer X over Y."]
+        end
+      end
+
+      it "uses the subclass value" do
+        expect(custom_tool.prompt_guidelines).to eq(["Prefer X over Y."])
+      end
+    end
+  end
 end

--- a/spec/lib/tools/bash_spec.rb
+++ b/spec/lib/tools/bash_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Tools::Bash do
     end
   end
 
+  describe ".prompt_snippet" do
+    it "advertises bash to the agent in the system prompt menu" do
+      expect(described_class.prompt_snippet).to eq("Run shell commands.")
+    end
+  end
+
+  describe ".prompt_guidelines" do
+    it "steers the agent toward edit_file/read_file and away from cd repetition" do
+      guidelines = described_class.prompt_guidelines
+
+      expect(guidelines).to include(a_string_matching(/Working directory persists/))
+      expect(guidelines).to include(a_string_matching(/prefer edit_file over `sed`/))
+      expect(guidelines).to include(a_string_matching(/prefer read_file over `cat`/))
+    end
+  end
+
   describe "#execute" do
     context "with single command" do
       it "returns the rendered output" do

--- a/spec/lib/tools/edit_spec.rb
+++ b/spec/lib/tools/edit_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Tools::Edit do
     end
   end
 
+  describe ".prompt_snippet" do
+    it "advertises edit_file in the system prompt menu" do
+      expect(described_class.prompt_snippet).to eq("Replace exact text in a file.")
+    end
+  end
+
+  describe ".prompt_guidelines" do
+    it "contributes no guidelines — the input schema already documents old_text uniqueness" do
+      expect(described_class.prompt_guidelines).to eq([])
+    end
+  end
+
   describe ".input_schema" do
     it "defines path, old_text, and new_text as required string properties" do
       schema = described_class.input_schema

--- a/spec/lib/tools/edit_spec.rb
+++ b/spec/lib/tools/edit_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Tools::Edit do
   end
 
   describe ".prompt_guidelines" do
-    it "contributes no guidelines — the input schema already documents old_text uniqueness" do
-      expect(described_class.prompt_guidelines).to eq([])
+    it "owns the case for choosing edit_file over sed/awk/heredoc rewrites" do
+      expect(described_class.prompt_guidelines).to include(a_string_matching(/edit_file whenever you'd otherwise pipe.*`sed`/))
     end
   end
 

--- a/spec/lib/tools/read_spec.rb
+++ b/spec/lib/tools/read_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Tools::Read do
     end
   end
 
+  describe ".prompt_snippet" do
+    it "advertises read_file in the system prompt menu" do
+      expect(described_class.prompt_snippet).to eq("Read a file.")
+    end
+  end
+
+  describe ".prompt_guidelines" do
+    it "contributes no guidelines — the bash steering already names read_file" do
+      expect(described_class.prompt_guidelines).to eq([])
+    end
+  end
+
   describe ".input_schema" do
     it "defines path as a required string property" do
       schema = described_class.input_schema

--- a/spec/lib/tools/registry_spec.rb
+++ b/spec/lib/tools/registry_spec.rb
@@ -256,4 +256,45 @@ RSpec.describe Tools::Registry do
       expect(registry.any?).to be true
     end
   end
+
+  describe ".tool_classes_for" do
+    it "returns all standard tools plus spawn tools for a main session" do
+      session = Session.create!
+
+      classes = described_class.tool_classes_for(session)
+
+      expect(classes).to include(Tools::Bash, Tools::Read, Tools::Write, Tools::Edit, Tools::Think)
+      expect(classes).to include(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
+      expect(classes).not_to include(Tools::MarkGoalCompleted)
+    end
+
+    it "swaps spawn tools for mark_goal_completed on a sub-agent session" do
+      parent = Session.create!
+      child = Session.create!(parent_session: parent, prompt: "sub-agent")
+
+      classes = described_class.tool_classes_for(child)
+
+      expect(classes).to include(Tools::MarkGoalCompleted)
+      expect(classes).not_to include(Tools::SpawnSubagent, Tools::SpawnSpecialist, Tools::OpenIssue)
+    end
+
+    it "filters standard tools through granted_tools while always keeping ALWAYS_GRANTED_TOOLS" do
+      session = Session.create!(granted_tools: %w[bash])
+
+      classes = described_class.tool_classes_for(session)
+
+      expect(classes).to include(Tools::Bash, Tools::Think)
+      expect(classes).not_to include(Tools::Read, Tools::Write, Tools::Edit)
+    end
+
+    it "returns a fresh array each call so callers can safely mutate" do
+      session = Session.create!
+
+      first = described_class.tool_classes_for(session)
+      second = described_class.tool_classes_for(session)
+
+      expect(first).to eq(second)
+      expect(first).not_to equal(second)
+    end
+  end
 end

--- a/spec/lib/tools/write_spec.rb
+++ b/spec/lib/tools/write_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Tools::Write do
     end
   end
 
+  describe ".prompt_snippet" do
+    it "advertises write_file in the system prompt menu" do
+      expect(described_class.prompt_snippet).to eq("Create or overwrite a whole file.")
+    end
+  end
+
+  describe ".prompt_guidelines" do
+    it "steers the agent toward edit_file for targeted changes" do
+      expect(described_class.prompt_guidelines).to include(a_string_matching(/replaces the whole file.*use edit_file/))
+    end
+  end
+
   describe ".input_schema" do
     it "defines path and content as required string properties" do
       schema = described_class.input_schema

--- a/spec/lib/tools/write_spec.rb
+++ b/spec/lib/tools/write_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Tools::Write do
 
   describe ".prompt_guidelines" do
     it "steers the agent toward edit_file for targeted changes" do
-      expect(described_class.prompt_guidelines).to include(a_string_matching(/replaces the whole file.*use edit_file/))
+      expect(described_class.prompt_guidelines).to include(a_string_matching(/full rewrites.*edit_file leaves the rest/))
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -995,6 +995,34 @@ RSpec.describe Session do
       expect(session.assemble_system_prompt).not_to include("WHAT/WHY/HOW")
     end
 
+    it "includes the available tools menu and tool guidelines after the sisters block" do
+      prompt = session.assemble_system_prompt
+      sisters_idx = prompt.index("## Your Sisters")
+      tools_idx = prompt.index("## Available Tools")
+      guidelines_idx = prompt.index("## Tool Guidelines")
+
+      expect(tools_idx).to be > sisters_idx
+      expect(guidelines_idx).to be > tools_idx
+    end
+
+    it "lists each opted-in built-in tool by name in the available tools menu" do
+      prompt = session.assemble_system_prompt
+
+      expect(prompt).to include("- bash: Run shell commands.")
+      expect(prompt).to include("- read_file: Read a file.")
+      expect(prompt).to include("- write_file: Create or overwrite a whole file.")
+      expect(prompt).to include("- edit_file: Replace exact text in a file.")
+    end
+
+    it "concatenates per-tool prompt_guidelines into the tool guidelines section" do
+      prompt = session.assemble_system_prompt
+
+      expect(prompt).to match(/## Tool Guidelines\n\n- /)
+      expect(prompt).to include("Working directory persists between bash calls")
+      expect(prompt).to include("prefer edit_file over `sed`")
+      expect(prompt).to include("write_file replaces the whole file")
+    end
+
     context "with multiple skills" do
       let(:tmp_dir) { Dir.mktmpdir }
 
@@ -1033,6 +1061,71 @@ RSpec.describe Session do
 
       expect { session.send(:assemble_soul_section) }
         .to raise_error(Session::MissingSoulError, /Run `anima install`/)
+    end
+  end
+
+  describe "#assemble_available_tools_section" do
+    it "renders one Markdown bullet per tool that exposes a prompt_snippet" do
+      session = Session.create!
+
+      section = session.send(:assemble_available_tools_section)
+
+      expect(section).to start_with("## Available Tools\n\n")
+      expect(section).to include("- bash: Run shell commands.")
+      expect(section).to include("- edit_file: Replace exact text in a file.")
+    end
+
+    it "omits tools without a prompt_snippet (e.g. think, view_messages)" do
+      session = Session.create!
+
+      section = session.send(:assemble_available_tools_section)
+
+      expect(section).not_to include("- think:")
+      expect(section).not_to include("- view_messages:")
+    end
+
+    it "respects granted_tools so the menu mirrors the registered toolset" do
+      session = Session.create!(granted_tools: %w[bash read_file])
+
+      section = session.send(:assemble_available_tools_section)
+
+      expect(section).to include("- bash: Run shell commands.")
+      expect(section).to include("- read_file: Read a file.")
+      expect(section).not_to include("- edit_file:")
+      expect(section).not_to include("- write_file:")
+    end
+
+    it "returns nil when no tool exposes a prompt_snippet" do
+      session = Session.create!
+      stub_const("Tools::Registry::STANDARD_TOOLS", [])
+      stub_const("Tools::Registry::ALWAYS_GRANTED_TOOLS", [])
+      allow(session).to receive(:sub_agent?).and_return(true)
+      allow(Tools::MarkGoalCompleted).to receive(:prompt_snippet).and_return(nil)
+
+      expect(session.send(:assemble_available_tools_section)).to be_nil
+    end
+  end
+
+  describe "#assemble_tool_guidelines_section" do
+    it "joins each tool's prompt_guidelines into a single bullet list" do
+      session = Session.create!
+
+      section = session.send(:assemble_tool_guidelines_section)
+
+      expect(section).to start_with("## Tool Guidelines\n\n")
+      expect(section).to include("- Working directory persists between bash calls")
+      expect(section).to include("- For targeted text changes, prefer edit_file over `sed`")
+      expect(section).to include("- write_file replaces the whole file")
+    end
+
+    it "returns nil when no tool contributes guidelines" do
+      session = Session.create!
+      stub_const("Tools::Registry::STANDARD_TOOLS", [])
+      stub_const("Tools::Registry::ALWAYS_GRANTED_TOOLS", [])
+      allow(session).to receive(:sub_agent?).and_return(true)
+      allow(Tools::MarkGoalCompleted).to receive(:prompt_guidelines).and_return([])
+
+      expect(session.send(:assemble_tool_guidelines_section)).to be_nil
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1020,7 +1020,8 @@ RSpec.describe Session do
       expect(prompt).to match(/## Tool Guidelines\n\n- /)
       expect(prompt).to include("Working directory persists between bash calls")
       expect(prompt).to include("prefer edit_file over `sed`")
-      expect(prompt).to include("write_file replaces the whole file")
+      expect(prompt).to include("Reach for edit_file whenever you'd otherwise pipe")
+      expect(prompt).to include("Use write_file only for new files or full rewrites")
     end
 
     context "with multiple skills" do
@@ -1115,7 +1116,8 @@ RSpec.describe Session do
       expect(section).to start_with("## Tool Guidelines\n\n")
       expect(section).to include("- Working directory persists between bash calls")
       expect(section).to include("- For targeted text changes, prefer edit_file over `sed`")
-      expect(section).to include("- write_file replaces the whole file")
+      expect(section).to include("- Reach for edit_file whenever you'd otherwise pipe")
+      expect(section).to include("- Use write_file only for new files or full rewrites")
     end
 
     it "returns nil when no tool contributes guidelines" do


### PR DESCRIPTION
## Summary

- Adds two optional class methods on `Tools::Base` — `prompt_snippet` (one-line menu entry) and `prompt_guidelines` (behavioural bullets) — defaulting to `nil` / `[]` so existing tools are unaffected.
- Built-in file/shell tools opt in: `bash` (snippet + 3 guidelines), `read_file` (snippet), `write_file` (snippet + 1 guideline), `edit_file` (snippet). Other tools fall through to the defaults and are omitted from the rendered sections.
- Assembles two new system prompt sections — `## Available Tools` and `## Tool Guidelines` — between the sisters block and snapshots in `Session#assemble_system_prompt`. Both sections are static per session, so they fit the prompt-caching trajectory.
- Refactors `Session#tool_schemas` to share its tool-class resolution with the new section assemblers via a private `resolved_tool_classes` helper — single source of truth for "what tools is this session running."

## Why

Tracked in #465. Observed behavior: the agent avoids `edit_file` (using `bash` + `sed` instead) and re-`cd`s every command despite the bash tool description saying the session is persistent. Root cause: tool descriptions are too sparse and the bare API schema can't outweigh the model's training priors. Borrowing pi-mono's three-layer approach (schema description → `prompt_snippet` → `prompt_guidelines`) gives the system prompt enough reinforcement to flip those priors without changing tool behavior. Prompt text was reviewed against the project's prompting bible (no restating the schema; consequences over bare constraints; intent over mechanics).

## Test plan

- [x] `bundle exec rspec spec/lib/tools spec/models/session_spec.rb` — covers the new base-class defaults, per-tool overrides, and section assembly (with empty-case + `granted_tools` filter).
- [x] `bundle exec rspec spec/lib/providers/anthropic_spec.rb` — manually patched the non-rerecordable 529 cassette to match the new request body.
- [x] `bundle exec standardrb` clean.
- [x] `bundle exec reek` no actionable new warnings (one stylistic FeatureEnvy on a builder, same pattern reek tolerates elsewhere in the file).

## Note for review

The `session_happy_path_smoke_spec` cassette uses `match_requests_on: [:method, :uri]`, so the system prompt change did not break it — but that also means the test never asserted on the prompt body in the first place. The system prompt could be replaced with arbitrary content and it would still go green. Worth a follow-up to either tighten the matcher to include `:body` or assert on the captured request body separately. Not in this PR's scope.

## Out of scope

- Specialist tools, MCP tools, and the other standard tools (`think`, `web_get`, `view_messages`, `search_messages`, spawn tools) — they keep the default `nil` snippet / `[]` guidelines and naturally drop out of the rendered sections. Easy to opt them in later.

Closes #465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)