### PR TITLE
#465 chore: strip out-of-scope tool guideline content

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Inside the Brain, three independent LLM processes run in parallel on a shared ev
 
 ### Three Muses
 
-**Aoide — the performer.** The main LLM (Claude Opus 4.6), the muse of voice and performance. Thinks, decides, uses tools, talks to the user. Reads a system prompt assembled fresh every turn (soul + sisters block + tool menu + tool guidelines + snapshots) and a live **viewport** of events from the database — never a static array. Everything the agent outputs is Aoide; her sisters stay silent in her voice.
+**Aoide — the performer.** The main LLM (Claude Opus 4.6), the muse of voice and performance. Thinks, decides, uses tools, talks to the user. Reads a system prompt assembled fresh every turn (soul + sisters block + tool menu + snapshots) and a live **viewport** of events from the database — never a static array. Everything the agent outputs is Aoide; her sisters stay silent in her voice.
 
 **Melete — the preparer.** A separate LLM process (Claude Haiku 4.5) that runs as Aoide's subconscious between turns. She observes the conversation and handles everything Aoide shouldn't break flow for: activating relevant skills, managing workflows, tracking goals, naming the session. The first microservice on Anima's event bus — the working proof that background subscribers scale. → [Preparation as a Second Brain (Melete)](#preparation-as-a-second-brain-melete)
 
@@ -294,7 +294,7 @@ The TUI is a standalone client with zero Rails dependency. Its settings cover co
 
 ### Three Layers (mirroring biology)
 
-1. **Cortex (Aoide)** — the main LLM, the muse of performance. Thinking, decisions, tool use. Reads the system prompt (soul + sisters + tool menu + tool guidelines + snapshots) and the event viewport. This layer is fully implemented.
+1. **Cortex (Aoide)** — the main LLM, the muse of performance. Thinking, decisions, tool use. Reads the system prompt (soul + sisters + tool menu + snapshots) and the event viewport. This layer is fully implemented.
 
 2. **Endocrine system (Thymos)** [planned] — a lightweight background process. Reads recent events. Doesn't respond. Just updates hormone levels. Pure stimulus→response, like a biological gland. Melete is the architectural proof that background subscribers work — Thymos plugs into the same event bus.
 
@@ -318,7 +318,7 @@ Events flow through two channels:
 1. **In-process** — Rails Structured Event Reporter (local subscribers like Persister)
 2. **Over the wire** — Action Cable WebSocket (`Event::Broadcasting` callbacks push to connected TUI clients)
 
-Events fire, subscribers react, state updates. The system prompt — soul, sisters block, tool menu, tool guidelines, and snapshots — is assembled fresh for each LLM call. Skills, workflows, and goals flow through the message stream as phantom tool pairs instead, keeping the system prompt stable for prompt caching. The agent's identity (soul.md) is always current, never stale.
+Events fire, subscribers react, state updates. The system prompt — soul, sisters block, tool menu, and snapshots — is assembled fresh for each LLM call. Skills, workflows, and goals flow through the message stream as phantom tool pairs instead, keeping the system prompt stable for prompt caching. The agent's identity (soul.md) is always current, never stale.
 
 ### Context as Viewport, Not Tape
 

--- a/lib/tools/bash.rb
+++ b/lib/tools/bash.rb
@@ -22,12 +22,6 @@ module Tools
 
     def self.prompt_snippet = "Run shell commands."
 
-    def self.prompt_guidelines = [
-      "Working directory persists between bash calls — `cd` once or use absolute paths.",
-      "For targeted text changes, prefer edit_file over `sed`/`awk` — exact-match replacement is safer than pattern matching.",
-      "For reading files, prefer read_file over `cat`."
-    ]
-
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/edit.rb
+++ b/lib/tools/edit.rb
@@ -22,10 +22,6 @@ module Tools
 
     def self.prompt_snippet = "Replace exact text in a file."
 
-    def self.prompt_guidelines = [
-      "Reach for edit_file whenever you'd otherwise pipe a file through `sed`, `awk`, or a heredoc rewrite — exact-text replacement is faster, leaves the rest of the file untouched, and returns a diff."
-    ]
-
     def self.input_schema
       {
         type: "object",

--- a/lib/tools/write.rb
+++ b/lib/tools/write.rb
@@ -21,10 +21,6 @@ module Tools
 
     def self.prompt_snippet = "Create or overwrite a whole file."
 
-    def self.prompt_guidelines = [
-      "Use write_file only for new files or full rewrites — for targeted changes, edit_file leaves the rest of the file untouched."
-    ]
-
     def self.input_schema
       {
         type: "object",

--- a/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
+++ b/spec/cassettes/Providers_Anthropic/_create_message/raises_ServerError_on_529_overload.yml
@@ -58,15 +58,7 @@ http_interactions:
         waiting on multiple agents, just wait — they''ll arrive. Do other work in
         the meantime if you can.\n\n## Available Tools\n\n- bash: Run shell commands.\n-
         read_file: Read a file.\n- write_file: Create or overwrite a whole file.\n-
-        edit_file: Replace exact text in a file.\n\n## Tool Guidelines\n\n- Working
-        directory persists between bash calls — `cd` once or use absolute paths.\n-
-        For targeted text changes, prefer edit_file over `sed`/`awk` — exact-match
-        replacement is safer than pattern matching.\n- For reading files, prefer read_file
-        over `cat`.\n- Use write_file only for new files or full rewrites — for targeted
-        changes, edit_file leaves the rest of the file untouched.\n- Reach for edit_file
-        whenever you''d otherwise pipe a file through `sed`, `awk`, or a heredoc rewrite
-        — exact-text replacement is faster, leaves the rest of the file untouched,
-        and returns a diff.","cache_control":{"type":"ephemeral"}}]}'
+        edit_file: Replace exact text in a file.","cache_control":{"type":"ephemeral"}}]}'
     headers:
       Authorization:
       - "<AUTHORIZATION>"

--- a/spec/lib/tools/bash_spec.rb
+++ b/spec/lib/tools/bash_spec.rb
@@ -29,12 +29,8 @@ RSpec.describe Tools::Bash do
   end
 
   describe ".prompt_guidelines" do
-    it "steers the agent toward edit_file/read_file and away from cd repetition" do
-      guidelines = described_class.prompt_guidelines
-
-      expect(guidelines).to include(a_string_matching(/Working directory persists/))
-      expect(guidelines).to include(a_string_matching(/prefer edit_file over `sed`/))
-      expect(guidelines).to include(a_string_matching(/prefer read_file over `cat`/))
+    it "contributes nothing — guideline text is deferred to a follow-up ticket" do
+      expect(described_class.prompt_guidelines).to eq([])
     end
   end
 

--- a/spec/lib/tools/edit_spec.rb
+++ b/spec/lib/tools/edit_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe Tools::Edit do
   end
 
   describe ".prompt_guidelines" do
-    it "owns the case for choosing edit_file over sed/awk/heredoc rewrites" do
-      expect(described_class.prompt_guidelines).to include(a_string_matching(/edit_file whenever you'd otherwise pipe.*`sed`/))
+    it "contributes nothing — guideline text is deferred to a follow-up ticket" do
+      expect(described_class.prompt_guidelines).to eq([])
     end
   end
 

--- a/spec/lib/tools/write_spec.rb
+++ b/spec/lib/tools/write_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Tools::Write do
   end
 
   describe ".prompt_guidelines" do
-    it "steers the agent toward edit_file for targeted changes" do
-      expect(described_class.prompt_guidelines).to include(a_string_matching(/full rewrites.*edit_file leaves the rest/))
+    it "contributes nothing — guideline text is deferred to a follow-up ticket" do
+      expect(described_class.prompt_guidelines).to eq([])
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -995,14 +995,12 @@ RSpec.describe Session do
       expect(session.assemble_system_prompt).not_to include("WHAT/WHY/HOW")
     end
 
-    it "includes the available tools menu and tool guidelines after the sisters block" do
+    it "places the available tools menu after the sisters block" do
       prompt = session.assemble_system_prompt
       sisters_idx = prompt.index("## Your Sisters")
       tools_idx = prompt.index("## Available Tools")
-      guidelines_idx = prompt.index("## Tool Guidelines")
 
       expect(tools_idx).to be > sisters_idx
-      expect(guidelines_idx).to be > tools_idx
     end
 
     it "lists each opted-in built-in tool by name in the available tools menu" do
@@ -1014,14 +1012,8 @@ RSpec.describe Session do
       expect(prompt).to include("- edit_file: Replace exact text in a file.")
     end
 
-    it "concatenates per-tool prompt_guidelines into the tool guidelines section" do
-      prompt = session.assemble_system_prompt
-
-      expect(prompt).to match(/## Tool Guidelines\n\n- /)
-      expect(prompt).to include("Working directory persists between bash calls")
-      expect(prompt).to include("prefer edit_file over `sed`")
-      expect(prompt).to include("Reach for edit_file whenever you'd otherwise pipe")
-      expect(prompt).to include("Use write_file only for new files or full rewrites")
+    it "omits the tool guidelines section while no tool contributes guideline text" do
+      expect(session.assemble_system_prompt).not_to include("## Tool Guidelines")
     end
 
     context "with multiple skills" do
@@ -1108,26 +1100,22 @@ RSpec.describe Session do
   end
 
   describe "#assemble_tool_guidelines_section" do
-    it "joins each tool's prompt_guidelines into a single bullet list" do
+    it "returns nil while no tool contributes guideline text" do
       session = Session.create!
+
+      expect(session.send(:assemble_tool_guidelines_section)).to be_nil
+    end
+
+    it "joins each opted-in tool's prompt_guidelines into a bullet list when tools provide them" do
+      session = Session.create!
+      allow(Tools::Bash).to receive(:prompt_guidelines).and_return(["First bullet."])
+      allow(Tools::Edit).to receive(:prompt_guidelines).and_return(["Second bullet."])
 
       section = session.send(:assemble_tool_guidelines_section)
 
       expect(section).to start_with("## Tool Guidelines\n\n")
-      expect(section).to include("- Working directory persists between bash calls")
-      expect(section).to include("- For targeted text changes, prefer edit_file over `sed`")
-      expect(section).to include("- Reach for edit_file whenever you'd otherwise pipe")
-      expect(section).to include("- Use write_file only for new files or full rewrites")
-    end
-
-    it "returns nil when no tool contributes guidelines" do
-      session = Session.create!
-      stub_const("Tools::Registry::STANDARD_TOOLS", [])
-      stub_const("Tools::Registry::ALWAYS_GRANTED_TOOLS", [])
-      allow(session).to receive(:sub_agent?).and_return(true)
-      allow(Tools::MarkGoalCompleted).to receive(:prompt_guidelines).and_return([])
-
-      expect(session.send(:assemble_tool_guidelines_section)).to be_nil
+      expect(section).to include("- First bullet.")
+      expect(section).to include("- Second bullet.")
     end
   end
 


### PR DESCRIPTION
## Summary

Issue #465 explicitly listed "writing guidelines for the tools" as out of scope — those were to be added later in a follow-up. The implementation that merged in #472 populated `bash`, `edit_file`, and `write_file` with concrete guideline strings anyway. This PR removes them.

## What changes

- `Tools::Bash.prompt_guidelines` removed (was 3 bullets).
- `Tools::Edit.prompt_guidelines` removed (was 1 bullet, added during the self-review pass).
- `Tools::Write.prompt_guidelines` removed (was 1 bullet).
- Each tool now inherits the empty `[]` default from `Tools::Base`.
- Specs updated to assert the empty default per tool.
- `Session#assemble_tool_guidelines_section` still works — when nothing is opted in it returns `nil` and the section is omitted from the system prompt. A spec exercises the populated case via stubs so the assembler isn't left untested.
- README updated: "tool guidelines" no longer listed as a system prompt section since it currently doesn't render.
- 529 cassette repatched (menu only, no guidelines).

## What stays

- `Tools::Base.prompt_snippet` / `Tools::Base.prompt_guidelines` interface — unchanged.
- The `## Available Tools` menu — unchanged; snippets are in scope per the ticket.
- `Session#assemble_available_tools_section` and `Session#assemble_tool_guidelines_section` — unchanged.

## Test plan

- [x] `bundle exec rspec spec/lib/tools spec/models/session_spec.rb spec/lib/providers/anthropic_spec.rb` — 605 green.
- [x] `bundle exec rspec spec/integration/session_happy_path_smoke_spec.rb` — green.
- [x] `bundle exec standardrb` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)