### PR TITLE
#480 chore: instrument Aoide main loop with dev-only debug logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Always clean up tmux sessions when done. Use `anima-test` as the session name fo
 **Important:** Use `./exe/anima` (not `bundle exec anima`) to test local code changes. The exe uses `require_relative` so it loads local `lib/` directly. `bundle exec` may load the installed gem version instead.
 
 Melete debug log (dev only): `tail -f log/melete.log`
-Aoide debug log (dev only): `tail -f log/aoide.log` — raw API response, raw tool_use blocks, and dispatched tool name/id from the main loop.
+Aoide debug log (dev only): `tail -f log/aoide.log` — raw API response, raw tool_use blocks (pre-normalization), and dispatched tool name/id. Use to correlate "what came in from the API" against "what got dispatched".
 
 ## Triggering API 400 for smoke testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Always clean up tmux sessions when done. Use `anima-test` as the session name fo
 **Important:** Use `./exe/anima` (not `bundle exec anima`) to test local code changes. The exe uses `require_relative` so it loads local `lib/` directly. `bundle exec` may load the installed gem version instead.
 
 Melete debug log (dev only): `tail -f log/melete.log`
+Aoide debug log (dev only): `tail -f log/aoide.log` — raw API response, raw tool_use blocks, and dispatched tool name/id from the main loop.
 
 ## Triggering API 400 for smoke testing
 

--- a/lib/aoide.rb
+++ b/lib/aoide.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# Aoide — the muse of voice. The agent's main conversational loop:
-# she takes the system prompt, recent messages, and tool registry, and
-# turns each LLM response into dispatched tool executions. One of the
-# Three Muses: Melete prepares, Aoide performs, Mneme remembers.
+# Aoide — the muse of voice. Turns each LLM response into dispatched
+# tool executions and persisted messages. One of the Three Muses: she
+# performs while Melete prepares the stage and Mneme remembers.
 module Aoide
   # Dev-only logger that writes to log/aoide.log.
   # In non-development environments returns a null logger so

--- a/lib/aoide.rb
+++ b/lib/aoide.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Aoide — the muse of voice. The agent's main conversational loop:
+# she takes the system prompt, recent messages, and tool registry, and
+# turns each LLM response into dispatched tool executions. One of the
+# Three Muses: Melete prepares, Aoide performs, Mneme remembers.
+module Aoide
+  # Dev-only logger that writes to log/aoide.log.
+  # In non-development environments returns a null logger so
+  # call sites don't need conditionals.
+  #
+  # @return [Logger]
+  def self.logger
+    @logger ||= build_logger
+  end
+
+  def self.build_logger
+    return Logger.new(File::NULL) unless Rails.env.development?
+
+    Logger.new(Rails.root.join("log", "aoide.log")).tap do |log|
+      log.formatter = proc { |severity, time, _progname, msg|
+        "[#{time.strftime("%H:%M:%S.%L")}] #{severity}  #{msg}\n"
+      }
+    end
+  end
+  private_class_method :build_logger
+end

--- a/lib/events/subscribers/llm_response_handler.rb
+++ b/lib/events/subscribers/llm_response_handler.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "toon"
+
 module Events
   module Subscribers
     # Handles the aftermath of a single LLM round-trip emitted via
@@ -130,8 +132,8 @@ module Events
           "session=#{sid} — response received " \
           "(#{blocks.size} block(s), #{raw_tool_uses.size} tool_use)"
         )
-        log.debug("session=#{sid} raw response:\n#{JSON.pretty_generate(response)}")
-        log.debug("session=#{sid} raw tool_use blocks:\n#{JSON.pretty_generate(raw_tool_uses)}")
+        log.debug("session=#{sid} raw response:\n#{Toon.encode(response)}")
+        log.debug("session=#{sid} raw tool_use blocks:\n#{Toon.encode(raw_tool_uses)}")
       end
     end
   end

--- a/lib/events/subscribers/llm_response_handler.rb
+++ b/lib/events/subscribers/llm_response_handler.rb
@@ -45,6 +45,7 @@ module Events
 
       private
 
+      # @return [Logger] dev-only Aoide logger
       def log = Aoide.logger
 
       def content_blocks(response)
@@ -120,20 +121,23 @@ module Events
       end
 
       # Diagnostic trace of every Anthropic response that reaches the
-      # main loop: full payload at debug, raw +tool_use+ blocks at
-      # debug, one-line summary at info. Lets a reader correlate
-      # "what came in from the API" against "what got dispatched"
-      # when investigating spurious tool calls.
+      # main loop: a one-line summary at info, the full payload and
+      # raw +tool_use+ blocks (pre-normalization) at debug — paired so
+      # the inbound API response can be correlated against what got
+      # dispatched. Block form on +log.debug+ so +Toon.encode+ never
+      # runs unless the level allows it.
       def log_raw_response(session, response)
         sid = session.id
         blocks = content_blocks(response)
         raw_tool_uses = blocks.select { |block| block_type(block) == "tool_use" }
+
         log.info(
           "session=#{sid} — response received " \
           "(#{blocks.size} block(s), #{raw_tool_uses.size} tool_use)"
         )
-        log.debug("session=#{sid} raw response:\n#{Toon.encode(response)}")
-        log.debug("session=#{sid} raw tool_use blocks:\n#{Toon.encode(raw_tool_uses)}")
+        {"raw response" => response, "raw tool_use blocks" => raw_tool_uses}.each do |label, payload|
+          log.debug { "session=#{sid} #{label}:\n#{Toon.encode(payload)}" }
+        end
       end
     end
   end

--- a/lib/events/subscribers/llm_response_handler.rb
+++ b/lib/events/subscribers/llm_response_handler.rb
@@ -25,6 +25,8 @@ module Events
         response = payload[:response] || {}
         api_metrics = payload[:api_metrics]
 
+        log_raw_response(session, response)
+
         tool_uses = normalize_tool_uses(response)
         text = extract_text(response)
 
@@ -40,6 +42,8 @@ module Events
       end
 
       private
+
+      def log = Aoide.logger
 
       def content_blocks(response)
         response["content"] || response[:content] || []
@@ -82,29 +86,52 @@ module Events
       end
 
       def persist_tool_call(session, tool_use)
+        tool_use_id = tool_use["id"]
+        tool_name = tool_use["name"]
         session.messages.create!(
           message_type: "tool_call",
-          tool_use_id: tool_use["id"],
+          tool_use_id: tool_use_id,
           payload: {
             "type" => "tool_call",
-            "tool_name" => tool_use["name"],
-            "tool_use_id" => tool_use["id"],
+            "tool_name" => tool_name,
+            "tool_use_id" => tool_use_id,
             "tool_input" => tool_use["input"],
-            "content" => "Calling #{tool_use["name"]}"
+            "content" => "Calling #{tool_name}"
           },
           timestamp: Time.current.to_ns
         )
       end
 
       def dispatch_tool_executions(session, tool_uses)
+        sid = session.id
         tool_uses.each do |tool_use|
+          tool_use_id = tool_use["id"]
+          tool_name = tool_use["name"]
+          log.info("session=#{sid} dispatching tool=#{tool_name} id=#{tool_use_id}")
           ToolExecutionJob.perform_later(
-            session.id,
-            tool_use_id: tool_use["id"],
-            tool_name: tool_use["name"],
+            sid,
+            tool_use_id: tool_use_id,
+            tool_name: tool_name,
             tool_input: tool_use["input"]
           )
         end
+      end
+
+      # Diagnostic trace of every Anthropic response that reaches the
+      # main loop: full payload at debug, raw +tool_use+ blocks at
+      # debug, one-line summary at info. Lets a reader correlate
+      # "what came in from the API" against "what got dispatched"
+      # when investigating spurious tool calls.
+      def log_raw_response(session, response)
+        sid = session.id
+        blocks = content_blocks(response)
+        raw_tool_uses = blocks.select { |block| block_type(block) == "tool_use" }
+        log.info(
+          "session=#{sid} — response received " \
+          "(#{blocks.size} block(s), #{raw_tool_uses.size} tool_use)"
+        )
+        log.debug("session=#{sid} raw response:\n#{JSON.pretty_generate(response)}")
+        log.debug("session=#{sid} raw tool_use blocks:\n#{JSON.pretty_generate(raw_tool_uses)}")
       end
     end
   end

--- a/spec/lib/events/subscribers/llm_response_handler_spec.rb
+++ b/spec/lib/events/subscribers/llm_response_handler_spec.rb
@@ -109,12 +109,12 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
         .with(/session=#{session.id} — response received \(2 block\(s\), 1 tool_use\)/)
     end
 
-    it "logs the raw response payload as pretty JSON at debug level" do
+    it "logs the raw response payload as TOON at debug level" do
       response = {"content" => [{"type" => "text", "text" => "hello"}], "stop_reason" => "end_turn"}
       dispatch(response)
 
       expect(Aoide.logger).to have_received(:debug)
-        .with(a_string_including("raw response:", JSON.pretty_generate(response)))
+        .with(a_string_including("raw response:", Toon.encode(response)))
     end
 
     it "logs raw tool_use blocks before normalization, preserving missing ids" do

--- a/spec/lib/events/subscribers/llm_response_handler_spec.rb
+++ b/spec/lib/events/subscribers/llm_response_handler_spec.rb
@@ -92,4 +92,65 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
       expect(session.reload.aasm_state).to eq("idle")
     end
   end
+
+  describe "diagnostic logging" do
+    before do
+      allow(Aoide.logger).to receive(:info)
+      allow(Aoide.logger).to receive(:debug)
+    end
+
+    it "logs a one-line summary including block and tool_use counts" do
+      dispatch({"content" => [
+        {"type" => "text", "text" => "thinking"},
+        {"type" => "tool_use", "id" => "toolu_1", "name" => "bash", "input" => {}}
+      ]})
+
+      expect(Aoide.logger).to have_received(:info)
+        .with(/session=#{session.id} — response received \(2 block\(s\), 1 tool_use\)/)
+    end
+
+    it "logs the raw response payload as pretty JSON at debug level" do
+      response = {"content" => [{"type" => "text", "text" => "hello"}], "stop_reason" => "end_turn"}
+      dispatch(response)
+
+      expect(Aoide.logger).to have_received(:debug)
+        .with(a_string_including("raw response:", JSON.pretty_generate(response)))
+    end
+
+    it "logs raw tool_use blocks before normalization, preserving missing ids" do
+      raw_blocks_message = nil
+      allow(Aoide.logger).to receive(:debug) do |msg|
+        raw_blocks_message = msg if msg.start_with?("session=#{session.id} raw tool_use blocks:")
+      end
+
+      dispatch({"content" => [
+        {"type" => "text", "text" => "thinking"},
+        {"type" => "tool_use", "name" => "from_melete_goal", "input" => {"goal" => "x"}}
+      ]})
+
+      expect(raw_blocks_message).to include("from_melete_goal")
+      expect(raw_blocks_message).not_to match(/"id":\s*"[0-9a-f-]{36}"/i)
+    end
+
+    it "logs each dispatched tool name and id at info level" do
+      dispatch({"content" => [
+        {"type" => "tool_use", "id" => "toolu_1", "name" => "bash", "input" => {"command" => "ls"}},
+        {"type" => "tool_use", "id" => "toolu_2", "name" => "read", "input" => {"path" => "/tmp"}}
+      ]})
+
+      expect(Aoide.logger).to have_received(:info)
+        .with(/dispatching tool=bash id=toolu_1/)
+      expect(Aoide.logger).to have_received(:info)
+        .with(/dispatching tool=read id=toolu_2/)
+    end
+
+    it "traces spurious from_* tool calls all the way to dispatch" do
+      dispatch({"content" => [
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_zero-width-sleuth", "input" => {}}
+      ]})
+
+      expect(Aoide.logger).to have_received(:info)
+        .with(/dispatching tool=from_zero-width-sleuth id=toolu_phantom/)
+    end
+  end
 end

--- a/spec/lib/events/subscribers/llm_response_handler_spec.rb
+++ b/spec/lib/events/subscribers/llm_response_handler_spec.rb
@@ -94,9 +94,14 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
   end
 
   describe "diagnostic logging" do
+    let(:debug_messages) { [] }
+
     before do
       allow(Aoide.logger).to receive(:info)
-      allow(Aoide.logger).to receive(:debug)
+      messages = debug_messages
+      allow(Aoide.logger).to receive(:debug) do |*args, &block|
+        messages << (block ? block.call : args.first)
+      end
     end
 
     it "logs a one-line summary including block and tool_use counts" do
@@ -113,23 +118,18 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
       response = {"content" => [{"type" => "text", "text" => "hello"}], "stop_reason" => "end_turn"}
       dispatch(response)
 
-      expect(Aoide.logger).to have_received(:debug)
-        .with(a_string_including("raw response:", Toon.encode(response)))
+      expect(debug_messages).to include(a_string_including("raw response:", Toon.encode(response)))
     end
 
     it "logs raw tool_use blocks before normalization, preserving missing ids" do
-      raw_blocks_message = nil
-      allow(Aoide.logger).to receive(:debug) do |msg|
-        raw_blocks_message = msg if msg.start_with?("session=#{session.id} raw tool_use blocks:")
-      end
-
       dispatch({"content" => [
         {"type" => "text", "text" => "thinking"},
         {"type" => "tool_use", "name" => "from_melete_goal", "input" => {"goal" => "x"}}
       ]})
 
-      expect(raw_blocks_message).to include("from_melete_goal")
-      expect(raw_blocks_message).not_to match(/"id":\s*"[0-9a-f-]{36}"/i)
+      raw_blocks = debug_messages.find { |m| m.start_with?("session=#{session.id} raw tool_use blocks:") }
+      expect(raw_blocks).to include("from_melete_goal")
+      expect(raw_blocks).not_to match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)
     end
 
     it "logs each dispatched tool name and id at info level" do
@@ -144,11 +144,13 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
         .with(/dispatching tool=read id=toolu_2/)
     end
 
-    it "traces spurious from_* tool calls all the way to dispatch" do
+    it "traces a spurious from_* tool call from the raw blocks log to dispatch" do
       dispatch({"content" => [
         {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_zero-width-sleuth", "input" => {}}
       ]})
 
+      raw_blocks = debug_messages.find { |m| m.start_with?("session=#{session.id} raw tool_use blocks:") }
+      expect(raw_blocks).to include("from_zero-width-sleuth")
       expect(Aoide.logger).to have_received(:info)
         .with(/dispatching tool=from_zero-width-sleuth id=toolu_phantom/)
     end


### PR DESCRIPTION
## Summary

Wires up dev-only debug logging into `Events::Subscribers::LLMResponseHandler` so we can pin down whether spurious `from_*` tool calls (e.g. `from_melete_goal`, `from_zero-width-sleuth` → `Tools::UnknownToolError`) originate from the LLM (hallucination) or from somewhere inside Anima (internal leak).

This is the **research-spike data-gathering step** of #480 — not a fix. The decision (hallucination vs internal leak) and the follow-up implementation issue come after a session that exhibits the bug is run against the new logs.

## What's logged (at the point the API response enters the main loop)

1. **Raw Anthropic API response payload** — full structure, encoded as TOON, debug level. Captured before `normalize_tool_uses` runs.
2. **Raw `tool_use` blocks** — debug level, TOON-encoded, shown pre-normalization so missing `id`s look missing. If a `from_melete_goal` block is here, the LLM produced it; if it's only in the dispatched list, something else synthesized it.
3. **Each dispatched tool execution** — info level, one line per call, with name + id.

Plus a one-line info summary at session boundary (`response received (N block(s), M tool_use)`) so a reader can scan the timeline without `--debug`.

Payloads are encoded with `Toon.encode` (already used by `lib/tui/screens/chat.rb` and the tool decorators) — same project convention, ~30% fewer lines than `JSON.pretty_generate`, lossless round-trip.

## Where it lives

- `lib/aoide.rb` — new module-level logger, mirrors `Melete.logger` / `Mneme.logger` byte-for-byte: dev-only `Logger.new("log/aoide.log")`, returns `Logger.new(File::NULL)` outside `Rails.env.development?` so call sites stay unconditional.
- `lib/events/subscribers/llm_response_handler.rb` — three log points: `log_raw_response` at the top of `#emit`, info line in `dispatch_tool_executions`, plus `def log = Aoide.logger`.
- `CLAUDE.md` — adds `tail -f log/aoide.log` next to the existing Melete tip.

## How to use the logs

After this lands, run a session in dev that's likely to surface the bug (it tends to happen when sub-agents are messaging in or skills/goals are being injected). Then:

```
tail -f log/aoide.log | grep -E "raw tool_use blocks|dispatching"
```

If a `dispatching tool=from_*` line appears whose tool name is also present in the matching `raw tool_use blocks:` payload, the LLM hallucinated it. If the `from_*` name is absent from the raw blocks but appears in dispatch, something inside Anima is synthesizing the tool_use after the API response.

## Architectural prior

The codebase review for this spike (PR #445 + drain-principles note + `PendingMessage#promote_as_phantom_pair!`) already favours the hallucination hypothesis: phantom `from_*` pairs are assembled inbound by `PendingMessage#promote!` as message-array entries, and the outgoing tool registry (`Tools::Registry.tool_classes_for`) is built exclusively from real `Tool` subclasses — none of which start with `from_`. So an internal leak is architecturally implausible under the current design. The logging confirms or refutes that without us having to assume.

## Smoke test (against dev brain on 42135)

Restarted the brain after this branch was on disk, said hi, read `log/aoide.log` — got:

```
[10:38:34.813] INFO  session=15 — response received (1 block(s), 0 tool_use)
[10:38:34.814] DEBUG  session=15 raw response:
model: claude-opus-4-6
id: msg_01DGMeXArS2ZQMNagL4HH4AU
type: message
role: assistant
content[1]{type,text}:
  text,"…"
…
[10:38:34.814] DEBUG  session=15 raw tool_use blocks:
[0]:
```

Three signals firing as designed; TOON encoding reads cleanly.

## Boy Scout

While in the handler, factored `session.id`, `tool_use["id"]`, and `tool_use["name"]` reads in `dispatch_tool_executions` and `persist_tool_call` to local variables — reek was flagging the duplicate method calls.

## Test plan

- [x] `bundle exec rspec spec/lib/events/subscribers/llm_response_handler_spec.rb` — 13 examples, 0 failures (5 new, all asserting the logger receives the right calls)
- [x] `bundle exec rspec spec/jobs/drain_job_spec.rb` — 11 examples, 0 failures (sanity check on the upstream emitter)
- [x] `bundle exec standardrb` — clean on changed files
- [x] `bundle exec reek lib/events/subscribers/llm_response_handler.rb` — only 2 pre-existing FeatureEnvy warnings remain (inherent iteration shape; not introduced by this PR and not obviously improved by extraction)
- [x] Manual: dev brain smoke test (above) — `log/aoide.log` populates correctly on a benign greeting.
- [ ] Real-session: wait for a session that exhibits the `from_*` bug, read the logs, decide hallucination vs internal leak, record on #480, open follow-up implementation issue.

## Acceptance criteria from #480

- [x] After a session that exhibits the bug, the logs contain enough information to determine whether the `from_*` tool_use block was present in the API response or synthesized later. *(structurally yes — verified by spec + smoke test, awaiting real-session confirmation)*
- [ ] Decision recorded on #480: hallucination vs internal leak. *(blocked on a real session with the new logs)*
- [ ] Follow-up implementation issue opened with the appropriate fix. *(blocked on the decision above)*

Refs #480