### PR TITLE
#480 fix: silently strip from_* tool calls before dispatch

### DIFF
--- a/lib/aoide/phantom_call_filter.rb
+++ b/lib/aoide/phantom_call_filter.rb
@@ -33,7 +33,8 @@ module Aoide
       filtered = content.reject { |block| phantom_tool_use?(block) }
       return response if filtered.size == content.size
 
-      response.merge("content" => filtered)
+      key = response.key?("content") ? "content" : :content
+      response.merge(key => filtered)
     end
 
     def self.phantom_tool_use?(block)

--- a/lib/aoide/phantom_call_filter.rb
+++ b/lib/aoide/phantom_call_filter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Aoide
+  # Strips +from_*+ tool_use blocks from a raw Anthropic response before
+  # the rest of the main loop sees them.
+  #
+  # The +from_*+ prefix is reserved for messages delivered *to* the
+  # agent — phantom tool_call/tool_response pairs assembled by
+  # +PendingMessage#promote!+ to surface sister-muse and sub-agent
+  # output as conversation turns. They are never registered as
+  # callable tools, so when the model hallucinates a +from_*+ tool_use
+  # block (typically while waiting for a sub-agent's push delivery),
+  # +Tools::Registry+ raises +UnknownToolError+, the failure is
+  # persisted, and tokens are wasted on a round-trip the model
+  # already had to be told not to make. This filter drops those
+  # blocks at the entry point of the response handler so they never
+  # reach dispatch.
+  #
+  # Pure: takes a hash, returns a hash. No I/O, no AR, no events.
+  module PhantomCallFilter
+    PHANTOM_PREFIX = "from_"
+
+    # Returns +response+ with every +from_*+ tool_use block removed
+    # from its +content+ array. If no such block is present, returns
+    # +response+ unchanged (same object, same identity).
+    #
+    # @param response [Hash] raw Anthropic response payload
+    # @return [Hash] sanitized response
+    def self.call(response)
+      content = response["content"] || response[:content]
+      return response unless content.is_a?(Array)
+
+      filtered = content.reject { |block| phantom_tool_use?(block) }
+      return response if filtered.size == content.size
+
+      response.merge("content" => filtered)
+    end
+
+    def self.phantom_tool_use?(block)
+      return false unless block.is_a?(Hash)
+
+      type = block["type"] || block[:type]
+      name = block["name"] || block[:name]
+      type == "tool_use" && name.is_a?(String) && name.start_with?(PHANTOM_PREFIX)
+    end
+    private_class_method :phantom_tool_use?
+  end
+end

--- a/lib/events/subscribers/llm_response_handler.rb
+++ b/lib/events/subscribers/llm_response_handler.rb
@@ -28,6 +28,7 @@ module Events
         api_metrics = payload[:api_metrics]
 
         log_raw_response(session, response)
+        response = Aoide::PhantomCallFilter.call(response)
 
         tool_uses = normalize_tool_uses(response)
         text = extract_text(response)

--- a/spec/lib/aoide/phantom_call_filter_spec.rb
+++ b/spec/lib/aoide/phantom_call_filter_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Aoide::PhantomCallFilter do
+  describe ".call" do
+    it "returns the response unchanged when content has no tool_use blocks" do
+      response = {"content" => [{"type" => "text", "text" => "hello"}]}
+
+      expect(described_class.call(response)).to be(response)
+    end
+
+    it "returns the response unchanged when no tool_use is from_*-named" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "toolu_1", "name" => "bash", "input" => {}}
+      ]}
+
+      expect(described_class.call(response)).to be(response)
+    end
+
+    it "drops tool_use blocks whose name starts with from_" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_shell-runner", "input" => {}}
+      ]}
+
+      filtered = described_class.call(response)
+
+      expect(filtered["content"]).to eq([])
+    end
+
+    it "preserves text blocks alongside dropped from_* tool_use blocks" do
+      response = {"content" => [
+        {"type" => "text", "text" => "thinking out loud"},
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_melete_goal", "input" => {}}
+      ]}
+
+      filtered = described_class.call(response)
+
+      expect(filtered["content"]).to eq([
+        {"type" => "text", "text" => "thinking out loud"}
+      ])
+    end
+
+    it "preserves legitimate tool_use blocks alongside dropped from_* blocks" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "toolu_real", "name" => "bash", "input" => {"command" => "ls"}},
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_zero-width-sleuth", "input" => {}}
+      ]}
+
+      filtered = described_class.call(response)
+
+      expect(filtered["content"]).to eq([
+        {"type" => "tool_use", "id" => "toolu_real", "name" => "bash", "input" => {"command" => "ls"}}
+      ])
+    end
+
+    it "drops every from_* block when multiple are present" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "p1", "name" => "from_a", "input" => {}},
+        {"type" => "text", "text" => "between them"},
+        {"type" => "tool_use", "id" => "p2", "name" => "from_b", "input" => {}}
+      ]}
+
+      filtered = described_class.call(response)
+
+      expect(filtered["content"]).to eq([
+        {"type" => "text", "text" => "between them"}
+      ])
+    end
+
+    it "leaves the original response object untouched (does not mutate)" do
+      original_content = [
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_shell-runner", "input" => {}}
+      ]
+      response = {"content" => original_content, "stop_reason" => "tool_use"}
+
+      described_class.call(response)
+
+      expect(response["content"]).to be(original_content)
+      expect(response["content"].size).to eq(1)
+    end
+
+    it "carries non-content keys through unchanged" do
+      response = {
+        "content" => [{"type" => "tool_use", "id" => "p1", "name" => "from_x", "input" => {}}],
+        "stop_reason" => "tool_use",
+        "usage" => {"input_tokens" => 42}
+      }
+
+      filtered = described_class.call(response)
+
+      expect(filtered["stop_reason"]).to eq("tool_use")
+      expect(filtered["usage"]).to eq({"input_tokens" => 42})
+    end
+
+    it "tolerates a missing content key" do
+      response = {"stop_reason" => "end_turn"}
+
+      expect(described_class.call(response)).to eq("stop_reason" => "end_turn")
+    end
+
+    it "tolerates a non-array content value (defensive against malformed payloads)" do
+      response = {"content" => nil}
+
+      expect(described_class.call(response)).to be(response)
+    end
+
+    it "tolerates symbol-keyed content (provider may stringify late)" do
+      response = {content: [
+        {type: "tool_use", id: "p1", name: "from_phantom", input: {}}
+      ]}
+
+      filtered = described_class.call(response)
+
+      expect(filtered["content"]).to eq([])
+    end
+
+    it "ignores blocks that aren't hashes" do
+      response = {"content" => ["not a hash", {"type" => "text", "text" => "real"}]}
+
+      expect(described_class.call(response)).to be(response)
+    end
+
+    it "ignores tool_use blocks with a non-string name" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "x", "name" => nil, "input" => {}}
+      ]}
+
+      expect(described_class.call(response)).to be(response)
+    end
+  end
+end

--- a/spec/lib/aoide/phantom_call_filter_spec.rb
+++ b/spec/lib/aoide/phantom_call_filter_spec.rb
@@ -105,14 +105,23 @@ RSpec.describe Aoide::PhantomCallFilter do
       expect(described_class.call(response)).to be(response)
     end
 
-    it "tolerates symbol-keyed content (provider may stringify late)" do
+    it "tolerates symbol-keyed content and rewrites the same key (no mixed string/symbol shape)" do
       response = {content: [
         {type: "tool_use", id: "p1", name: "from_phantom", input: {}}
       ]}
 
       filtered = described_class.call(response)
 
-      expect(filtered["content"]).to eq([])
+      expect(filtered).to eq(content: [])
+      expect(filtered.key?("content")).to be(false)
+    end
+
+    it "drops a tool_use whose name is exactly the bare prefix" do
+      response = {"content" => [
+        {"type" => "tool_use", "id" => "p1", "name" => "from_", "input" => {}}
+      ]}
+
+      expect(described_class.call(response)["content"]).to eq([])
     end
 
     it "ignores blocks that aren't hashes" do

--- a/spec/lib/events/subscribers/llm_response_handler_spec.rb
+++ b/spec/lib/events/subscribers/llm_response_handler_spec.rb
@@ -144,15 +144,53 @@ RSpec.describe Events::Subscribers::LLMResponseHandler do
         .with(/dispatching tool=read id=toolu_2/)
     end
 
-    it "traces a spurious from_* tool call from the raw blocks log to dispatch" do
+    it "still logs spurious from_* blocks in the raw payload (filter runs after logging)" do
       dispatch({"content" => [
         {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_zero-width-sleuth", "input" => {}}
       ]})
 
       raw_blocks = debug_messages.find { |m| m.start_with?("session=#{session.id} raw tool_use blocks:") }
       expect(raw_blocks).to include("from_zero-width-sleuth")
-      expect(Aoide.logger).to have_received(:info)
-        .with(/dispatching tool=from_zero-width-sleuth id=toolu_phantom/)
+    end
+  end
+
+  describe "phantom (from_*) tool call filtering" do
+    it "drops from_*-only responses to a clean end of turn (no dispatch, no failed tool_result)" do
+      expect {
+        dispatch({"content" => [
+          {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_shell-runner", "input" => {"from" => "shell-runner"}}
+        ]})
+      }.not_to have_enqueued_job(ToolExecutionJob)
+
+      expect(session.messages.where(message_type: "tool_call")).to be_empty
+      expect(session.reload.aasm_state).to eq("idle")
+    end
+
+    it "dispatches only the legitimate tool calls when a from_* block sits alongside them" do
+      expect {
+        dispatch({"content" => [
+          {"type" => "tool_use", "id" => "toolu_real", "name" => "bash", "input" => {"command" => "ls"}},
+          {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_zero-width-sleuth", "input" => {}}
+        ]})
+      }.to have_enqueued_job(ToolExecutionJob).with(session.id, hash_including(tool_name: "bash"))
+        .and(have_enqueued_job(ToolExecutionJob).exactly(1).times)
+
+      tool_calls = session.messages.where(message_type: "tool_call")
+      expect(tool_calls.size).to eq(1)
+      expect(tool_calls.first.payload["tool_name"]).to eq("bash")
+      expect(session.reload.aasm_state).to eq("executing")
+    end
+
+    it "keeps the agent's text reply when a from_* block is the only tool call" do
+      dispatch({"content" => [
+        {"type" => "text", "text" => "Spawning, then waiting for push delivery."},
+        {"type" => "tool_use", "id" => "toolu_phantom", "name" => "from_melete_goal", "input" => {}}
+      ]})
+
+      agent_message = session.messages.find_by(message_type: "agent_message")
+      expect(agent_message.payload["content"]).to eq("Spawning, then waiting for push delivery.")
+      expect(session.messages.where(message_type: "tool_call")).to be_empty
+      expect(session.reload.aasm_state).to eq("idle")
     end
   end
 end


### PR DESCRIPTION
## Summary

Implements the fix for #480 based on the research-spike findings recorded in [the comment on the issue](https://github.com/hoblin/anima/issues/480#issuecomment-4350731469).

The spike (PR #485) confirmed that spurious `from_*` tool calls — `from_shell-runner`, `from_zero-width-sleuth`, `from_melete_goal`, etc. — are **LLM hallucinations**, not internal leaks. The model emits them as legitimate `tool_use` blocks in the raw Anthropic response, complete with fabricated input schemas, despite the `from_*` naming convention from PR #445 + system-prompt sister block + a Level 2 memory explicitly documenting the anti-pattern. Three reproductions in ~3 minutes of a single deliberately-constructed session.

## What this PR does

A small pure filter — `Aoide::PhantomCallFilter.call(hash) → hash` — drops every block where `type == "tool_use" && name.start_with?("from_")` from `response["content"]` before the rest of the main loop sees it. The filter has no AR, no events, no I/O — pure hash transformation, easy to spec in isolation.

It runs at the top of `Events::Subscribers::LLMResponseHandler#emit`, **immediately after `log_raw_response`** so the dev-only diagnostic log from PR #485 keeps observing the *pre-filter* API response. This matters: we want to keep measuring hallucination rate after the fix lands, and decide later whether a feedback loop (synthesised tool_result, Mneme nudge) is worth adding.

After the strip, the existing handler logic carries the rest of the work unchanged:

- `normalize_tool_uses` operates on the filtered content → no `from_*` enters dispatch.
- `extract_text` is unaffected by the strip → text always survives.
- The `if tool_uses.any? … elsif session.may_response_complete? …` branch handles the empty case naturally → `from_*`-only responses land at clean `response_complete!`.

## Three edge cases the user explicitly asked to cover

| Response shape | Behaviour |
| --- | --- |
| Only `from_*` tool calls | No dispatch, no failed `tool_result`, session → `idle` (clean end of turn) |
| `from_*` + legitimate tool calls | Only legitimate calls dispatch; session → `executing`; one `tool_call` message persisted |
| Text + `from_*` tool calls | Text persisted as `agent_message`; no dispatch; session → `idle` |

All three are asserted in `spec/lib/events/subscribers/llm_response_handler_spec.rb`. The filter itself has 13 unit specs against fixture payloads (including symbol-keyed content, missing content key, non-array content, malformed blocks).

## Diagnostic continuity

`log/aoide.log` keeps logging the raw API response and raw `tool_use` blocks pre-filter. Post-fix, `dispatching tool=from_*` lines should disappear, but `from_*` blocks may still appear in `raw tool_use blocks:` — that's the signal that the model is still hallucinating. If frequency stays high we'll know without re-instrumenting.

## Test plan

- [x] `bundle exec rspec spec/lib/aoide/phantom_call_filter_spec.rb` — 13 examples, 0 failures
- [x] `bundle exec rspec spec/lib/events/subscribers/llm_response_handler_spec.rb` — 16 examples (3 new edge cases), 0 failures
- [x] `bundle exec rspec spec/jobs/drain_job_spec.rb` — 11 examples, 0 failures (sanity on upstream emitter)
- [x] `bundle exec standardrb` — clean on changed files
- [x] `bundle exec reek lib/aoide/phantom_call_filter.rb lib/events/subscribers/llm_response_handler.rb` — 2 pre-existing FeatureEnvy warnings remain, none introduced
- [ ] Smoke test on dev brain — restart on this branch, reproduce the parallel-subagent scenario, confirm `dispatching tool=from_*` lines no longer appear and no `UnknownToolError` lands in the conversation. (Doing right after this PR opens.)

Closes #480