### PR TITLE
#424 fix: show per-request cache stats in Token Economy HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,8 @@ The right-side HUD panel shows session state at a glance: session name, goals (w
 |-----|-------------|
 | `5h` | 5-hour rate limit utilization with progress bar and reset countdown |
 | `7d` | 7-day rate limit utilization with progress bar |
-| `⚡` | Cache hit rate — percentage of input tokens served from cache |
-| `💾` | Cumulative tokens saved by cache hits |
+| `⚡` | Cache hit rate of the latest call — percentage of input tokens served from cache |
+| `💾` | Tokens served from cache on the latest call |
 | `⠛⣿` | Braille sparkline — per-call cache hit history (2 calls per character); drops signal cache busts |
 | `🟢` | Connection status and current view mode |
 

--- a/lib/tui/message_store.rb
+++ b/lib/tui/message_store.rb
@@ -100,7 +100,8 @@ module TUI
     # Events with `"action" => "update"` and a matching `"id"` replace
     # the existing entry's data in-place rather than appending.
     #
-    # Extracts api_metrics when present and accumulates token economy data.
+    # Extracts api_metrics when present and records the latest call's
+    # token economy data for the HUD.
     #
     # @param event_data [Hash] Action Cable event payload with "type", "content",
     #   and optionally "rendered" (hash of mode => lines), "id", "action", "api_metrics"

--- a/lib/tui/message_store.rb
+++ b/lib/tui/message_store.rb
@@ -63,17 +63,23 @@ module TUI
       @mutex.synchronize { @entries.size + @pending_entries.size }
     end
 
-    # Returns aggregated token economy data for HUD display.
-    # Includes running totals, cache hit rate, and latest rate limit snapshot.
+    # Returns token economy data for HUD display.
+    #
+    # Token counts, rate limits, and cache hit rate reflect the most recent API
+    # call — accumulating them across a session produces values larger than the
+    # context window, which is meaningless. `call_count` and `cache_history`
+    # remain session-wide so the HUD can detect "any metrics yet?" and render
+    # the per-call sparkline.
     #
     # @return [Hash] token economy stats:
-    #   - :input_tokens [Integer] total input tokens across all calls
-    #   - :output_tokens [Integer] total output tokens
-    #   - :cache_read_input_tokens [Integer] total cached token reads
-    #   - :cache_creation_input_tokens [Integer] total cache writes
-    #   - :call_count [Integer] number of API calls tracked
-    #   - :cache_hit_rate [Float] percentage of input served from cache (0.0-1.0)
+    #   - :input_tokens [Integer] uncached input tokens from the latest call
+    #   - :output_tokens [Integer] output tokens from the latest call
+    #   - :cache_read_input_tokens [Integer] cached token reads from the latest call
+    #   - :cache_creation_input_tokens [Integer] cache writes from the latest call
+    #   - :call_count [Integer] number of API calls tracked this session
+    #   - :cache_hit_rate [Float] hit rate of the latest call (0.0-1.0)
     #   - :rate_limits [Hash, nil] latest rate limit values from API
+    #   - :cache_history [Array<Float>] per-call hit rates for the sparkline
     def token_economy
       @mutex.synchronize do
         stats = @token_economy.dup
@@ -104,7 +110,7 @@ module TUI
 
       # Track API metrics for token economy HUD (only on create, not update)
       if event_data["action"] != "update"
-        accumulate_api_metrics(event_data["api_metrics"])
+        track_api_metrics(event_data["api_metrics"])
       end
 
       if event_data["action"] == "update" && message_id
@@ -436,12 +442,15 @@ module TUI
       }
     end
 
-    # Accumulates API metrics from a message into running totals.
-    # Updates rate limits with the latest snapshot (most recent wins).
+    # Records API metrics from the most recent message.
+    #
+    # Token counts and rate limits are last-wins (per-request semantics);
+    # `call_count` increments and `cache_history` appends so the HUD can
+    # show a sparkline of per-call hit rates.
     #
     # @param api_metrics [Hash, nil] metrics from API response with "usage" and "rate_limits"
     # @return [void]
-    def accumulate_api_metrics(api_metrics)
+    def track_api_metrics(api_metrics)
       return unless api_metrics.is_a?(Hash)
 
       @mutex.synchronize do
@@ -451,10 +460,10 @@ module TUI
           cache_read = usage["cache_read_input_tokens"].to_i
           cache_create = usage["cache_creation_input_tokens"].to_i
 
-          @token_economy[:input_tokens] += input
-          @token_economy[:output_tokens] += usage["output_tokens"].to_i
-          @token_economy[:cache_read_input_tokens] += cache_read
-          @token_economy[:cache_creation_input_tokens] += cache_create
+          @token_economy[:input_tokens] = input
+          @token_economy[:output_tokens] = usage["output_tokens"].to_i
+          @token_economy[:cache_read_input_tokens] = cache_read
+          @token_economy[:cache_creation_input_tokens] = cache_create
           @token_economy[:call_count] += 1
 
           # Per-call cache hit rate for sparkline graph

--- a/spec/lib/tui/message_store_spec.rb
+++ b/spec/lib/tui/message_store_spec.rb
@@ -741,13 +741,27 @@ RSpec.describe TUI::MessageStore do
           }
         }
       })
+      store.process_event({
+        "type" => "agent_message",
+        "content" => "third",
+        "api_metrics" => {
+          "usage" => {
+            "input_tokens" => 5,
+            "output_tokens" => 3,
+            "cache_read_input_tokens" => 45,
+            "cache_creation_input_tokens" => 0
+          }
+        }
+      })
 
       stats = store.token_economy
-      expect(stats[:input_tokens]).to eq(30)
-      expect(stats[:output_tokens]).to eq(15)
-      expect(stats[:cache_read_input_tokens]).to eq(200)
+      expect(stats[:input_tokens]).to eq(5)
+      expect(stats[:output_tokens]).to eq(3)
+      expect(stats[:cache_read_input_tokens]).to eq(45)
       expect(stats[:cache_creation_input_tokens]).to eq(0)
-      expect(stats[:call_count]).to eq(2)
+      expect(stats[:cache_hit_rate]).to be_within(0.001).of(45.0 / 50)
+      expect(stats[:call_count]).to eq(3)
+      expect(stats[:cache_history].size).to eq(3)
     end
 
     it "calculates cache hit rate correctly" do

--- a/spec/lib/tui/message_store_spec.rb
+++ b/spec/lib/tui/message_store_spec.rb
@@ -692,7 +692,7 @@ RSpec.describe TUI::MessageStore do
       expect(stats[:rate_limits]).to be_nil
     end
 
-    it "accumulates token counts from api_metrics" do
+    it "tracks token counts from api_metrics" do
       store.process_event({
         "type" => "agent_message",
         "content" => "Hello",
@@ -714,20 +714,39 @@ RSpec.describe TUI::MessageStore do
       expect(stats[:call_count]).to eq(1)
     end
 
-    it "accumulates across multiple messages" do
-      2.times do
-        store.process_event({
-          "type" => "agent_message",
-          "content" => "msg",
-          "api_metrics" => {
-            "usage" => {"input_tokens" => 50, "output_tokens" => 25}
+    # Regression: cumulative summing produced impossibly large values
+    # (1M+ cached tokens in a single context). See issue #424.
+    it "tracks the most recent call's token counts, not a running sum" do
+      store.process_event({
+        "type" => "agent_message",
+        "content" => "first",
+        "api_metrics" => {
+          "usage" => {
+            "input_tokens" => 100,
+            "output_tokens" => 50,
+            "cache_read_input_tokens" => 80,
+            "cache_creation_input_tokens" => 20
           }
-        })
-      end
+        }
+      })
+      store.process_event({
+        "type" => "agent_message",
+        "content" => "second",
+        "api_metrics" => {
+          "usage" => {
+            "input_tokens" => 30,
+            "output_tokens" => 15,
+            "cache_read_input_tokens" => 200,
+            "cache_creation_input_tokens" => 0
+          }
+        }
+      })
 
       stats = store.token_economy
-      expect(stats[:input_tokens]).to eq(100)
-      expect(stats[:output_tokens]).to eq(50)
+      expect(stats[:input_tokens]).to eq(30)
+      expect(stats[:output_tokens]).to eq(15)
+      expect(stats[:cache_read_input_tokens]).to eq(200)
+      expect(stats[:cache_creation_input_tokens]).to eq(0)
       expect(stats[:call_count]).to eq(2)
     end
 
@@ -770,7 +789,7 @@ RSpec.describe TUI::MessageStore do
       expect(stats[:rate_limits]["5h_utilization"]).to eq(0.25)
     end
 
-    it "does not accumulate metrics on update actions" do
+    it "ignores api_metrics on update actions so call_count stays accurate" do
       store.process_event({
         "type" => "agent_message",
         "id" => 1,
@@ -782,7 +801,7 @@ RSpec.describe TUI::MessageStore do
         "id" => 1,
         "action" => "update",
         "content" => "updated",
-        "api_metrics" => {"usage" => {"input_tokens" => 50}}
+        "api_metrics" => {"usage" => {"input_tokens" => 999}}
       })
 
       expect(store.token_economy[:input_tokens]).to eq(50)


### PR DESCRIPTION
## Summary

Fixes #424. The `💾` cached-tokens counter in the Token Economy HUD accumulated `cache_read_input_tokens` across every API call in the session, producing impossible values like 1M+ tokens. The original design called for per-call metrics in the primary HUD; the implementation lost the distinction during the #400 rollout.

- Switch the four token counters (`input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`) to last-wins semantics, matching the existing `rate_limits` pattern in the same method.
- Keep `call_count` accumulating — it gates "any metrics yet?" rendering. Keep `cache_history` accumulating — it backs the per-call sparkline.
- Rename `accumulate_api_metrics` → `track_api_metrics` and update YARD docs to reflect the new semantics.
- Update the README HUD legend to describe the per-request behavior.

## Test plan

- [x] `bundle exec rspec spec/lib/tui/message_store_spec.rb spec/lib/tui/app_spec.rb` — 307 examples, 0 failures
- [x] New regression test asserts the counter shows the latest call's value, not the running sum (the exact symptom from #424)
- [x] `standardrb --fix` clean
- [ ] CI green