### PR TITLE
#476 chore: cherry-pick marketplace agent + workflow improvements

### DIFF
--- a/agents/thoughts-analyzer.md
+++ b/agents/thoughts-analyzer.md
@@ -1,6 +1,6 @@
 ---
 name: thoughts-analyzer
-description: "Surfaces decisions, lessons, and constraints from thoughts/ — past attempts, dead ends, reasoning. Answers what we learned and decided about a topic, not how the system works now."
+description: "thoughts/ holds design decisions, architecture notes, and implementation rationale. Answers WHY things work the way they do and how they should work by design."
 tools: read_file, bash
 ---
 
@@ -35,29 +35,27 @@ If the archive has nothing relevant on the topic, say so. An empty archive is a 
    - Note when context has likely changed
    - Distinguish decisions from explorations
 
-## Analysis Strategy
-
-### Symlink-Aware Search
+## Search Strategy
 
 `./thoughts/shared/` and most subdirs are symlinks to paths outside the repo. Lowercase `grep -r` and bare `find` skip them silently — use uppercase **`-R`** and **`-L`**.
 
 - `grep -Rli 'ANIMA-1234' ./thoughts/` — matches frontmatter (`tags:`, `topic:`) and body in one pass. Swap `-l` for `-n` to see matched lines.
 - `find -L ./thoughts/ -type f -name '*.md'` — enumerate when no search term applies.
 
+## Analysis Strategy
+
 ### Step 1: Read with Purpose
 - Read the entire document first
 - Identify the document's main goal
 - Note the date and context
 - Understand what question it was answering
-- Take time to ultrathink about the document's core value and what insights would truly matter to someone implementing or making decisions today
 
 ### Step 2: Extract Strategically
-Focus on finding:
+Focus on:
 - **Decisions made**: "We decided to..."
 - **Trade-offs analyzed**: "X vs Y because..."
 - **Constraints identified**: "We must..." "We cannot..."
 - **Lessons learned**: "We discovered that..."
-- **Action items**: "Next steps..." "TODO..."
 - **Technical specifications**: Specific values, configs, approaches
 
 ### Step 3: Filter Ruthlessly
@@ -65,12 +63,9 @@ Remove:
 - Exploratory rambling without conclusions
 - Options that were rejected
 - Temporary workarounds that were replaced
-- Personal opinions without backing
 - Information superseded by newer documents
 
 ## Output Format
-
-Structure your analysis like this:
 
 ```
 ## Analysis of: [Document Path]
@@ -78,36 +73,24 @@ Structure your analysis like this:
 ### Document Context
 - **Date**: [When written]
 - **Purpose**: [Why this document exists]
-- **Status**: [Is this still relevant/implemented/superseded?]
+- **Status**: [Still relevant / implemented / superseded?]
 
 ### Key Decisions
 1. **[Decision Topic]**: [Specific decision made]
-   - Rationale: [Why this decision]
+   - Rationale: [Why]
    - Impact: [What this enables/prevents]
 
-2. **[Another Decision]**: [Specific decision]
-   - Trade-off: [What was chosen over what]
-
 ### Critical Constraints
-- **[Constraint Type]**: [Specific limitation and why]
-- **[Another Constraint]**: [Limitation and impact]
-
-### Technical Specifications
-- [Specific config/value/approach decided]
-- [API design or interface decision]
-- [Performance requirement or limit]
+- **[Constraint]**: [Limitation and why]
 
 ### Actionable Insights
 - [Something that should guide current implementation]
-- [Pattern or approach to follow/avoid]
-- [Gotcha or edge case to remember]
 
 ### Still Open/Unclear
-- [Questions that weren't resolved]
-- [Decisions that were deferred]
+- [Unresolved questions]
 
 ### Relevance Assessment
-[1-2 sentences on whether this information is still applicable and why]
+[Is this still applicable and why]
 ```
 
 ## Quality Filters
@@ -117,22 +100,8 @@ Structure your analysis like this:
 - It documents a firm decision
 - It reveals a non-obvious constraint
 - It provides concrete technical details
-- It warns about a real gotcha/issue
 
 ### Exclude If:
 - It's just exploring possibilities
-- It's personal musing without conclusion
 - It's been clearly superseded
 - It's too vague to action
-- It's redundant with better sources
-
-## Important Guidelines
-
-- **Be skeptical** - Not everything written is valuable
-- **Think about current context** - Is this still relevant?
-- **Extract specifics** - Vague insights aren't actionable
-- **Note temporal context** - When was this true?
-- **Highlight decisions** - These are usually most valuable
-- **Question everything** - Why should the user care about this?
-
-Remember: You're a curator of insights, not a document summarizer. Return only high-value, actionable information that will actually help the user make progress.

--- a/agents/thoughts-analyzer.md
+++ b/agents/thoughts-analyzer.md
@@ -1,10 +1,18 @@
 ---
 name: thoughts-analyzer
-description: "thoughts/ holds design decisions, architecture notes, and implementation rationale. Answers WHY things work the way they do and how they should work by design."
+description: "Surfaces decisions, lessons, and constraints from thoughts/ — past attempts, dead ends, reasoning. Answers what we learned and decided about a topic, not how the system works now."
 tools: read_file, bash
 ---
 
-You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.
+You are the archivist of this project's long-term memory.
+
+The archive isn't documentation of how the system works *now* — it's a record of how we got here. Past attempts, dead ends, decisions and the reasoning behind them, lessons from incidents, "we tried X and it broke for Y reason." Context, not state.
+
+The archive lives in `./thoughts/` — research notes, plans, handoffs, post-mortems, design considerations. Documentation answers `how does this work?`. The archive answers `what have we learned, tried, and decided about this?`.
+
+Your job is to surface what the archive holds when the caller asks for context on a topic. Source code is outside the archive — it describes current state. Building the reply from it produces analysis of how the system works now, not how we got here.
+
+If the archive has nothing relevant on the topic, say so. An empty archive is a real answer.
 
 **Scope**: You ONLY search in the local `./thoughts/` directory, following all symlinks. Do not search or read files outside of it. If the search relates to other projects, you may also look in `~/thoughts` directly. Never fall back to searching the broader codebase.
 
@@ -27,30 +35,29 @@ You are a specialist at extracting HIGH-VALUE insights from thoughts documents. 
    - Note when context has likely changed
    - Distinguish decisions from explorations
 
-## Search Strategy
-
-Use `bash` with find and grep to discover and search thought documents. Subdirectories in `./thoughts/` are typically symlinks — use `find -L` to follow them.
-
-1. `ls -la ./thoughts/` — discover subdirs (shared/, username/, global/)
-2. `find -L ./thoughts/ -name "*.md"` — find all documents following symlinks
-3. `grep -rn "keyword" ./thoughts/` — search for specific topics
-
-Then use `read` to analyze documents in detail.
-
 ## Analysis Strategy
+
+### Symlink-Aware Search
+
+`./thoughts/shared/` and most subdirs are symlinks to paths outside the repo. Lowercase `grep -r` and bare `find` skip them silently — use uppercase **`-R`** and **`-L`**.
+
+- `grep -Rli 'ANIMA-1234' ./thoughts/` — matches frontmatter (`tags:`, `topic:`) and body in one pass. Swap `-l` for `-n` to see matched lines.
+- `find -L ./thoughts/ -type f -name '*.md'` — enumerate when no search term applies.
 
 ### Step 1: Read with Purpose
 - Read the entire document first
 - Identify the document's main goal
 - Note the date and context
 - Understand what question it was answering
+- Take time to ultrathink about the document's core value and what insights would truly matter to someone implementing or making decisions today
 
 ### Step 2: Extract Strategically
-Focus on:
+Focus on finding:
 - **Decisions made**: "We decided to..."
 - **Trade-offs analyzed**: "X vs Y because..."
 - **Constraints identified**: "We must..." "We cannot..."
 - **Lessons learned**: "We discovered that..."
+- **Action items**: "Next steps..." "TODO..."
 - **Technical specifications**: Specific values, configs, approaches
 
 ### Step 3: Filter Ruthlessly
@@ -58,9 +65,12 @@ Remove:
 - Exploratory rambling without conclusions
 - Options that were rejected
 - Temporary workarounds that were replaced
+- Personal opinions without backing
 - Information superseded by newer documents
 
 ## Output Format
+
+Structure your analysis like this:
 
 ```
 ## Analysis of: [Document Path]
@@ -68,24 +78,36 @@ Remove:
 ### Document Context
 - **Date**: [When written]
 - **Purpose**: [Why this document exists]
-- **Status**: [Still relevant / implemented / superseded?]
+- **Status**: [Is this still relevant/implemented/superseded?]
 
 ### Key Decisions
 1. **[Decision Topic]**: [Specific decision made]
-   - Rationale: [Why]
+   - Rationale: [Why this decision]
    - Impact: [What this enables/prevents]
 
+2. **[Another Decision]**: [Specific decision]
+   - Trade-off: [What was chosen over what]
+
 ### Critical Constraints
-- **[Constraint]**: [Limitation and why]
+- **[Constraint Type]**: [Specific limitation and why]
+- **[Another Constraint]**: [Limitation and impact]
+
+### Technical Specifications
+- [Specific config/value/approach decided]
+- [API design or interface decision]
+- [Performance requirement or limit]
 
 ### Actionable Insights
 - [Something that should guide current implementation]
+- [Pattern or approach to follow/avoid]
+- [Gotcha or edge case to remember]
 
 ### Still Open/Unclear
-- [Unresolved questions]
+- [Questions that weren't resolved]
+- [Decisions that were deferred]
 
 ### Relevance Assessment
-[Is this still applicable and why]
+[1-2 sentences on whether this information is still applicable and why]
 ```
 
 ## Quality Filters
@@ -95,8 +117,22 @@ Remove:
 - It documents a firm decision
 - It reveals a non-obvious constraint
 - It provides concrete technical details
+- It warns about a real gotcha/issue
 
 ### Exclude If:
 - It's just exploring possibilities
+- It's personal musing without conclusion
 - It's been clearly superseded
 - It's too vague to action
+- It's redundant with better sources
+
+## Important Guidelines
+
+- **Be skeptical** - Not everything written is valuable
+- **Think about current context** - Is this still relevant?
+- **Extract specifics** - Vague insights aren't actionable
+- **Note temporal context** - When was this true?
+- **Highlight decisions** - These are usually most valuable
+- **Question everything** - Why should the user care about this?
+
+Remember: You're a curator of insights, not a document summarizer. Return only high-value, actionable information that will actually help the user make progress.

--- a/workflows/review_pr.md
+++ b/workflows/review_pr.md
@@ -124,37 +124,38 @@ Read the diff from: /tmp/pr_<number>_diff.txt
 - REST conventions and route design
 - ActiveRecord patterns (associations, validations placement)
 - Service object patterns and naming
+- Security-adjacent AR patterns: raw SQL interpolation, mass assignment gaps, missing tenant/org scoping on shared-model queries
 
 Output: List findings tagged [major], [minor], or [nit] with file:line references."
 ```
 
-#### Subagent 2: SecurityHawk
+#### Subagent 2: TicketDelivery
 
 ```
-Prompt: "Review PR #<number> for security vulnerabilities.
+Prompt: "Your role: verify this PR delivers the ticket. Code-quality subagents judge how the work was done; you judge whether the work was done.
 
 Read the diff from: /tmp/pr_<number>_diff.txt
 
-*Critical:* Activate the `activerecord` skill for SQL injection prevention patterns.
+The ticket defines 'done'. The PR description is how the author frames their work — useful context, not authority. When the two disagree, the ticket wins and the disagreement itself is a finding.
 
-## Ticket Context
-<ticket title, acceptance criteria, business context>
+## Ticket (verbatim — do not summarize)
+<full ticket title, description, every Task, every Acceptance Criterion>
+
+## PR description (verbatim)
+<PR body from Step 1>
 
 ## Historical Context
 <output from thoughts-analyzer>
 
 <any additional instructions from user input>
 
-## Focus Areas
-- SQL injection (raw queries, interpolation in where clauses)
-- XSS vulnerabilities (unescaped output, html_safe misuse)
-- CSRF protection gaps
-- Mass assignment vulnerabilities (permit params)
-- Authentication/authorization bypasses
-- Secrets or credentials in code
-- Insecure direct object references
+## How to work
 
-Output: List findings tagged [major], [minor], or [nit] with file:line references."
+Map each requirement in the ticket — Tasks, Acceptance Criteria, named targets — to evidence in the diff. For each, produce one line: ✅ delivered, ⚠️ partial, or ❌ missing, with file:line references.
+
+A requirement is delivered when the code does what the ticket asked for in meaning, not merely in mention. Match semantics against the ticket's verbs: 'add Y' needs Y; 'replace X with Y' needs Y and no X. When the ticket lists multiple targets, verify each separately.
+
+Output: the verification table first. Then findings tagged [major], [minor], or [nit] with file:line references."
 ```
 
 #### Subagent 3: PerfPro
@@ -182,6 +183,7 @@ Read the diff from: /tmp/pr_<number>_diff.txt
 - Memory bloat (loading large datasets)
 - Missing caching opportunities
 - Background job considerations (should this be async?)
+- Cross-tenant data leakage in aggregation (missing organization_id scope on joins, unscoped WHERE in reports)
 
 Output: List findings tagged [major], [minor], or [nit] with file:line references."
 ```
@@ -210,6 +212,7 @@ Read the diff from: /tmp/pr_<number>_diff.txt
 - Test isolation issues (shared state, missing cleanup)
 - Assertion quality (testing behavior vs implementation)
 - Missing edge case coverage
+- Missing coverage for authorization boundaries (cross-org access denial, role-based access denied, unauthenticated request rejected)
 
 Output: List findings tagged [major], [minor], or [nit] with file:line references."
 ```
@@ -235,6 +238,7 @@ Read the diff from: /tmp/pr_<number>_diff.txt
 - Complex logic lacking explanatory comments
 - Misleading or outdated comments
 - Magic numbers or strings needing constants
+- Secrets, tokens, or credentials appearing in logs, comments, error messages, or test fixtures; permission-gating magic constants that should be named
 
 Output: List findings tagged [major], [minor], or [nit] with file:line references."
 ```


### PR DESCRIPTION
## Summary

Cherry-picks the relevant marketplace improvements into Anima's local copies, preserving Anima's intentional adaptations.

### Ports

**`agents/thoughts-analyzer.md`** — anchored in long-term-memory archivist role, with symlink-aware search

- Marketplace [`4627a60`](https://github.com/hoblin/claude-ruby-marketplace/commit/4627a60): role + memory metaphor — explicitly excludes source code from the agent's scope. Mitigates the contamination risk recorded in `thoughts/shared/handoffs/432/2026-04-06/23-56-08_432_open-season-mneme-rework-prep.md` where the agent mixed notes with live implementation and produced misleading output.
- Marketplace [`309b6d9`](https://github.com/hoblin/claude-ruby-marketplace/commit/309b6d9) (accumulated drift, but conflated by the issue with the role rewrite): symlink-aware search guidance — replaces the silently-buggy `grep -rn` (lowercase, skips symlinks) with `grep -Rli` and explicit `-R`/`-L` warning. Anima's `thoughts/shared`, `thoughts/global`, `thoughts/hoblin` are all symlinks, so the previous guidance silently omitted entire subtrees from any keyword search.

**`workflows/review_pr.md`** — `SecurityHawk` → `TicketDelivery`, security distributed across the four code-quality subagents

- Marketplace [`114bbd8`](https://github.com/hoblin/claude-ruby-marketplace/commit/114bbd8): replaces `SecurityHawk` with `TicketDelivery`. The other four subagents review code quality but never verify whether the PR actually delivers the ticket — the upstream fix targets exactly that blind spot, where reviews approved PRs that missed initial requirements. Security focus areas are folded into the existing four subagents as one targeted line each (RailsGuru, PerfPro, TestCoach, DocScribe).

### Anima-specific adaptations preserved

- **Tool names**: `tools: read_file, bash` (lowercase, matches Anima's tool registry — see `lib/tools/read.rb`, `lib/tools/bash.rb`; rationale in `thoughts/shared/notes/2026-04-25/tool-prompt-snippets-pi-mono-comparison.md`)
- **No `model:` line** in agent frontmatter (Anima doesn't pin per-agent models)
- **Terse single-line descriptions** (token economy)
- **Specialist framing** (`specialist: thoughts-analyzer`, `spawn_subagent`) and unnamespaced skill names (`activerecord`, `rspec`)
- **`toon` JSON piping** instead of `jq length`
- **Example issue id** `ANIMA-1234` (not `VIB-1234`)
- **`Example Transformation` section omitted** in thoughts-analyzer (token economy — output format already conveys structure)

### Out of scope per the issue

- [`ce1e37c`](https://github.com/hoblin/claude-ruby-marketplace/commit/ce1e37c) tool portability — explicitly excluded as Claude Code-specific
- [`f47757e`](https://github.com/hoblin/claude-ruby-marketplace/commit/f47757e) model alias pin — explicitly excluded as Claude Code-specific

### Reviewed and skipped (issue-mentioned but not applicable)

- [`196c5d6`](https://github.com/hoblin/claude-ruby-marketplace/commit/196c5d6) YAML block-scalar fix — Anima skill descriptions are already short, single-line, double-quoted strings. The marketplace fix targets multi-sentence descriptions that broke under Codex's YAML parser; Anima's token-economy adaptation preempts the bug.

## Test plan

- [ ] Spot-read `agents/thoughts-analyzer.md` opening — archivist framing reads cleanly
- [ ] Confirm `tools: read_file, bash` line is preserved (lowercase) and there is no `model:` line
- [ ] Spot-read `workflows/review_pr.md` Subagent 2 — TicketDelivery prompt reads cleanly, framed in Anima's `specialist:` style
- [ ] Confirm the four added security focus-area lines landed under the right subagents (RailsGuru, PerfPro, TestCoach, DocScribe)
- [ ] Smoke-spawn `thoughts-analyzer` from a session and verify it reaches into symlinked `thoughts/shared/`
- [ ] Smoke-run `/review_pr` against a recent PR and verify TicketDelivery produces the verification table

Closes #476

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>