### PR TITLE
#481 chore: add diagnostic logging to broadcast/drain pipeline

### DIFF
--- a/app/jobs/drain_job.rb
+++ b/app/jobs/drain_job.rb
@@ -48,7 +48,15 @@ class DrainJob < ApplicationJob
   # @param session_id [Integer]
   def perform(session_id)
     @session = Session.find(session_id)
-    return unless @session.start_processing!
+    unless @session.start_processing!
+      diagnostics_log.info(
+        "session=#{session_id} DrainJob — start_processing! refused: " \
+        "state=#{@session.aasm_state} round_complete?=#{@session.tool_round_complete?} " \
+        "mailbox_active=#{@session.pending_messages.active.count} " \
+        "mailbox_background=#{@session.pending_messages.background.count}"
+      )
+      return
+    end
 
     drained = drain_mailbox
     return @session.response_complete! if drained.zero?
@@ -83,6 +91,19 @@ class DrainJob < ApplicationJob
     @active_pm = @session.pending_messages.active.where.not(message_type: "tool_response").order(:created_at).first
 
     promoted = tool_responses.size + (@active_pm ? 1 : 0)
+
+    diagnostics_log.info(
+      "session=#{@session.id} drain_mailbox — tool_responses=#{tool_responses.size} " \
+      "active_pm=#{@active_pm&.id || "nil"}#{"(#{@active_pm.message_type})" if @active_pm} " \
+      "background=#{@session.pending_messages.background.count} promoted=#{promoted}"
+    )
+    if tool_responses.any?
+      diagnostics_log.debug(
+        "  tool_response PMs: " +
+          tool_responses.map { |pm| "PM##{pm.id}(uid=#{pm.tool_use_id} src=#{pm.source_name})" }.join(", ")
+      )
+    end
+
     return 0 if promoted.zero?
 
     tool_responses.each(&:promote!)
@@ -166,4 +187,6 @@ class DrainJob < ApplicationJob
   def shell_session
     @shell_session ||= ShellSession.for_session(@session)
   end
+
+  def diagnostics_log = BroadcastDiagnostics.logger
 end

--- a/app/models/pending_message.rb
+++ b/app/models/pending_message.rb
@@ -413,18 +413,42 @@ class PendingMessage < ApplicationRecord
   # type-specific dimmed indicator immediately. Includes the decorated
   # payload for the session's current view mode so the TUI can dispatch
   # by message type without a second round-trip.
+  #
+  # Wrapped in diagnostic logging (issue #481): every emit and any raise
+  # from the decorate/render path is captured so server emits can be
+  # paired against TUI receipts post-hoc.
   def broadcast_created
+    diagnostics_log.info(
+      "PM##{id} broadcast_created — type=#{message_type} source=#{source_name} " \
+      "tool_use_id=#{tool_use_id.inspect} session=#{session_id} view_mode=#{session.view_mode}"
+    )
     ActionCable.server.broadcast("session_#{session_id}", broadcast_payload(session.view_mode))
+  rescue => e
+    diagnostics_log.error("PM##{id} broadcast_created RAISED — #{e.class}: #{e.message}")
+    raise
   end
 
   # Broadcasts pending message removal so TUI clients clear the entry.
   # Fires on both promotion (normal flow) and recall (user edit).
+  #
+  # Wrapped in diagnostic logging (issue #481): every emit and any raise
+  # is captured so a missed remove broadcast can be distinguished from a
+  # TUI-side failure to apply it.
   def broadcast_removed
+    diagnostics_log.info(
+      "PM##{id} broadcast_removed — type=#{message_type} source=#{source_name} " \
+      "tool_use_id=#{tool_use_id.inspect} session=#{session_id}"
+    )
     ActionCable.server.broadcast("session_#{session_id}", {
       "action" => "pending_message_removed",
       "pending_message_id" => id
     })
+  rescue => e
+    diagnostics_log.error("PM##{id} broadcast_removed RAISED — #{e.class}: #{e.message}")
+    raise
   end
+
+  def diagnostics_log = BroadcastDiagnostics.logger
 
   # Populates +kind+ from {MESSAGE_TYPE_KINDS} so callers only need to
   # supply +message_type+. The mapping is the single source of truth for

--- a/lib/anima/cli.rb
+++ b/lib/anima/cli.rb
@@ -93,6 +93,8 @@ module Anima
     desc "tui", "Launch the Anima terminal interface"
     option :host, desc: "Brain server address (default: from tui.toml or #{DEFAULT_HOST})"
     option :debug, type: :boolean, default: false, desc: "Enable performance logging"
+    option :broadcast_debug, type: :boolean, default: false,
+      desc: "Log received WebSocket broadcasts to log/tui_broadcast.log (issue #481)"
     def tui
       require "ratatui_ruby"
       require_relative "../tui/settings"
@@ -106,7 +108,11 @@ module Anima
       cable_client = TUI::CableClient.new(host: host)
       cable_client.connect
 
-      TUI::App.new(cable_client: cable_client, debug: options[:debug]).run
+      TUI::App.new(
+        cable_client: cable_client,
+        debug: options[:debug],
+        broadcast_debug: options[:broadcast_debug]
+      ).run
     end
 
     desc "version", "Show version"

--- a/lib/broadcast_diagnostics.rb
+++ b/lib/broadcast_diagnostics.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Diagnostic logger for the PendingMessage broadcast / drain pipeline.
+# Tracks every broadcast emitted by {PendingMessage}, every Message
+# broadcast emitted by {Events::Subscribers::MessageBroadcaster}, and
+# the round membership decisions made by {DrainJob}, so per-PM
+# mismatches between server emits and TUI receipts can be diagnosed
+# without restarting the agent.
+#
+# Investigative tool for issue #481 (TUI pending tool responses leak):
+# pair the server's `log/broadcast.log` with the TUI's
+# `log/tui_broadcast.log` to count creates/removes/messages per batch
+# round and identify any per-PM mismatch.
+module BroadcastDiagnostics
+  # Dev-only logger that writes to log/broadcast.log.
+  # In non-development environments returns a null logger so call
+  # sites don't need conditionals.
+  #
+  # @return [Logger]
+  def self.logger
+    @logger ||= build_logger
+  end
+
+  def self.build_logger
+    return Logger.new(File::NULL) unless Rails.env.development?
+
+    Logger.new(Rails.root.join("log", "broadcast.log")).tap do |log|
+      log.formatter = proc { |severity, time, _progname, msg|
+        "[#{time.strftime("%H:%M:%S.%L")}] #{severity}  #{msg}\n"
+      }
+    end
+  end
+  private_class_method :build_logger
+end

--- a/lib/events/subscribers/message_broadcaster.rb
+++ b/lib/events/subscribers/message_broadcaster.rb
@@ -23,11 +23,22 @@ module Events
         message = event[:payload][:message]
         action = ACTION_MAP.fetch(event[:payload][:type])
         session = message.session
+
+        BroadcastDiagnostics.logger.info(
+          "Message##{message.id} broadcast — type=#{message.message_type} action=#{action} " \
+          "tool_use_id=#{message.tool_use_id.inspect} session=#{message.session_id} view_mode=#{session.view_mode}"
+        )
+
         broadcast_payload = message.payload.merge("id" => message.id, "action" => action)
         broadcast_payload["api_metrics"] = message.api_metrics if message.api_metrics.present?
         broadcast_payload["rendered"] = {session.view_mode => message.decorate.render(session.view_mode)}
 
         ActionCable.server.broadcast("session_#{message.session_id}", broadcast_payload)
+      rescue => e
+        BroadcastDiagnostics.logger.error(
+          "Message##{message&.id} broadcast RAISED — #{e.class}: #{e.message}"
+        )
+        raise
       end
     end
   end

--- a/lib/tui/app.rb
+++ b/lib/tui/app.rb
@@ -6,6 +6,7 @@ require_relative "cable_client"
 require_relative "input_buffer"
 require_relative "message_store"
 require_relative "performance_logger"
+require_relative "broadcast_logger"
 require_relative "screens/chat"
 
 module TUI
@@ -77,12 +78,16 @@ module TUI
     attr_reader :shutdown_requested
     # @return [TUI::PerformanceLogger] frame timing logger (no-op when debug is off)
     attr_reader :perf_logger
+    # @return [TUI::BroadcastLogger] WebSocket broadcast logger (no-op when broadcast_debug is off)
+    attr_reader :broadcast_logger
 
     # @param cable_client [TUI::CableClient] WebSocket client connected to the brain
     # @param debug [Boolean] enable performance logging to log/tui_performance.log
-    def initialize(cable_client:, debug: false)
+    # @param broadcast_debug [Boolean] enable broadcast logging to log/tui_broadcast.log (issue #481)
+    def initialize(cable_client:, debug: false, broadcast_debug: false)
       @cable_client = cable_client
       @perf_logger = PerformanceLogger.new(enabled: debug)
+      @broadcast_logger = BroadcastLogger.new(enabled: broadcast_debug)
       @current_screen = :chat
       @command_mode = false
       @session_picker_active = false
@@ -108,7 +113,11 @@ module TUI
       @previous_signal_handlers = {}
       @watchdog_thread = nil
       @screens = {
-        chat: Screens::Chat.new(cable_client: cable_client, perf_logger: @perf_logger)
+        chat: Screens::Chat.new(
+          cable_client: cable_client,
+          perf_logger: @perf_logger,
+          broadcast_logger: @broadcast_logger
+        )
       }
     end
 

--- a/lib/tui/broadcast_logger.rb
+++ b/lib/tui/broadcast_logger.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "logger"
+require_relative "settings"
+
+module TUI
+  # Diagnostic logger for ActionCable broadcasts received by the TUI.
+  #
+  # When enabled via `--broadcast-debug`, logs every dispatched WebSocket
+  # message to `log/tui_broadcast.log` so server-side
+  # `log/broadcast.log` (written by {BroadcastDiagnostics}) can be
+  # paired against TUI receipts to find leaks per the issue #481
+  # investigation.
+  #
+  # Counterpart to {TUI::PerformanceLogger} — both are no-op when
+  # disabled, both write to a rotated log file.
+  #
+  # @example
+  #   logger = BroadcastLogger.new(enabled: true)
+  #   logger.info("recv pending_message_created PM=42")
+  class BroadcastLogger
+    # @param enabled [Boolean] whether to actually log (no-op when false)
+    def initialize(enabled: false)
+      @enabled = enabled
+      @logger = nil
+
+      return unless @enabled
+
+      @logger = Logger.new(Settings.broadcast_log_path, 1, 5 * 1024 * 1024) # 5MB rotation
+      @logger.formatter = proc { |_sev, time, _prog, msg| "[#{time.strftime("%H:%M:%S.%L")}] #{msg}\n" }
+      @logger.info("TUI Broadcast Logger started — pid=#{Process.pid}")
+    end
+
+    # @return [Boolean] true when logging is active
+    def enabled?
+      @enabled
+    end
+
+    # @param message [String]
+    def info(message)
+      @logger&.info(message)
+    end
+
+    # @param message [String]
+    def error(message)
+      @logger&.error(message)
+    end
+  end
+end

--- a/lib/tui/screens/chat.rb
+++ b/lib/tui/screens/chat.rb
@@ -3,6 +3,7 @@
 require_relative "../input_buffer"
 require_relative "../flash"
 require_relative "../performance_logger"
+require_relative "../broadcast_logger"
 require_relative "../height_map"
 require_relative "../decorators/base_decorator"
 require_relative "../decorators/bash_decorator"
@@ -55,10 +56,12 @@ module TUI
       # @param cable_client [TUI::CableClient] WebSocket client connected to the brain
       # @param message_store [TUI::MessageStore, nil] injectable for testing
       # @param perf_logger [TUI::PerformanceLogger, nil] optional performance logger
-      def initialize(cable_client:, message_store: nil, perf_logger: nil)
+      # @param broadcast_logger [TUI::BroadcastLogger, nil] optional broadcast diagnostic logger (issue #481)
+      def initialize(cable_client:, message_store: nil, perf_logger: nil, broadcast_logger: nil)
         @cable_client = cable_client
         @message_store = message_store || MessageStore.new
         @perf_logger = perf_logger || PerformanceLogger.new(enabled: false)
+        @broadcast_logger = broadcast_logger || BroadcastLogger.new(enabled: false)
         @input_buffer = InputBuffer.new
         @flash = Flash.new
         @session_state = "idle"
@@ -294,6 +297,14 @@ module TUI
           action = msg["action"]
           type = msg["type"]
 
+          if @broadcast_logger.enabled? && (action || type)
+            @broadcast_logger.info(
+              "recv action=#{action.inspect} type=#{type.inspect} " \
+              "id=#{msg["id"].inspect} pm_id=#{msg["pending_message_id"].inspect} " \
+              "tool_use_id=#{msg.dig("tool_use_id").inspect}"
+            )
+          end
+
           case action
           when "session_state"
             handle_session_state(msg)
@@ -320,9 +331,18 @@ module TUI
           when "sessions_list"
             @sessions_list = msg["sessions"]
           when "pending_message_created"
-            @message_store.add_pending(msg["pending_message_id"], msg) if msg["pending_message_id"]
+            pm_id = msg["pending_message_id"]
+            @broadcast_logger.info(
+              "recv pending_message_created PM=#{pm_id.inspect} type=#{msg["message_type"]} " \
+              "rendered_present=#{!msg.dig("rendered")&.values&.compact.to_a.empty?}"
+            )
+            @message_store.add_pending(pm_id, msg) if pm_id
           when "pending_message_removed"
-            @message_store.remove_pending(msg["pending_message_id"]) if msg["pending_message_id"]
+            pm_id = msg["pending_message_id"]
+            removed = pm_id ? @message_store.remove_pending(pm_id) : false
+            @broadcast_logger.info(
+              "recv pending_message_removed PM=#{pm_id.inspect} matched=#{removed}"
+            )
           when "authentication_required"
             @authentication_required = true
           when "token_saved"

--- a/spec/lib/anima/cli_spec.rb
+++ b/spec/lib/anima/cli_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe Anima::CLI do
 
       expect(TUI::CableClient).to have_received(:new).with(host: "localhost:19999")
       expect(cable_client).to have_received(:connect)
-      expect(TUI::App).to have_received(:new).with(cable_client: cable_client, debug: false)
+      expect(TUI::App).to have_received(:new)
+        .with(cable_client: cable_client, debug: false, broadcast_debug: false)
     end
 
     it "passes debug: true when --debug flag is given" do
@@ -99,7 +100,23 @@ RSpec.describe Anima::CLI do
         described_class.start(["tui", "--host", "localhost:19999", "--debug"])
       }.to output(/Connecting to brain/).to_stdout
 
-      expect(TUI::App).to have_received(:new).with(cable_client: cable_client, debug: true)
+      expect(TUI::App).to have_received(:new)
+        .with(cable_client: cable_client, debug: true, broadcast_debug: false)
+    end
+
+    it "passes broadcast_debug: true when --broadcast-debug flag is given" do
+      cable_client = instance_double(TUI::CableClient, connect: nil, disconnect: nil, status: :subscribed)
+      allow(TUI::CableClient).to receive(:new).with(host: "localhost:19999").and_return(cable_client)
+
+      app = instance_double(TUI::App, run: nil)
+      allow(TUI::App).to receive(:new).and_return(app)
+
+      expect {
+        described_class.start(["tui", "--host", "localhost:19999", "--broadcast-debug"])
+      }.to output(/Connecting to brain/).to_stdout
+
+      expect(TUI::App).to have_received(:new)
+        .with(cable_client: cable_client, debug: false, broadcast_debug: true)
     end
   end
 

--- a/templates/tui.toml
+++ b/templates/tui.toml
@@ -207,3 +207,12 @@ border_input_disconnected = "dark_gray"
 
 # File path for TUI performance debug logs (relative to working directory).
 log_path = "log/tui_performance.log"
+
+# ─── Broadcast diagnostics (issue #481) ──────────────────────────
+
+[broadcast]
+
+# File path for TUI broadcast diagnostic logs (relative to working
+# directory). Pair with the brain's log/broadcast.log to identify
+# per-PendingMessage broadcast leaks. Enable with `--broadcast-debug`.
+log_path = "log/tui_broadcast.log"


### PR DESCRIPTION
## Summary

Investigative logging for #481 (TUI pending tool responses leak: some entries persist until restart). Adds a paired server + TUI logging stream so a leak round can be replayed post-hoc.

- **Server side** — new `BroadcastDiagnostics.logger` (Melete/Mneme module-logger pattern) writes to `log/broadcast.log` in dev only:
  - `PendingMessage#broadcast_created` / `#broadcast_removed` — every emit, with PM id, message_type, source_name, tool_use_id, session_id, view_mode
  - `MessageBroadcaster#emit` — every Message broadcast, with id + tool_use_id + action
  - `DrainJob#perform` — when `start_processing!` refuses, log state + `tool_round_complete?` + mailbox counts
  - `DrainJob#drain_mailbox` — round membership (tool_response PM ids + tool_use_ids), promoted count
- **TUI side** — new `TUI::BroadcastLogger` (PerformanceLogger flag-gated pattern), opt-in via `--broadcast-debug`, writes to `log/tui_broadcast.log`:
  - Every received WebSocket message logged with `action`, `type`, `id`, `pending_message_id`, `tool_use_id`
  - For `pending_message_removed`: logs whether `MessageStore#remove_pending` actually matched a stored entry (the silent-miss case is the leak's smoking gun)
- TOML template gets a new `[broadcast] log_path` setting; existing users will need `anima migrate` to pick it up before passing `--broadcast-debug`.

## Why this approach

Research ruled out the original "decorator raise eats the broadcast" framing — `drain_mailbox` runs each `promote!` in its own transaction, so a per-PM render failure can't take down siblings. Research also ruled out the comment's revised hypothesis that a `from_melete_goal` unknown-tool error breaks `Session#tool_round_complete?` — unknown-tool PMs have `message_type: \"tool_response\"` and the correct `tool_use_id`, so the round-completion query counts them correctly. The remaining failure modes (broadcast lost in transit, TUI subscription race on reconnect, `remove_pending` silent miss because the create broadcast was missed) all need the *paired* server-emit / TUI-receipt log to diagnose, which is what this PR delivers.

## How to use

```bash
# Server (always on in dev)
tail -f log/broadcast.log

# TUI side (opt-in)
./exe/anima tui --host localhost:42135 --broadcast-debug
tail -f log/tui_broadcast.log
```

Reproduce a batch tool round (e.g. spawn multiple sub-agents in parallel), wait for the leak, then compare:
- N PMs created → N `broadcast_created` server lines → N `recv pending_message_created` TUI lines?
- N PMs destroyed → N `broadcast_removed` server lines → N `recv pending_message_removed matched=true` TUI lines?
- N Messages created → N `MessageBroadcaster ... broadcast` server lines → matching `recv action=create type=tool_response` TUI lines?

Any mismatch identifies the leak point.

## Test plan

- [x] `bundle exec rspec spec/models/pending_message_spec.rb spec/jobs/drain_job_spec.rb spec/lib/events/subscribers/message_broadcaster_spec.rb spec/lib/tui/` — 748 examples pass
- [x] `bundle exec rspec spec/lib/anima/cli_spec.rb` — updated to assert new `broadcast_debug` kwarg, new spec for `--broadcast-debug` flag
- [x] `bundle exec standardrb` — clean
- [ ] Manual smoke: launch dev brain + TUI with `--broadcast-debug`, trigger a multi-tool round, verify both log files populate; record findings on #481
- [ ] After root cause identified: open follow-up implementation issue and reference from #481 (per AC)

## Breaking changes

- TUI users who already have `~/.anima/tui.toml` will need to run `anima migrate` to pick up the new `[broadcast] log_path` setting before passing `--broadcast-debug`. Users who never pass the flag are unaffected (the setting is only read when the flag is on).

Closes part of #481 (the diagnostic-logging acceptance criterion). Root-cause identification + follow-up implementation issue are the remaining ACs and will be handled after the diagnostic logs let us reproduce.